### PR TITLE
Add a polyfill to enable newer compiler features

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -153,4 +153,7 @@
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
     <PackageVersion Include="xunit" Version="2.9.0" />
   </ItemGroup>
+  <ItemGroup>
+    <GlobalPackageReference Include="PolySharp" Version="1.15.0" />
+  </ItemGroup>
 </Project>

--- a/NuGet.config
+++ b/NuGet.config
@@ -12,7 +12,7 @@
     <clear />
     <packageSource key="NuGet.org">
       <package pattern="Antlr" />
-      <package pattern="AngleSharp.*" />      
+      <package pattern="AngleSharp.*" />
       <package pattern="AngleSharp" />
       <package pattern="Autofac.*" />
       <package pattern="Autofac" />
@@ -52,6 +52,7 @@
       <package pattern="Owin" />
       <package pattern="Polly.Extensions.Http" />
       <package pattern="Polly" />
+      <package pattern="PolySharp" />
       <package pattern="Portable.BouncyCastle" />
       <package pattern="RazorEngine" />
       <package pattern="RouteMagic" />

--- a/src/NuGet.Jobs.GitHubIndexer/GitRepoSearchers/GitHub/GitHubSearcher.cs
+++ b/src/NuGet.Jobs.GitHubIndexer/GitRepoSearchers/GitHub/GitHubSearcher.cs
@@ -118,7 +118,7 @@ namespace NuGet.Jobs.GitHubIndexer
 
                     var request = new SearchRepositoriesRequest
                     {
-                        Stars = new Range(_minStars, upperStarBound),
+                        Stars = new(_minStars, upperStarBound),
                         Language = Language.CSharp,
                         SortField = RepoSearchSort.Stars,
                         Order = SortDirection.Descending,

--- a/tests/NuGet.Services.Contracts.Tests/ContractsFacts.cs
+++ b/tests/NuGet.Services.Contracts.Tests/ContractsFacts.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Linq;
@@ -19,6 +19,44 @@ namespace NuGet.Services
                 // included in the assembly by newer language versions
                 "Microsoft.CodeAnalysis.EmbeddedAttribute",
                 "System.Runtime.CompilerServices.RefSafetyRulesAttribute",
+                // generated polyfills from PolySharp
+                "System.Runtime.CompilerServices.NullableAttribute",
+                "System.Runtime.CompilerServices.NullableContextAttribute",
+                "System.Index",
+                "System.Range",
+                "System.Runtime.Versioning.RequiresPreviewFeaturesAttribute",
+                "System.Runtime.CompilerServices.AsyncMethodBuilderAttribute",
+                "System.Runtime.CompilerServices.CallerArgumentExpressionAttribute",
+                "System.Runtime.CompilerServices.CollectionBuilderAttribute",
+                "System.Runtime.CompilerServices.CompilerFeatureRequiredAttribute",
+                "System.Runtime.CompilerServices.InterpolatedStringHandlerArgumentAttribute",
+                "System.Runtime.CompilerServices.InterpolatedStringHandlerAttribute",
+                "System.Runtime.CompilerServices.IsExternalInit",
+                "System.Runtime.CompilerServices.ModuleInitializerAttribute",
+                "System.Runtime.CompilerServices.OverloadResolutionPriorityAttribute",
+                "System.Runtime.CompilerServices.ParamCollectionAttribute",
+                "System.Runtime.CompilerServices.RequiredMemberAttribute",
+                "System.Runtime.CompilerServices.RequiresLocationAttribute",
+                "System.Runtime.CompilerServices.SkipLocalsInitAttribute",
+                "System.Diagnostics.CodeAnalysis.AllowNullAttribute",
+                "System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute",
+                "System.Diagnostics.CodeAnalysis.DisallowNullAttribute",
+                "System.Diagnostics.CodeAnalysis.DoesNotReturnAttribute",
+                "System.Diagnostics.CodeAnalysis.DoesNotReturnIfAttribute",
+                "System.Diagnostics.CodeAnalysis.ExperimentalAttribute",
+                "System.Diagnostics.CodeAnalysis.MaybeNullAttribute",
+                "System.Diagnostics.CodeAnalysis.MaybeNullWhenAttribute",
+                "System.Diagnostics.CodeAnalysis.MemberNotNullAttribute",
+                "System.Diagnostics.CodeAnalysis.MemberNotNullWhenAttribute",
+                "System.Diagnostics.CodeAnalysis.NotNullAttribute",
+                "System.Diagnostics.CodeAnalysis.NotNullIfNotNullAttribute",
+                "System.Diagnostics.CodeAnalysis.NotNullWhenAttribute",
+                "System.Diagnostics.CodeAnalysis.SetsRequiredMembersAttribute",
+                "System.Diagnostics.CodeAnalysis.StringSyntaxAttribute",
+                "System.Diagnostics.CodeAnalysis.UnscopedRefAttribute",
+                "System.Index+ThrowHelper",
+                "System.Range+HashHelpers",
+                "System.Range+ThrowHelper",
             };
 
             // Act

--- a/tests/NuGet.Services.Contracts.Tests/ContractsFacts.cs
+++ b/tests/NuGet.Services.Contracts.Tests/ContractsFacts.cs
@@ -19,44 +19,6 @@ namespace NuGet.Services
                 // included in the assembly by newer language versions
                 "Microsoft.CodeAnalysis.EmbeddedAttribute",
                 "System.Runtime.CompilerServices.RefSafetyRulesAttribute",
-                // generated polyfills from PolySharp
-                "System.Runtime.CompilerServices.NullableAttribute",
-                "System.Runtime.CompilerServices.NullableContextAttribute",
-                "System.Index",
-                "System.Range",
-                "System.Runtime.Versioning.RequiresPreviewFeaturesAttribute",
-                "System.Runtime.CompilerServices.AsyncMethodBuilderAttribute",
-                "System.Runtime.CompilerServices.CallerArgumentExpressionAttribute",
-                "System.Runtime.CompilerServices.CollectionBuilderAttribute",
-                "System.Runtime.CompilerServices.CompilerFeatureRequiredAttribute",
-                "System.Runtime.CompilerServices.InterpolatedStringHandlerArgumentAttribute",
-                "System.Runtime.CompilerServices.InterpolatedStringHandlerAttribute",
-                "System.Runtime.CompilerServices.IsExternalInit",
-                "System.Runtime.CompilerServices.ModuleInitializerAttribute",
-                "System.Runtime.CompilerServices.OverloadResolutionPriorityAttribute",
-                "System.Runtime.CompilerServices.ParamCollectionAttribute",
-                "System.Runtime.CompilerServices.RequiredMemberAttribute",
-                "System.Runtime.CompilerServices.RequiresLocationAttribute",
-                "System.Runtime.CompilerServices.SkipLocalsInitAttribute",
-                "System.Diagnostics.CodeAnalysis.AllowNullAttribute",
-                "System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute",
-                "System.Diagnostics.CodeAnalysis.DisallowNullAttribute",
-                "System.Diagnostics.CodeAnalysis.DoesNotReturnAttribute",
-                "System.Diagnostics.CodeAnalysis.DoesNotReturnIfAttribute",
-                "System.Diagnostics.CodeAnalysis.ExperimentalAttribute",
-                "System.Diagnostics.CodeAnalysis.MaybeNullAttribute",
-                "System.Diagnostics.CodeAnalysis.MaybeNullWhenAttribute",
-                "System.Diagnostics.CodeAnalysis.MemberNotNullAttribute",
-                "System.Diagnostics.CodeAnalysis.MemberNotNullWhenAttribute",
-                "System.Diagnostics.CodeAnalysis.NotNullAttribute",
-                "System.Diagnostics.CodeAnalysis.NotNullIfNotNullAttribute",
-                "System.Diagnostics.CodeAnalysis.NotNullWhenAttribute",
-                "System.Diagnostics.CodeAnalysis.SetsRequiredMembersAttribute",
-                "System.Diagnostics.CodeAnalysis.StringSyntaxAttribute",
-                "System.Diagnostics.CodeAnalysis.UnscopedRefAttribute",
-                "System.Index+ThrowHelper",
-                "System.Range+HashHelpers",
-                "System.Range+ThrowHelper",
             };
 
             // Act
@@ -66,6 +28,10 @@ namespace NuGet.Services
             Assert.NotEmpty(types);
             foreach (var type in types)
             {
+                if (!type.IsVisible)
+                {
+                    continue;
+                }
                 if (exclude.Contains(type.FullName))
                 {
                     continue;


### PR DESCRIPTION
New versions of C# offer many features that improve quality of life: nullable annotations, record types, init and required properties, etc. These can be enabled in projects targeting older framework versions by adding the right attributes and types to the compilation.

PolySharp is a source generator which automatically does this.  For each project, it will generate all of the types/attributes which are missing. In the case of an InternalsVisibleTo reference, it is smart enough to only define types in the second assembly that are not being consumed from the first assembly (avoiding duplicate type definitions).
