### PR TITLE
Add CommandTimeout property to Db2AzureSearch configuration

### DIFF
--- a/src/NuGet.Services.AzureSearch/Db2AzureSearch/Db2AzureSearchConfiguration.cs
+++ b/src/NuGet.Services.AzureSearch/Db2AzureSearch/Db2AzureSearchConfiguration.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using NuGet.Services.AzureSearch.AuxiliaryFiles;
@@ -8,6 +8,7 @@ namespace NuGet.Services.AzureSearch.Db2AzureSearch
     public class Db2AzureSearchConfiguration : AzureSearchJobConfiguration, IAuxiliaryDataStorageConfiguration
     {
         public int DatabaseBatchSize { get; set; } = 10000;
+        public int DatabaseCommandTimeoutInSeconds { get; set; } = 30;
         public string CatalogIndexUrl { get; set; }
         public string AuxiliaryDataStorageConnectionString { get; set; }
         public string AuxiliaryDataStorageContainer { get; set; }

--- a/src/NuGet.Services.AzureSearch/Db2AzureSearch/NewPackageRegistrationFromDbProducer.cs
+++ b/src/NuGet.Services.AzureSearch/Db2AzureSearch/NewPackageRegistrationFromDbProducer.cs
@@ -234,6 +234,8 @@ namespace NuGet.Services.AzureSearch.Db2AzureSearch
         {
             using (var context = await CreateContextAsync())
             {
+                context.SetCommandTimeout(_options.Value.DatabaseCommandTimeoutInSeconds);
+
                 var minKey = range.MinKey;
                 var query = context
                     .Set<Package>()


### PR DESCRIPTION
Addresses https://github.com/NuGet/Engineering/issues/5771

Db2AzureSearch was timing out on same large queries when run against the PROD DB. This PR adds a CommandTimeout config property for Db2AzureSearch. 

The default timeout is 30s, but we want to increase it for PROD, so we'll add a custom CommandTimout to the PROD configs for Db2AzureSearch. 

NuGetDeployment config changes: https://nuget.visualstudio.com/NuGetMicrosoft/_git/NuGetDeployment/pullrequest/2589