### PR TITLE
Make KeyVaultReader aware of Local_Development

### DIFF
--- a/src/NuGet.Services.Configuration/ConfigurationRootSecretReaderFactory.cs
+++ b/src/NuGet.Services.Configuration/ConfigurationRootSecretReaderFactory.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -12,6 +12,7 @@ namespace NuGet.Services.Configuration
     {
         private string _vaultName;
         private bool _useManagedIdentity;
+        private bool _localDevelopment;
         private string _tenantId;
         private string _clientId;
         private string _certificateThumbprint;
@@ -38,6 +39,16 @@ namespace NuGet.Services.Configuration
             else
             {
                 _clientId = config[Constants.KeyVaultClientIdKey];
+            }
+
+            string localDevelopment = config[Constants.ConfigureForLocalDevelopment];
+            if (!string.IsNullOrEmpty(localDevelopment))
+            {
+                _localDevelopment = bool.Parse(localDevelopment);
+            }
+            else
+            {
+                _localDevelopment= false;
             }
 
             _tenantId = config[Constants.KeyVaultTenantIdKey];
@@ -74,7 +85,7 @@ namespace NuGet.Services.Configuration
 
             if (_useManagedIdentity)
             {
-                keyVaultConfiguration = new KeyVaultConfiguration(_vaultName, _clientId);
+                keyVaultConfiguration = new KeyVaultConfiguration(_vaultName, _clientId, _localDevelopment);
             }
             else
             {

--- a/src/NuGet.Services.Configuration/ConfigurationRootSecretReaderFactory.cs
+++ b/src/NuGet.Services.Configuration/ConfigurationRootSecretReaderFactory.cs
@@ -31,9 +31,8 @@ namespace NuGet.Services.Configuration
             _vaultName = config[Constants.KeyVaultVaultNameKey];
 
             string useManagedIdentity = config[Constants.KeyVaultUseManagedIdentity];
-            if (!string.IsNullOrEmpty(useManagedIdentity))
+            if (bool.TryParse(useManagedIdentity, out _useManagedIdentity) && _useManagedIdentity)
             {
-                _useManagedIdentity = bool.Parse(useManagedIdentity);
                 _clientId = string.IsNullOrEmpty(config[Constants.KeyVaultClientIdKey]) ? config[Constants.ManagedIdentityClientIdKey] : config[Constants.KeyVaultClientIdKey];
             }
             else
@@ -42,11 +41,7 @@ namespace NuGet.Services.Configuration
             }
 
             string localDevelopment = config[Constants.ConfigureForLocalDevelopment];
-            if (!string.IsNullOrEmpty(localDevelopment))
-            {
-                _localDevelopment = bool.Parse(localDevelopment);
-            }
-            else
+            if (!bool.TryParse(localDevelopment, out _localDevelopment))
             {
                 _localDevelopment= false;
             }

--- a/src/NuGet.Services.KeyVault/KeyVaultConfiguration.cs
+++ b/src/NuGet.Services.KeyVault/KeyVaultConfiguration.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -10,6 +10,7 @@ namespace NuGet.Services.KeyVault
     {
         public string VaultName { get; }
         public bool UseManagedIdentity { get; }
+        public bool LocalDevelopment { get; }
         public string TenantId { get; }
         public string ClientId { get; }
         public X509Certificate2 Certificate { get; }
@@ -25,7 +26,7 @@ namespace NuGet.Services.KeyVault
         /// <summary>
         /// The constructor for keyvault configuration when using managed identities
         /// </summary>
-        public KeyVaultConfiguration(string vaultName, string clientId)
+        public KeyVaultConfiguration(string vaultName, string clientId, bool localDevelopment = false)
         {
             if (string.IsNullOrWhiteSpace(vaultName))
             {
@@ -35,6 +36,7 @@ namespace NuGet.Services.KeyVault
             VaultName = vaultName;
             UseManagedIdentity = true;
             ClientId = clientId;
+            LocalDevelopment = localDevelopment;
         }
 
         /// <summary>

--- a/src/NuGet.Services.KeyVault/KeyVaultReader.cs
+++ b/src/NuGet.Services.KeyVault/KeyVaultReader.cs
@@ -97,7 +97,7 @@ namespace NuGet.Services.KeyVault
 
             if (_configuration.UseManagedIdentity)
             {
-                if (string.IsNullOrEmpty(_configuration.ClientId))
+                if (string.IsNullOrEmpty(_configuration.ClientId) || _configuration.LocalDevelopment)
                 {
                     credential = new DefaultAzureCredential();
                 }


### PR DESCRIPTION
This makes the KeyVaultReader aware and reactive to the new top level Local_Development appsettings.json option (introduced in https://github.com/NuGet/NuGetGallery/pull/10297) and makes it fall back to using DefaultAzureCredential instead of ManagedIdentityCredential.