### PR TITLE
Show SHA256 everywhere.

### DIFF
--- a/src/NuGet.Services.Validation.Issues/UnauthorizedCertificateFailure.cs
+++ b/src/NuGet.Services.Validation.Issues/UnauthorizedCertificateFailure.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -9,14 +9,14 @@ namespace NuGet.Services.Validation.Issues
     public sealed class UnauthorizedCertificateFailure : ValidationIssue
     {
         [JsonConstructor]
-        public UnauthorizedCertificateFailure(string sha1Thumbprint)
+        public UnauthorizedCertificateFailure(string sha256Thumbprint)
         {
-            Sha1Thumbprint = sha1Thumbprint ?? throw new ArgumentNullException(nameof(sha1Thumbprint));
+            Sha256Thumbprint = sha256Thumbprint ?? throw new ArgumentNullException(nameof(sha256Thumbprint));
         }
 
         public override ValidationIssueCode IssueCode => ValidationIssueCode.PackageIsSignedWithUnauthorizedCertificate;
 
         [JsonProperty("t", Required = Required.Always)]
-        public string Sha1Thumbprint { get; }
+        public string Sha256Thumbprint { get; }
     }
 }

--- a/src/NuGetGallery.Core/Extensions/ValidationIssueExtensions.cs
+++ b/src/NuGetGallery.Core/Extensions/ValidationIssueExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -52,7 +52,7 @@ namespace NuGetGallery
                     return "This package must be signed with a registered certificate. [Read more...](https://aka.ms/nuget-signed-ref)";
                 case ValidationIssueCode.PackageIsSignedWithUnauthorizedCertificate:
                     var certIssue = (UnauthorizedCertificateFailure)validationIssue;
-                    return $"The package was signed, but the signing certificate {(certIssue != null ? $"(SHA-1 thumbprint {certIssue.Sha1Thumbprint})" : "")} is not associated with your account. You must register this certificate to publish signed packages. [Read more...](https://aka.ms/nuget-signed-ref)";
+                    return $"The package was signed, but the signing certificate {(certIssue != null ? $"(SHA-256 thumbprint {certIssue.Sha256Thumbprint})" : "")} is not associated with your account. You must register this certificate to publish signed packages. [Read more...](https://aka.ms/nuget-signed-ref)";
                 case ValidationIssueCode.SymbolErrorCode_ChecksumDoesNotMatch:
                     return "The checksum does not match for the dll(s) and corresponding pdb(s).";
                 case ValidationIssueCode.SymbolErrorCode_MatchingAssemblyNotFound:

--- a/src/NuGetGallery/Views/Packages/_ValidationIssue.cshtml
+++ b/src/NuGetGallery/Views/Packages/_ValidationIssue.cshtml
@@ -53,7 +53,7 @@
         {
             var typedIssue = (UnauthorizedCertificateFailure)Model;
             <text>
-                The package was signed, but the signing certificate (SHA-1 thumbprint @typedIssue.Sha1Thumbprint) is not associated with your account.
+                The package was signed, but the signing certificate (SHA-256 thumbprint @typedIssue.Sha256Thumbprint) is not associated with your account.
                 You must register this certificate to publish signed packages. <a href="https://aka.ms/nuget-signed-ref">Read more...</a>
             </text>
             break;

--- a/src/StatusAggregator/Job.cs
+++ b/src/StatusAggregator/Job.cs
@@ -359,7 +359,7 @@ namespace StatusAggregator
                 certificate = new X509Certificate2(certBytes);
             }
 
-            logger.LogInformation("Successfully parsed certificate with SHA-1 thumbprint {Thumbprint}", certificate.Thumbprint);
+            logger.LogInformation("Successfully parsed certificate with SHA-256 thumbprint {SHA256Thumbprint}", certificate.ComputeSHA256Thumbprint());
             return certificate;
         }
     }

--- a/src/StatusAggregator/StatusAggregator.csproj
+++ b/src/StatusAggregator/StatusAggregator.csproj
@@ -7,6 +7,7 @@
     <ProjectReference Include="..\NuGet.Jobs.Common\NuGet.Jobs.Common.csproj" />
     <ProjectReference Include="..\NuGet.Services.Incidents\NuGet.Services.Incidents.csproj" />
     <ProjectReference Include="..\NuGet.Services.Status.Table\NuGet.Services.Status.Table.csproj" />
+    <ProjectReference Include="..\Validation.PackageSigning.Core\Validation.PackageSigning.Core.csproj" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Scripts\*" />

--- a/src/Validation.PackageSigning.ProcessSignature/SignatureValidator.cs
+++ b/src/Validation.PackageSigning.ProcessSignature/SignatureValidator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -652,7 +652,7 @@ namespace NuGet.Jobs.Validation.PackageSigning.ProcessSignature
 
                     return await RejectAsync(
                         context,
-                        new UnauthorizedCertificateFailure(signingCertificate.Thumbprint.ToLowerInvariant()));
+                        new UnauthorizedCertificateFailure(signingFingerprint.ToLowerInvariant()));
                 }
             }
 

--- a/tests/NuGet.Services.Validation.Issues.Tests/ValidationIssuesFacts.cs
+++ b/tests/NuGet.Services.Validation.Issues.Tests/ValidationIssuesFacts.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -217,7 +217,7 @@ namespace NuGet.Services.Validation.Issues.Tests
                 // Assert
                 Assert.NotNull(result);
                 Assert.Equal(ValidationIssueCode.PackageIsSignedWithUnauthorizedCertificate, result.IssueCode);
-                Assert.Equal("thumbprint", result.Sha1Thumbprint);
+                Assert.Equal("thumbprint", result.Sha256Thumbprint);
             }
 
             private PackageValidationIssue CreatePackageValidationIssue(ValidationIssueCode issueCode, string data)

--- a/tests/NuGetGallery.Facts/Infrastructure/Mail/MarkdownMessageServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Infrastructure/Mail/MarkdownMessageServiceFacts.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -1372,7 +1372,7 @@ namespace NuGetGallery
                         return "This package must be signed with a registered certificate. [Read more...](https://aka.ms/nuget-signed-ref)";
                     case ValidationIssueCode.PackageIsSignedWithUnauthorizedCertificate:
                         var certIssue = (UnauthorizedCertificateFailure)validationIssue;
-                        return $"The package was signed, but the signing certificate (SHA-1 thumbprint {certIssue.Sha1Thumbprint}) is not associated with your account. You must register this certificate to publish signed packages. [Read more...](https://aka.ms/nuget-signed-ref)";
+                        return $"The package was signed, but the signing certificate (SHA-256 thumbprint {certIssue.Sha256Thumbprint}) is not associated with your account. You must register this certificate to publish signed packages. [Read more...](https://aka.ms/nuget-signed-ref)";
                     default:
                         return "There was an unknown failure when validating your package.";
                 }
@@ -2315,7 +2315,7 @@ namespace NuGetGallery
                         return "This package must be signed with a registered certificate. [Read more...](https://aka.ms/nuget-signed-ref)";
                     case ValidationIssueCode.PackageIsSignedWithUnauthorizedCertificate:
                         var certIssue = (UnauthorizedCertificateFailure)validationIssue;
-                        return $"The package was signed, but the signing certificate (SHA-1 thumbprint {certIssue.Sha1Thumbprint}) is not associated with your account. You must register this certificate to publish signed packages. [Read more...](https://aka.ms/nuget-signed-ref)";
+                        return $"The package was signed, but the signing certificate (SHA-256 thumbprint {certIssue.Sha256Thumbprint}) is not associated with your account. You must register this certificate to publish signed packages. [Read more...](https://aka.ms/nuget-signed-ref)";
                     case ValidationIssueCode.SymbolErrorCode_ChecksumDoesNotMatch:
                         return "The checksum does not match for the dll(s) and corresponding pdb(s).";
                     case ValidationIssueCode.SymbolErrorCode_MatchingAssemblyNotFound:

--- a/tests/Validation.PackageSigning.ProcessSignature.Tests/SignatureValidatorFacts.cs
+++ b/tests/Validation.PackageSigning.ProcessSignature.Tests/SignatureValidatorFacts.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -478,7 +478,7 @@ namespace Validation.PackageSigning.ProcessSignature.Tests
                 Assert.Single(result.Issues);
                 var issue = Assert.IsType<UnauthorizedCertificateFailure>(result.Issues[0]);
                 Assert.Equal(ValidationIssueCode.PackageIsSignedWithUnauthorizedCertificate, issue.IssueCode);
-                Assert.Equal(TestResources.Leaf2Sha1Thumbprint, issue.Sha1Thumbprint);
+                Assert.Equal(TestResources.Leaf1Thumbprint, issue.Sha256Thumbprint);
             }
 
             [Fact]
@@ -883,7 +883,7 @@ namespace Validation.PackageSigning.ProcessSignature.Tests
                 Assert.Single(result.Issues);
                 var issue = Assert.IsType<UnauthorizedCertificateFailure>(result.Issues[0]);
                 Assert.Equal(ValidationIssueCode.PackageIsSignedWithUnauthorizedCertificate, issue.IssueCode);
-                Assert.Equal(TestResources.Leaf2Sha1Thumbprint, issue.Sha1Thumbprint);
+                Assert.Equal(TestResources.Leaf1Thumbprint, issue.Sha256Thumbprint);
             }
 
             [Fact]


### PR DESCRIPTION
Update all messaging to use SHA256 hash instead of SHA-1 hashes for certificates.
Addresses https://github.com/NuGet/NuGetGallery/issues/10073