### PR TITLE
Add devpod.sh to trusted image domains

### DIFF
--- a/src/NuGetGallery/App_Data/Files/Content/Trusted-Image-Domains.json
+++ b/src/NuGetGallery/App_Data/Files/Content/Trusted-Image-Domains.json
@@ -23,6 +23,7 @@
         "codefactor.io",
         "coveralls.io",
         "dev.azure.com",
+        "devpod.sh",
         "flat.badgen.net",
         "gitlab.com",
         "img.shields.io",


### PR DESCRIPTION
Adds devpod.sh to the list of trusted image domains in order to display the "Open in DevPod" button in nuget gallery readmes 

solves #10336 