### PR TITLE
Reducing restrictions on expected client paths when parsing versions

### DIFF
--- a/python/StatsLogParser/loginterpretation/packagedefinition.py
+++ b/python/StatsLogParser/loginterpretation/packagedefinition.py
@@ -91,13 +91,14 @@ class PackageDefinition:
         if not request_url or not request_url.lower().endswith(PackageDefinition.NUGET_EXE_URL_ENDING):
             return None
 
-        # path example: /artifacts/win-x86-commandline/v5.9.1/nuget.exe
+        # origin path example: /artifacts/win-x86-commandline/v5.9.1/nuget.exe
+        # new CDN logs request path, not origin path:  /win-x86-commandline/v5.11.6/nuget.exe
 
         request_url = urllib.parse.unquote(request_url)
         url_segments = [segment for segment in request_url.split('/') if segment]
 
-        if len(url_segments) < 4:
-            # proper nuget.exe URL paths have at least 4 segments
+        if len(url_segments) < 2:
+            # proper nuget.exe URL paths have at least 2 segments
             return None
 
         suspected_version_segment = url_segments[-2].lower()

--- a/python/StatsLogParser/tests/test_packagedefinition.py
+++ b/python/StatsLogParser/tests/test_packagedefinition.py
@@ -52,10 +52,12 @@ def test_from_request_url_returns_none_when_invalid_url(request_url):
     ("5.9.1", "https://localhost/artifacts/win-x86-commandline/v5.9.1/nuget.exe"),
     ("5.8.0-preview.2", "https://localhost/artifacts/win-x86-commandline/v5.8.0-preview.2/nuget.exe"),
     ("3.5.0-beta2", "https://localhost/artifacts/win-x86-commandline/v3.5.0-beta2/nuget.exe"),
-    ("latest", "https://localhost/artifacts/win-x86-commandline/latest/nuget.exe")])
+    ("latest", "https://localhost/artifacts/win-x86-commandline/latest/nuget.exe"),
+    ("5.11.6", "/win-x86-commandline/v5.11.6/nuget.exe"),
+    ("latest", "/win-x86-commandline/latest/nuget.exe")])
 def test_from_nuget_exe_url_extracts_nuget_exe_version(expected_version, request_url):
     found =  PackageDefinition.from_nuget_exe_url(request_url)
-    assert found and found.package_version == expected_version
+    assert found and found.package_id == 'tool/nuget.exe' and found.package_version == expected_version
 
 @pytest.mark.parametrize("request_url", [
     "",
@@ -66,7 +68,7 @@ def test_from_nuget_exe_url_extracts_nuget_exe_version(expected_version, request
     "http://localhost/artifacts/win-x86-commandline/v3.5.0/get.exe"
     ])
 def test_from_nuget_exe_url_returns_none_when_invalid_url(request_url):
-    found =  PackageDefinition.from_nuget_exe_url(request_url)
+    found = PackageDefinition.from_nuget_exe_url(request_url)
     assert not found
 
 # To invoke the pytest framework and run all tests


### PR DESCRIPTION
Existing URL path parsing code for statistics is a bit too strict. It expected client URL path to contain at least 4 segments while it only ever looks at 2 of them. As a result, when log content changed from origin path to request path for logs we're getting from CDN, the code started to not consider those as client download URLs.
This PR addresses it.