### PR TITLE
CodeQL-related updates.

### DIFF
--- a/src/NuGetGallery.Core/Certificates/CertificateFile.cs
+++ b/src/NuGetGallery.Core/Certificates/CertificateFile.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -65,6 +65,7 @@ namespace NuGetGallery
         private static string GetSha1Thumbprint(MemoryStream stream)
         {
 #pragma warning disable CA5350 // Do Not Use Weak Cryptographic Algorithms
+            // CodeQL [SM02196] Calculated for backwards compatibility, it is not used for anything
             using (var hashAlgorithm = SHA1.Create())
 #pragma warning restore CA5350 // Do Not Use Weak Cryptographic Algorithms
             {

--- a/src/NuGetGallery/Controllers/ApiController.cs
+++ b/src/NuGetGallery/Controllers/ApiController.cs
@@ -329,8 +329,8 @@ namespace NuGetGallery
         [ApiAuthorize]
         [ApiScopeRequired(NuGetScopes.PackagePush, NuGetScopes.PackagePushVersion)]
         [ActionName("CreatePackageVerificationKey")]
-        public virtual async Task<ActionResult> CreatePackageVerificationKeyAsync(string id, string version)
         // CodeQL [SM00433] This endpoint uses API Key authentication
+        public virtual async Task<ActionResult> CreatePackageVerificationKeyAsync(string id, string version)
         {
             // For backwards compatibility, we must preserve existing behavior where the client always pushes
             // symbols and the VerifyPackageKey callback returns the appropriate response. For this reason, we

--- a/tests/NuGetGallery.Core.Facts/Services/CloudBlobCoreFileStorageServiceIntegrationTests.cs
+++ b/tests/NuGetGallery.Core.Facts/Services/CloudBlobCoreFileStorageServiceIntegrationTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -171,14 +171,6 @@ namespace NuGetGallery
             var fileName = _prefixA;
             var expectedContent = "Hello, world.";
             var bytes = Encoding.UTF8.GetBytes(expectedContent);
-            string expectedContentMD5;
-#pragma warning disable CA5351  
-            using (var md5 = MD5.Create())
-            {
-                expectedContentMD5 = Convert.ToBase64String(md5.ComputeHash(bytes));
-            }
-#pragma warning disable CA5351 
-
             var container = _clientA.GetContainerReference(folderName);
             var file = container.GetBlobReference(fileName);
 


### PR DESCRIPTION
Progress on https://github.com/NuGet/Engineering/issues/5719.

For `GetSha1Thumbprint`: CodeQL started complaining about it, we already had warning suppression there, added CodeQL suppression as well.
For `CreatePackageVerificationKeyAsync`: we already had one in place, but it now started to complain about one line above, so, moved.
For `OpenWriteAsyncReturnsWritableStream` in tests: MD5 was calculated, but not used in test, so dropped the code.

Goes directly to `main` as CodeQL only checks that branch and there are no functional changes.