### PR TITLE
Increase ReposPerPackage from 5 to 20

### DIFF
--- a/src/NuGetGallery.Core/GitHub/NuGetPackageGitHubInformation.cs
+++ b/src/NuGetGallery.Core/GitHub/NuGetPackageGitHubInformation.cs
@@ -9,7 +9,7 @@ namespace NuGetGallery
 {
     public class NuGetPackageGitHubInformation
     {
-        public const int ReposPerPackage = 5;
+        public const int ReposPerPackage = 20;
 
         public readonly static NuGetPackageGitHubInformation Empty = new NuGetPackageGitHubInformation(new List<RepositoryInformation>());
 


### PR DESCRIPTION
Summary of the changes (in less than 80 characters):

Updates the number of dependent packages shown from 5 to 20.

Contributes to https://github.com/NuGet/NuGetGallery/issues/10266