### PR TITLE
Test:  Replace BouncyCastle with System.Formats.Asn1

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -81,6 +81,7 @@
     <PackageVersion Include="Microsoft.Extensions.Primitives" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Identity.Client" Version="4.65.0" />
     <PackageVersion Include="Microsoft.Identity.Web" Version="3.6.2" />
+    <PackageVersion Include="Microsoft.Internal.NuGet.Testing.SignedPackages" Version="6.13.2-rc.1" />
     <PackageVersion Include="Microsoft.Net.Http" Version="2.2.29" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageVersion Include="Microsoft.Owin.Host.SystemWeb" Version="4.2.2" />
@@ -136,16 +137,17 @@
     <PackageVersion Include="System.Data.SqlClient" Version="4.8.6" />
     <PackageVersion Include="System.Diagnostics.Debug" Version="4.3.0" />
     <PackageVersion Include="System.Drawing.Common" Version="9.0.0" />
-    <PackageVersion Include="System.Formats.Asn1" Version="8.0.1" />
+    <PackageVersion Include="System.Formats.Asn1" Version="8.0.2" />
     <PackageVersion Include="System.Linq.Expressions" Version="4.3.0" />
     <PackageVersion Include="System.Net.Http" Version="4.3.4" />
     <PackageVersion Include="System.Reflection.Metadata" Version="1.7.0-preview1-26717-04" />
     <PackageVersion Include="System.Runtime" Version="4.3.1" />
+    <PackageVersion Include="System.Security.Cryptography.Pkcs" Version="8.0.1" />
+    <PackageVersion Include="System.Security.Cryptography.X509Certificates" Version="4.3.2" />
     <PackageVersion Include="System.Text.Encodings.Web" Version="8.0.0" />
     <PackageVersion Include="System.Text.Json" Version="8.0.5" />
     <PackageVersion Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
     <PackageVersion Include="System.ValueTuple" Version="4.5.0" />
-    <PackageVersion Include="Test.Utility" Version="6.4.2-rc.25" />
     <PackageVersion Include="UAParser" Version="3.1.44" />
     <PackageVersion Include="WebActivatorEx" Version="2.0.6" />
     <PackageVersion Include="WebGrease" Version="1.6.0" />

--- a/NuGet.config
+++ b/NuGet.config
@@ -2,6 +2,7 @@
 <configuration>
   <packageSources>
     <clear />
+    <add key="dotnet-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
     <add key="NuGet.org" value="https://api.nuget.org/v3/index.json" />
     <add key="nuget-build" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/nuget-build/nuget/v3/index.json" />
   </packageSources>
@@ -10,6 +11,9 @@
   </disabledPackageSources>
   <packageSourceMapping>
     <clear />
+    <packageSource key="dotnet-tools">
+      <package pattern="Microsoft.Internal.NuGet.Testing.SignedPackages" />
+    </packageSource>
     <packageSource key="NuGet.org">
       <package pattern="Antlr" />
       <package pattern="AngleSharp.*" />
@@ -78,7 +82,6 @@
       <package pattern="NuGet.Services.*" />
       <package pattern="NuGet.StrongName.*" />
       <package pattern="Strathweb.CacheOutput.WebApi2.StrongName" />
-      <package pattern="Test.Utility" />
     </packageSource>
     <packageSource key="nuget-server-upstreams">
       <package pattern="Microsoft.Internal.*" />

--- a/tests/Validation.PackageSigning.Core.Tests/Support/ExtensionMethods.cs
+++ b/tests/Validation.PackageSigning.Core.Tests/Support/ExtensionMethods.cs
@@ -2,19 +2,12 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Security.Cryptography.X509Certificates;
-using Test.Utility.Signing;
-using BCCertificate = Org.BouncyCastle.X509.X509Certificate;
+using Microsoft.Internal.NuGet.Testing.SignedPackages;
 
 namespace Validation.PackageSigning.Core.Tests.Support
 {
     public static class ExtensionMethods
     {
-        public static X509Certificate2 ToX509Certificate2(this BCCertificate certificate)
-        {
-            return new X509Certificate2(certificate.GetEncoded());
-        }
-
         public static DisposableList<IDisposable> RegisterResponders(
             this ISigningTestServer testServer,
             CertificateAuthority ca,

--- a/tests/Validation.PackageSigning.Core.Tests/Support/X509AuthorityInformationAccessExtension.cs
+++ b/tests/Validation.PackageSigning.Core.Tests/Support/X509AuthorityInformationAccessExtension.cs
@@ -1,0 +1,57 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#nullable enable
+
+using System;
+using System.Formats.Asn1;
+using System.Security.Cryptography.X509Certificates;
+
+namespace Microsoft.Internal.NuGet.Testing.SignedPackages
+{
+    internal sealed class X509AuthorityInformationAccessExtension : X509Extension
+    {
+        private static readonly string AuthorityInfoAccess = "1.3.6.1.5.5.7.1.1";
+        private static readonly string Ocsp = "1.3.6.1.5.5.7.48.1";
+        private static readonly string CaIssuers = "1.3.6.1.5.5.7.48.2";
+
+        internal X509AuthorityInformationAccessExtension(Uri? ocspResponderUrl, Uri? caIssuersUrl)
+            : base(AuthorityInfoAccess, Encode(ocspResponderUrl, caIssuersUrl), critical: false)
+        {
+        }
+
+        private static byte[] Encode(Uri? ocspResponderUrl, Uri? caIssuersUrl)
+        {
+            AsnWriter writer = new(AsnEncodingRules.DER);
+
+            using (writer.PushSequence())
+            {
+                if (ocspResponderUrl is not null)
+                {
+                    using (writer.PushSequence())
+                    {
+                        writer.WriteObjectIdentifier(Ocsp);
+                        writer.WriteCharacterString(
+                            UniversalTagNumber.IA5String,
+                            ocspResponderUrl.OriginalString,
+                            new Asn1Tag(TagClass.ContextSpecific, tagValue: 6));
+                    }
+                }
+
+                if (caIssuersUrl is not null)
+                {
+                    using (writer.PushSequence())
+                    {
+                        writer.WriteObjectIdentifier(CaIssuers);
+                        writer.WriteCharacterString(
+                            UniversalTagNumber.IA5String,
+                            caIssuersUrl.OriginalString,
+                            new Asn1Tag(TagClass.ContextSpecific, tagValue: 6));
+                    }
+                }
+            }
+
+            return writer.Encode();
+        }
+    }
+}

--- a/tests/Validation.PackageSigning.Core.Tests/Support/X509V3CertificateGeneratorExtensions.cs
+++ b/tests/Validation.PackageSigning.Core.Tests/Support/X509V3CertificateGeneratorExtensions.cs
@@ -1,79 +1,35 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
-using System.Collections.Generic;
-using Org.BouncyCastle.Asn1;
-using Org.BouncyCastle.Asn1.X509;
-using Test.Utility.Signing;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using Microsoft.Internal.NuGet.Testing.SignedPackages;
+using NuGet.Packaging.Signing;
 
-namespace Org.BouncyCastle.X509
+namespace Validation.PackageSigning.Core
 {
     public static class X509V3CertificateGeneratorExtensions
     {
-        public static void MakeExpired(this X509V3CertificateGenerator generator)
+        public static void AddSigningEku(this CertificateRequest certificateRequest)
         {
-            // TODO: Migrate to "TestCertificateGenerator".
-            // See: https://github.com/NuGet/NuGetGallery/issues/8216
+            var usages = new OidCollection { new Oid(Oids.CodeSigningEku) };
 
-            // This was copied from Test.Utility's SigningTestUtility.CertificateModificationGeneratorExpiredCert,
-            // which was changed to accept a "TestCertificateGenerator" instead.
-            // See: https://github.com/NuGet/NuGet.Client/pull/2685/files#diff-6c1acc7ed04355ba9e02b589e7e32a41L69
-            var usages = new[] { KeyPurposeID.IdKPCodeSigning };
-
-            generator.AddExtension(
-                X509Extensions.ExtendedKeyUsage.Id,
-                critical: true,
-                extensionValue: new ExtendedKeyUsage(usages));
-
-            generator.SetNotBefore(DateTime.UtcNow.AddHours(-1));
-            generator.SetNotAfter(DateTime.UtcNow.AddHours(-1));
-        }
-
-        public static void AddSigningEku(this X509V3CertificateGenerator generator)
-        {
-            // TODO: Migrate to "TestCertificateGenerator".
-            // See: https://github.com/NuGet/NuGetGallery/issues/8216
-
-            // This was copied from Test.Utility's SigningTestUtility.CertificateModificationGeneratorForCodeSigningEkuCert.
-            // which was changed to accept a "TestCertificateGenerator" instead.
-            // See: https://github.com/NuGet/NuGet.Client/pull/2685/files#diff-6c1acc7ed04355ba9e02b589e7e32a41L69
-            var usages = new[] { KeyPurposeID.IdKPCodeSigning };
-
-            generator.AddExtension(
-                X509Extensions.ExtendedKeyUsage.Id,
-                critical: true,
-                extensionValue: new ExtendedKeyUsage(usages));
+            certificateRequest.CertificateExtensions.Add(
+                new X509EnhancedKeyUsageExtension(
+                    usages,
+                    critical: true));
         }
 
         public static void AddAuthorityInfoAccess(
-            this X509V3CertificateGenerator generator,
-            CertificateAuthority ca,
+            this CertificateRequest certificateRequest,
+            CertificateAuthority certificateAuthority,
             bool addOcsp = false,
             bool addCAIssuers = false)
         {
-            var vector = new List<Asn1Encodable>();
-
-            if (addOcsp)
-            {
-                vector.Add(
-                    new AccessDescription(
-                        AccessDescription.IdADOcsp,
-                        new GeneralName(GeneralName.UniformResourceIdentifier, ca.OcspResponderUri.OriginalString)));
-            }
-
-            if (addCAIssuers)
-            {
-                vector.Add(
-                    new AccessDescription(
-                        AccessDescription.IdADCAIssuers,
-                        new GeneralName(GeneralName.UniformResourceIdentifier, ca.CertificateUri.OriginalString)));
-            }
-
-            generator.AddExtension(
-                X509Extensions.AuthorityInfoAccess,
-                critical: false,
-                extensionValue: new DerSequence(vector.ToArray()));
+            certificateRequest.CertificateExtensions.Add(
+                new X509AuthorityInformationAccessExtension(
+                    addOcsp ? certificateAuthority.OcspResponderUri : null,
+                    addCAIssuers ? certificateAuthority.CertificateUri : null));
         }
     }
 }

--- a/tests/Validation.PackageSigning.Core.Tests/Validation.PackageSigning.Core.Tests.csproj
+++ b/tests/Validation.PackageSigning.Core.Tests/Validation.PackageSigning.Core.Tests.csproj
@@ -7,8 +7,8 @@
     <ProjectReference Include="..\Validation.PackageSigning.Helpers\Tests.ContextHelpers.csproj" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.Internal.NuGet.Testing.SignedPackages" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="Test.Utility" />
     <PackageReference Include="NuGet.CommandLine" />
     <PackageReference Include="NuGet.Commands" />
     <PackageReference Include="NuGet.PackageManagement" />

--- a/tests/Validation.PackageSigning.ProcessSignature.Tests/SignatureValidatorIntegrationTests.cs
+++ b/tests/Validation.PackageSigning.ProcessSignature.Tests/SignatureValidatorIntegrationTests.cs
@@ -15,6 +15,7 @@ using System.Threading.Tasks;
 using ICSharpCode.SharpZipLib.Zip;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Microsoft.Internal.NuGet.Testing.SignedPackages;
 using Moq;
 using NuGet.Jobs.Validation.PackageSigning.Configuration;
 using NuGet.Jobs.Validation.PackageSigning.Messages;
@@ -27,7 +28,6 @@ using NuGet.Services.Logging;
 using NuGet.Services.Validation;
 using NuGet.Services.Validation.Issues;
 using NuGetGallery;
-using Test.Utility.Signing;
 using Tests.ContextHelpers;
 using TestUtil;
 using Validation.PackageSigning.Core.Tests.Support;
@@ -1960,16 +1960,6 @@ namespace Validation.PackageSigning.ProcessSignature.Tests
             VerifyPackageSigningStatus(result, ValidationStatus.Failed, PackageSigningStatus.Invalid);
             var issue = Assert.Single(result.Issues);
             Assert.Equal(ValidationIssueCode.PackageIsZip64, issue.IssueCode);
-        }
-
-        private IDisposable TemporarilyTrustUntrustedCertificate(X509Certificate2 certificate)
-        {
-            return new TrustedTestCert<X509Certificate2>(
-                certificate,
-                x => x,
-                new[] { X509StorePurpose.CodeSigning, X509StorePurpose.Timestamping },
-                StoreName.Root,
-                StoreLocation.LocalMachine);
         }
 
         private void SetSignatureFileContent(MemoryStream packageStream, byte[] fileContent)

--- a/tests/Validation.PackageSigning.ProcessSignature.Tests/Support/CertificateIntegrationTestFixture.cs
+++ b/tests/Validation.PackageSigning.ProcessSignature.Tests/Support/CertificateIntegrationTestFixture.cs
@@ -8,7 +8,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Common;
 using NuGet.Packaging.Signing;
-using NuGet.Test.Utility;
 using Xunit.Abstractions;
 
 namespace Validation.PackageSigning.ProcessSignature.Tests

--- a/tests/Validation.PackageSigning.ProcessSignature.Tests/Support/TestLogger.cs
+++ b/tests/Validation.PackageSigning.ProcessSignature.Tests/Support/TestLogger.cs
@@ -1,0 +1,118 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+using NuGet.Common;
+using Xunit.Abstractions;
+
+namespace Validation.PackageSigning.ProcessSignature.Tests
+{
+    internal sealed class TestLogger : ILogger
+    {
+        private readonly ITestOutputHelper _output;
+
+        internal TestLogger(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        public void LogDebug(string data)
+        {
+            DumpMessage("DEBUG", data);
+        }
+
+        public void LogError(string data)
+        {
+            DumpMessage("ERROR", data);
+        }
+
+        public void LogInformation(string data)
+        {
+            DumpMessage("INFO ", data);
+        }
+
+        public void LogMinimal(string data)
+        {
+            DumpMessage("LOG  ", data);
+        }
+
+        public void LogVerbose(string data)
+        {
+            DumpMessage("TRACE", data);
+        }
+
+        public void LogWarning(string data)
+        {
+            DumpMessage("WARN ", data);
+        }
+
+        public void LogInformationSummary(string data)
+        {
+            DumpMessage("ISMRY", data);
+        }
+
+        private void DumpMessage(string level, string data)
+        {
+            _output.WriteLine($"{level}: {data}");
+        }
+
+        public void Log(LogLevel level, string data)
+        {
+            switch (level)
+            {
+                case LogLevel.Debug:
+                    {
+                        LogDebug(data);
+                        break;
+                    }
+
+                case LogLevel.Error:
+                    {
+                        LogError(data);
+                        break;
+                    }
+
+                case LogLevel.Information:
+                    {
+                        LogInformation(data);
+                        break;
+                    }
+
+                case LogLevel.Minimal:
+                    {
+                        LogMinimal(data);
+                        break;
+                    }
+
+                case LogLevel.Verbose:
+                    {
+                        LogVerbose(data);
+                        break;
+                    }
+
+                case LogLevel.Warning:
+                    {
+                        LogWarning(data);
+                        break;
+                    }
+            }
+        }
+
+        public Task LogAsync(LogLevel level, string data)
+        {
+            Log(level, data);
+
+            return Task.CompletedTask;
+        }
+
+        public void Log(ILogMessage message)
+        {
+            Log(message.Level, message.Message);
+        }
+
+        public async Task LogAsync(ILogMessage message)
+        {
+            await LogAsync(message.Level, message.FormatWithCode());
+        }
+    }
+}

--- a/tests/Validation.PackageSigning.ProcessSignature.Tests/Validation.PackageSigning.ProcessSignature.Tests.csproj
+++ b/tests/Validation.PackageSigning.ProcessSignature.Tests/Validation.PackageSigning.ProcessSignature.Tests.csproj
@@ -3,6 +3,7 @@
     <TargetFramework>net472</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.Internal.NuGet.Testing.SignedPackages" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="SharpZipLib" />
     <PackageReference Include="xunit.runner.visualstudio">

--- a/tests/Validation.PackageSigning.ValidateCertificate.Tests/Support/X509V3CertificateGeneratorExtensions2.cs
+++ b/tests/Validation.PackageSigning.ValidateCertificate.Tests/Support/X509V3CertificateGeneratorExtensions2.cs
@@ -1,21 +1,22 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using Org.BouncyCastle.Asn1.X509;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using NuGet.Packaging.Signing;
 
-namespace Org.BouncyCastle.X509
+namespace Validation.PackageSigning.ValidateCertificate.Tests.Support
 {
     public static class X509V3CertificateGeneratorExtensions2
     {
-        public static void AddTimestampingEku(this X509V3CertificateGenerator generator)
+        public static void AddTimestampingEku(this CertificateRequest certificateRequest)
         {
-            // TimeStamping EKU
-            var usages = new[] { KeyPurposeID.IdKPTimeStamping };
+            var usages = new OidCollection { new Oid(Oids.TimeStampingEku) };
 
-            generator.AddExtension(
-                X509Extensions.ExtendedKeyUsage.Id,
-                critical: true,
-                extensionValue: new ExtendedKeyUsage(usages));
+            certificateRequest.CertificateExtensions.Add(
+                new X509EnhancedKeyUsageExtension(
+                    usages,
+                    critical: true));
         }
     }
 }

--- a/tests/Validation.PackageSigning.ValidateCertificate.Tests/Validation.PackageSigning.ValidateCertificate.Tests.csproj
+++ b/tests/Validation.PackageSigning.ValidateCertificate.Tests/Validation.PackageSigning.ValidateCertificate.Tests.csproj
@@ -9,6 +9,7 @@
     <ProjectReference Include="..\Validation.PackageSigning.Helpers\Tests.ContextHelpers.csproj" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.Internal.NuGet.Testing.SignedPackages" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit.runner.visualstudio">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
This change updates package signing test infrastructure to use System.Formats.Asn1 instead of BouncyCastle.

Resolve https://github.com/NuGet/Engineering/issues/5812.