### PR TITLE
Update NuGet client from 6.9.1 to 6.13.2

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,7 +3,7 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CentralPackageTransitivePinningEnabled>false</CentralPackageTransitivePinningEnabled>
     <EnablePackageVersionOverride>true</EnablePackageVersionOverride>
-    <NuGetClientPackageVersion>6.9.1</NuGetClientPackageVersion>
+    <NuGetClientPackageVersion>6.13.2</NuGetClientPackageVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Autofac.Extensions.DependencyInjection" Version="4.4.0" />


### PR DESCRIPTION
Update NuGet client libraries from 6.9.1 to 6.13.2.

Resolves https://github.com/NuGet/Engineering/issues/5815