### PR TITLE
BUG: 10341 - Proper Display of License Information

### DIFF
--- a/src/NuGetGallery/App_Code/ViewHelpers.cshtml
+++ b/src/NuGetGallery/App_Code/ViewHelpers.cshtml
@@ -732,6 +732,16 @@ var hlp = new AccordionHelper(name, formModelStatePrefix, expanded, page);
         return segment.Type == CompositeLicenseExpressionSegmentType.LicenseIdentifier || segment.Type == CompositeLicenseExpressionSegmentType.ExceptionIdentifier;
     }
 
+    public static bool IsLicense(CompositeLicenseExpressionSegment segment)
+    {
+        return segment.Type == CompositeLicenseExpressionSegmentType.LicenseIdentifier;
+    }
+
+    public static bool IsException(CompositeLicenseExpressionSegment segment)
+    {
+        return segment.Type == CompositeLicenseExpressionSegmentType.ExceptionIdentifier;
+    }
+
     public static MvcHtmlString GetExternalUrlAnchorTag(string data, string link)
     {
         return MvcHtmlString.Create(UriExtensions.GetExternalUrlAnchorTag(data, link));

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -79,7 +79,7 @@
             {
                 CommandPrefix = "> ",
             }
-                                };
+        };
     }
     else if (Model.IsDotnetNewTemplatePackageType)
     {
@@ -97,7 +97,7 @@
                 AlertLevel = AlertLevel.Info,
                 AlertMessage = "This package contains a <a href='https://aka.ms/dotnet-new'>.NET Template Package</a> you can call from the shell/command line.",
             }
-                                };
+        };
     }
     else if (Model.IsMSBuildSdkPackageType)
     {
@@ -115,7 +115,7 @@
                 AlertMessage = string.Format("For projects that support Sdk, copy this XML node into the project file to reference the package."),
                 CopyLabel = "Copy the SDK XML node",
             }
-                                };
+        };
     }
     else
     {
@@ -219,7 +219,7 @@
                 "https://cakebuild.net/support/nuget",
                 Model.GetCakeInstallPackageCommands()
                 )
-                                };
+        };
     }
 }
 
@@ -276,15 +276,15 @@
             <div class="install-script-row">
                 @* Writing out the install command must be on a single line to avoid undesired whitespace in the <pre> tag. *@
                 <pre class="install-script" id="@installPackageCommand.Key-text"><span class="install-command-row">@installPackageCommand.Value.Command</span>
-                <div class="copy-button">
+                    <div class="copy-button">
                         @if (installPackageCommand.Value.HasHeader) {<span class="package-manager-command-header">
                             @installPackageCommand.Value.Header
                         </span>
                         }<button id="@installPackageCommand.Key-button" class="btn btn-brand-icon" type="button"
-                                 data-toggle="popover" data-placement="bottom" data-content="Copied."
-                                 aria-label="@packageManager.CopyLabel" role="button">
-                <span class="ms-Icon ms-Icon--Copy" aria-hidden="true"></span>
-                <span>Copy</span>
+                                data-toggle="popover" data-placement="bottom" data-content="Copied."
+                                aria-label="@packageManager.CopyLabel" role="button">
+                            <span class="ms-Icon ms-Icon--Copy" aria-hidden="true"></span>
+                            <span>Copy</span>
                         </button>
                     </div>
                 </pre>
@@ -294,15 +294,15 @@
         {
             case AlertLevel.Info:
                 @ViewHelpers.AlertInfo(
-                                @<text>
-                                    @Html.Raw(packageManager.AlertMessage)
-                                </text>);
+                    @<text>
+                        @Html.Raw(packageManager.AlertMessage)
+                    </text>);
                 break;
             case AlertLevel.Warning:
                 @ViewHelpers.AlertWarning(
-                                @<text>
-                                    @Html.Raw(packageManager.AlertMessage)
-                                </text>, true);
+                    @<text>
+                        @Html.Raw(packageManager.AlertMessage)
+                    </text>, true);
                 break;
             default:
                 break;
@@ -361,9 +361,9 @@
                 {
                     <div class="content-hidden-notice">
                         @ViewHelpers.AlertDanger(
-                                        @<text>
-                                            This package's content is hidden as it violates our <a href="https://www.nuget.org/policies/terms" title="Terms of Use">Terms of Use</a>.
-                                        </text>)
+                            @<text>
+                                This package's content is hidden as it violates our <a href="https://www.nuget.org/policies/terms" title="Terms of Use">Terms of Use</a>.
+                            </text>)
                     </div>
                 }
 
@@ -375,63 +375,63 @@
                 @if (Model.Validating)
                 {
                     @ViewHelpers.AlertWarning(
-                                    @<text>
-                                        <strong>This package has not been published yet.</strong> It will appear in search results and
-                                        will be available for install/restore after both validation and indexing are complete. Package
-                                        validation and indexing may take up to an hour. <a href="https://aka.ms/NuGetPackageValidation">Read more</a>.
-                                    </text>
-)
+                        @<text>
+                            <strong>This package has not been published yet.</strong> It will appear in search results and
+                            will be available for install/restore after both validation and indexing are complete. Package
+                            validation and indexing may take up to an hour. <a href="https://aka.ms/NuGetPackageValidation">Read more</a>.
+                        </text>
+                    )
                     if (Model.EmbeddedLicenseType != EmbeddedLicenseFileType.Absent)
                     {
                         @ViewHelpers.AlertWarning(
-                                        @<text>
-                                            The license link will become available once package validation has completed successfully.
-                                        </text>
-)
+                            @<text>
+                                The license link will become available once package validation has completed successfully.
+                            </text>
+                        )
                     }
 
                     if (Model.ValidatingTooLong)
                     {
                         @ViewHelpers.AlertWarning(
-                                        @<text>
-                                            <strong>Package validation is taking longer than expected.</strong> This is not normal, but we are on it!
-                                        </text>
-)
+                            @<text>
+                                <strong>Package validation is taking longer than expected.</strong> This is not normal, but we are on it!
+                            </text>
+                        )
                     }
                 }
 
                 @if (Model.FailedValidation)
                 {
                     @ViewHelpers.AlertDanger(
-                                    @<text>
-                                        <strong>Package publishing failed.</strong> This package could not be published due to the following reason(s):
-                                        <ul class="failed-validation-alert-list">
-                                            @foreach (var issue in Model.PackageValidationIssues)
-                                            {
-                                                <li>@Html.Partial("_ValidationIssue", issue)</li>
-                                            }
-                                        </ul>
-                                        @if (!Model.PackageValidationIssues.Any(i => i.IssueCode == ValidationIssueCode.Unknown))
-                                        {
-                                            var issuePluralString = Model.PackageValidationIssues.Count > 1 ? "all the issues" : "the issue";
-                                            <text>Once you've fixed @issuePluralString with your package, you can reupload it with the same ID and version.</text>
-                                        }
-                                        else
-                                        {
-                                            <text>Please contact <a href="mailto:support@nuget.org">support@nuget.org</a> to help fix your package.</text>
-                                        }
-                                    </text>
-)
+                        @<text>
+                            <strong>Package publishing failed.</strong> This package could not be published due to the following reason(s):
+                            <ul class="failed-validation-alert-list">
+                                @foreach (var issue in Model.PackageValidationIssues)
+                                {
+                                    <li>@Html.Partial("_ValidationIssue", issue)</li>
+                                }
+                            </ul>
+                            @if (!Model.PackageValidationIssues.Any(i => i.IssueCode == ValidationIssueCode.Unknown))
+                            {
+                                var issuePluralString = Model.PackageValidationIssues.Count > 1 ? "all the issues" : "the issue";
+                                <text>Once you've fixed @issuePluralString with your package, you can reupload it with the same ID and version.</text>
+                            }
+                            else
+                            {
+                                <text>Please contact <a href="mailto:support@nuget.org">support@nuget.org</a> to help fix your package.</text>
+                            }
+                        </text>
+                    )
                 }
 
                 @if (Model.Deleted)
                 {
                     @ViewHelpers.AlertDanger(
-                                    @<text>
-                                        <strong>This package has been deleted from the gallery.</strong> It is no longer available
-                                        for install/restore.
-                                    </text>
-)
+                        @<text>
+                            <strong>This package has been deleted from the gallery.</strong> It is no longer available
+                            for install/restore.
+                        </text>
+                    )
                 }
 
                 @if (Model.IsPackageVulnerabilitiesEnabled && Model.Vulnerabilities != null)
@@ -454,67 +454,67 @@
                     if (Model.Prerelease)
                     {
                         @ViewHelpers.AlertInfo(
-                                        @<text>
-                                            This is a prerelease version of @(Model.Id).
-                                        </text>
-)
+                            @<text>
+                                This is a prerelease version of @(Model.Id).
+                            </text>
+                        )
                     }
-
+                    
                     if (Model.NuGetVersion.HasMetadata)
                     {
                         @ViewHelpers.AlertInfo(
-                                        @<text>
-                                            This package has a SemVer 2.0.0 package version: @(Model.FullVersion).
-                                        </text>
-)
+                            @<text>
+                                This package has a SemVer 2.0.0 package version: @(Model.FullVersion).
+                            </text>
+                        )
                     }
-
+                    
                     if (Model.VersionRequestedWasNotFound)
                     {
                         @ViewHelpers.AlertWarning(
-                                        @<text>
-                                            The specified version @Model.VersionRequested was not found. You have been taken to version @(Model.Version).
-                                        </text>
-)
+                            @<text>
+                                The specified version @Model.VersionRequested was not found. You have been taken to version @(Model.Version).
+                            </text>
+                        )
                     }
-
+                    
                     if (Model.HasNewerRelease)
                     {
                         @ViewHelpers.AlertInfo(
-                                        @<text>
-                                            There is a newer version of this package available.
-                                            <br /> See the version list below for details.
-                                        </text>
-)
+                            @<text>
+                                There is a newer version of this package available.
+                                <br /> See the version list below for details.
+                            </text>
+                        )
                     }
                     else if (Model.HasNewerPrerelease)
                     {
                         @ViewHelpers.AlertInfo(
-                                        @<text>
-                                            There is a newer prerelease version of this package available.
-                                            <br /> See the version list below for details.
-                                        </text>
-)
+                            @<text>
+                                There is a newer prerelease version of this package available.
+                                <br /> See the version list below for details.
+                            </text>
+                        )
                     }
 
                     if (Model.Listed && Model.IsIndexed.HasValue && !Model.IsIndexed.Value && Model.Available)
                     {
                         @ViewHelpers.AlertWarning(
-                                        @<text>
-                                            <strong>This package has not been indexed yet.</strong> It will appear in search results
-                                            and will be available for install/restore after indexing is complete.
-                                        </text>
-)
+                            @<text>
+                                <strong>This package has not been indexed yet.</strong> It will appear in search results
+                                and will be available for install/restore after indexing is complete.
+                            </text>
+                        )
                     }
                 }
 
                 @if (Model.HasEmbeddedIcon && Model.ShowDetailsAndLinks && Model.IsIndexed.HasValue && !Model.IsIndexed.Value && (Model.Available || Model.Validating))
                 {
                     @ViewHelpers.AlertWarning(
-                                    @<text>
-                                        The package icon will become available after this package is indexed.
-                                    </text>
-)
+                        @<text>
+                            The package icon will become available after this package is indexed.
+                        </text>
+                    )
                 }
 
                 @if (Model.CanDisplayPrivateMetadata && showSymbolsPackageStatus)
@@ -522,39 +522,39 @@
                     if (Model.LatestSymbolsPackage.StatusKey == PackageStatus.Validating)
                     {
                         @ViewHelpers.AlertWarning(
-                                        @<text>
-                                            <strong>The symbols for this package have not been indexed yet.</strong> They are not available
-                                            for download from the NuGet.org symbol server. Symbols will be available for download after both validation and indexing are complete.
-                                            Symbols validation and indexing may take up to an hour. <a href="https://aka.ms/NuGetSymbolsPackageValidation">Read more</a>.
+                            @<text>
+                                <strong>The symbols for this package have not been indexed yet.</strong> They are not available
+                                for download from the NuGet.org symbol server. Symbols will be available for download after both validation and indexing are complete.
+                                Symbols validation and indexing may take up to an hour. <a href="https://aka.ms/NuGetSymbolsPackageValidation">Read more</a>.
 
-                                            @AppendAvailableSymbolsMessage(hasSymbolsPackageAvailable)
-                                        </text>
-)
+                                @AppendAvailableSymbolsMessage(hasSymbolsPackageAvailable)
+                            </text>
+                        )
                     }
                     else if (Model.LatestSymbolsPackage.StatusKey == PackageStatus.FailedValidation)
                     {
                         @ViewHelpers.AlertDanger(
-                                        @<text>
-                                            <strong>Symbols package publishing failed.</strong> The associated symbols package could not be published due to the following reason(s):
-                                            <ul class="failed-validation-alert-list">
-                                                @foreach (var issue in Model.SymbolsPackageValidationIssues)
-                                                {
-                                                    <li>@Html.Partial("_ValidationIssue", issue)</li>
-                                                }
-                                            </ul>
-                                            @if (!Model.SymbolsPackageValidationIssues.Any(i => i.IssueCode == ValidationIssueCode.Unknown))
-                                            {
-                                                var issuePluralString = Model.SymbolsPackageValidationIssues.Count() > 1 ? "all the issues" : "the issue";
-                                                <text>Once you've fixed @issuePluralString with your symbols package, you can re-upload it.</text>
-                                            }
-                                            else
-                                            {
-                                                <text>Please contact <a href="mailto:support@nuget.org">support@nuget.org</a> to help fix your symbols package.</text>
-                                            }
+                            @<text>
+                                <strong>Symbols package publishing failed.</strong> The associated symbols package could not be published due to the following reason(s):
+                                <ul class="failed-validation-alert-list">
+                                    @foreach (var issue in Model.SymbolsPackageValidationIssues)
+                                    {
+                                        <li>@Html.Partial("_ValidationIssue", issue)</li>
+                                    }
+                                </ul>
+                                @if (!Model.SymbolsPackageValidationIssues.Any(i => i.IssueCode == ValidationIssueCode.Unknown))
+                                {
+                                    var issuePluralString = Model.SymbolsPackageValidationIssues.Count() > 1 ? "all the issues" : "the issue";
+                                    <text>Once you've fixed @issuePluralString with your symbols package, you can re-upload it.</text>
+                                }
+                                else
+                                {
+                                    <text>Please contact <a href="mailto:support@nuget.org">support@nuget.org</a> to help fix your symbols package.</text>
+                                }
 
-                                            @AppendAvailableSymbolsMessage(hasSymbolsPackageAvailable)
-                                        </text>
-)
+                                @AppendAvailableSymbolsMessage(hasSymbolsPackageAvailable)
+                            </text>
+                        )
                     }
                 }
 
@@ -563,21 +563,21 @@
                     if (Model.CanDisplayPrivateMetadata)
                     {
                         @ViewHelpers.AlertWarning(
-                                        @<text>
-                                            This package is unlisted and hidden from package listings.
-                                            You can see the package because you are one of its owners. To list the package again,
-                                            <a href="@Url.ManagePackage(Model)">change its listing setting</a>.
-                                        </text>
-)
+                            @<text>
+                                This package is unlisted and hidden from package listings.
+                                You can see the package because you are one of its owners. To list the package again,
+                                <a href="@Url.ManagePackage(Model)">change its listing setting</a>.
+                            </text>
+                        )
                     }
                     else
                     {
                         @ViewHelpers.AlertWarning(
-                                        @<text>
-                                            The owner has unlisted this package.
-                                            This could mean that the package is deprecated, has security vulnerabilities or shouldn't be used anymore.
-                                        </text>
-)
+                            @<text>
+                                The owner has unlisted this package.
+                                This could mean that the package is deprecated, has security vulnerabilities or shouldn't be used anymore.
+                            </text>
+                        )
                     }
                 }
 
@@ -630,7 +630,7 @@
                                 @if (Model.CanDisplayReadmeWarning && Model.CanDisplayPrivateMetadata)
                                 {
                                     <i class="ms-Icon ms-Icon--Warning" aria-hidden="true"></i>
-                                }
+                                } 
                                 else
                                 {
                                     <i class="ms-Icon ms-Icon--Dictionary" aria-hidden="true"></i>
@@ -639,24 +639,24 @@
                             </a>
                         </li>
 
-                        if (Model.CanDisplayTargetFrameworks())
-                        {
-                            activeBodyTab = activeBodyTab ?? "supportedframeworks";
-                            <li role="presentation" id="show-supportedframeworks-container">
-                                <a href="#supportedframeworks-body-tab"
-                                   role="tab"
-                                   data-toggle="tab"
-                                   data-target="#supportedframeworks-tab"
-                                   id="supportedframeworks-body-tab"
-                                   class="body-tab"
-                                   aria-controls="supportedframeworks-tab"
-                                   aria-selected="@(activeBodyTab == "supportedframeworks" ? "true" : "false")"
-                                   tabindex="@(activeBodyTab == "supportedframeworks" ? "0" : "-1")">
-                                    <i class="ms-Icon ms-Icon--Package" aria-hidden="true"></i>
-                                    Frameworks
-                                </a>
-                            </li>
-                        }
+                     if (Model.CanDisplayTargetFrameworks())
+                     {
+                        activeBodyTab = activeBodyTab ?? "supportedframeworks";
+                        <li role="presentation" id="show-supportedframeworks-container">
+                            <a href="#supportedframeworks-body-tab"
+                                role="tab"
+                                data-toggle="tab"
+                                data-target="#supportedframeworks-tab"
+                                id="supportedframeworks-body-tab"
+                                class="body-tab"
+                                aria-controls="supportedframeworks-tab"
+                                aria-selected="@(activeBodyTab == "supportedframeworks" ? "true" : "false")"
+                                tabindex="@(activeBodyTab == "supportedframeworks" ? "0" : "-1")">
+                                <i class="ms-Icon ms-Icon--Package" aria-hidden="true"></i>
+                                Frameworks
+                            </a>
+                        </li>
+                     }
 
                         activeBodyTab = activeBodyTab ?? "dependencies";
                         <li role="presentation">
@@ -738,9 +738,9 @@
                         @if ((Model.Validating || Model.FailedValidation) && Model.HasEmbeddedReadmeFile)
                         {
                             @ViewHelpers.AlertWarning(
-                                            @<text>
-                                                The readme will become available once package validation has completed successfully.
-                                            </text>)
+                                @<text>
+                                    The readme will become available once package validation has completed successfully.
+                                </text>)
                         }
                         else if (Model.ReadMeHtml != null)
                         {
@@ -777,17 +777,17 @@
 
                     if (Model.CanDisplayTargetFrameworks())
                     {
-                        <div role="tabpanel" class="tab-pane @(activeBodyTab == "supportedframeworks" ? "active" : "")" id="supportedframeworks-tab" aria-label="Supported frameworks tab content">
-                            @if (Model.PackageFrameworkCompatibility.Table.Count > 0)
-                            {
-                                @Html.Partial("_SupportedFrameworksTable", Model.PackageFrameworkCompatibility.Table)
-                            }
-                            else
-                            {
+                    <div role="tabpanel" class="tab-pane @(activeBodyTab == "supportedframeworks" ? "active" : "")" id="supportedframeworks-tab" aria-label="Supported frameworks tab content">
+                        @if (Model.PackageFrameworkCompatibility.Table.Count > 0)
+                        {
+                            @Html.Partial("_SupportedFrameworksTable", Model.PackageFrameworkCompatibility.Table)
+                        }
+                        else
+                        {
                             <span tabindex="0">There are no supported framework assets in this package.</span><br/>
-                                <p class="frameworktableinfo-text"><i>Learn more about <a href='https://docs.microsoft.com/dotnet/standard/frameworks' aria-label="Learn more about Target Frameworks">Target Frameworks</a> and <a href='https://docs.microsoft.com/dotnet/standard/net-standard' aria-label="Learn more about .NET Standard">.NET Standard</a>.</i></p>
-                            }
-                        </div>
+                            <p class="frameworktableinfo-text"><i>Learn more about <a href='https://docs.microsoft.com/dotnet/standard/frameworks' aria-label="Learn more about Target Frameworks">Target Frameworks</a> and <a href='https://docs.microsoft.com/dotnet/standard/net-standard' aria-label="Learn more about .NET Standard">.NET Standard</a>.</i></p>
+                        }
+                    </div>
                     }
 
                     <div role="tabpanel" class="tab-pane @(activeBodyTab == "dependencies" ? "active" : "")" id="dependencies-tab" aria-label="Dependencies tab content">
@@ -1183,10 +1183,10 @@
                                 }
                                 else
                                 {
-                                <a href="@Model.LicenseUrl"
-                                   data-track="outbound-license-url" title="Make sure you agree with the license" rel="nofollow">
-                                    License Info
-                                </a>
+                                    <a href="@Model.LicenseUrl"
+                                        data-track="outbound-license-url" title="Make sure you agree with the license" rel="nofollow">
+                                        License Info
+                                    </a>
                                 }
                             </li>
                         }
@@ -1216,8 +1216,8 @@
                         <li>
                             <i class="ms-Icon ms-Icon--FabricFolderSearch" aria-hidden="true" aria-label="@disclaimer" title="@disclaimer"></i>
                             <a href="@Model.NuGetPackageExplorerUrl" data-track="outbound-nugetpackageexplorer-url"
-                               aria-label="open in NuGet Package Explorer"
-                               title="Explore additional package info on NuGet Package Explorer" target="_blank" rel="nofollow noreferrer">
+                                aria-label="open in NuGet Package Explorer"
+                                title="Explore additional package info on NuGet Package Explorer" target="_blank" rel="nofollow noreferrer">
                                 Open in NuGet Package Explorer
                             </a>
                         </li>
@@ -1229,12 +1229,12 @@
 
                         <li>
                             <img class="icon"
-                                 aria-label="@disclaimer" title="@disclaimer"
-                                 src="@Url.Absolute("~/Content/gallery/img/fuget.svg")"
-                                 @ViewHelpers.ImageFallback(Url.Absolute("~/Content/gallery/img/fuget-32x32.png")) />
+                                    aria-label="@disclaimer" title="@disclaimer"
+                                    src="@Url.Absolute("~/Content/gallery/img/fuget.svg")"
+                                    @ViewHelpers.ImageFallback(Url.Absolute("~/Content/gallery/img/fuget-32x32.png")) />
                             <a href="@Model.FuGetUrl" data-track="outbound-fuget-url"
-                               aria-label="open in fuget.org explorer"
-                               title="Explore additional package info on fuget.org" target="_blank" rel="nofollow noreferrer">
+                                aria-label="open in fuget.org explorer"
+                                title="Explore additional package info on fuget.org" target="_blank" rel="nofollow noreferrer">
                                 Open in FuGet Package Explorer
                             </a>
                         </li>
@@ -1407,7 +1407,7 @@
 
 
             </div>
-
+                
             @if (!Model.Deleted && Model.ShowDetailsAndLinks)
             {
 
@@ -1433,20 +1433,20 @@
                 <p class="share-buttons">
                     <a href="https://www.facebook.com/sharer/sharer.php?u=@absolutePackageUrl&t=@encodedText" target="_blank" rel="nofollow noreferrer">
                         <img width="24" height="24" alt="Share this package on Facebook"
-                             src="@Url.Absolute("~/Content/gallery/img/facebook.svg")"
-                             @ViewHelpers.ImageFallback(Url.Absolute("~/Content/gallery/img/facebook-24x24.png")) />
+                                src="@Url.Absolute("~/Content/gallery/img/facebook.svg")"
+                                @ViewHelpers.ImageFallback(Url.Absolute("~/Content/gallery/img/facebook-24x24.png")) />
                     </a>
                     <a href="https://twitter.com/intent/tweet?url=@absolutePackageUrl&text=@encodedText" target="_blank" rel="nofollow noreferrer">
                         <img width="24" height="24" alt="Tweet this package"
-                             src="@Url.Absolute("~/Content/gallery/img/twitter.svg")"
-                             @ViewHelpers.ImageFallback(Url.Absolute("~/Content/gallery/img/twitter-24x24.png")) />
+                                src="@Url.Absolute("~/Content/gallery/img/twitter.svg")"
+                                @ViewHelpers.ImageFallback(Url.Absolute("~/Content/gallery/img/twitter-24x24.png")) />
                     </a>
                     @if (Model.IsAtomFeedEnabled)
                     {
                         <a href="@Url.PackageAtomFeed(Model.Id)" data-track="atom-feed">
                             <img width="24" height="24" alt="Use the Atom feed to subscribe to new versions of @Model.Id"
-                                 src="@Url.Absolute("~/Content/gallery/img/rss.svg")"
-                                 @ViewHelpers.ImageFallback(Url.Absolute("~/Content/gallery/img/rss-24x24.png")) />
+                                    src="@Url.Absolute("~/Content/gallery/img/rss.svg")"
+                                    @ViewHelpers.ImageFallback(Url.Absolute("~/Content/gallery/img/rss-24x24.png")) />
                         </a>
                     }
                 </p>
@@ -1489,16 +1489,16 @@
                              );
     </script>
 
-    @if (Model.IsMarkdigMdSyntaxHighlightEnabled)
-    {
+    @if (Model.IsMarkdigMdSyntaxHighlightEnabled) 
+    { 
         @ViewHelpers.IncludeSyntaxHighlightScript();
 
         <script>
-            document.addEventListener('DOMContentLoaded', (event) => {
-                document.querySelectorAll('pre code').forEach((el) => {
-                    hljs.highlightElement(el);
-                });
+        document.addEventListener('DOMContentLoaded', (event) => {
+            document.querySelectorAll('pre code').forEach((el) => {
+                hljs.highlightElement(el);
             });
+        });
         </script>
     }
 

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -79,7 +79,7 @@
             {
                 CommandPrefix = "> ",
             }
-        };
+                                };
     }
     else if (Model.IsDotnetNewTemplatePackageType)
     {
@@ -97,7 +97,7 @@
                 AlertLevel = AlertLevel.Info,
                 AlertMessage = "This package contains a <a href='https://aka.ms/dotnet-new'>.NET Template Package</a> you can call from the shell/command line.",
             }
-        };
+                                };
     }
     else if (Model.IsMSBuildSdkPackageType)
     {
@@ -115,7 +115,7 @@
                 AlertMessage = string.Format("For projects that support Sdk, copy this XML node into the project file to reference the package."),
                 CopyLabel = "Copy the SDK XML node",
             }
-        };
+                                };
     }
     else
     {
@@ -219,7 +219,7 @@
                 "https://cakebuild.net/support/nuget",
                 Model.GetCakeInstallPackageCommands()
                 )
-        };
+                                };
     }
 }
 
@@ -276,15 +276,15 @@
             <div class="install-script-row">
                 @* Writing out the install command must be on a single line to avoid undesired whitespace in the <pre> tag. *@
                 <pre class="install-script" id="@installPackageCommand.Key-text"><span class="install-command-row">@installPackageCommand.Value.Command</span>
-                    <div class="copy-button">
+                <div class="copy-button">
                         @if (installPackageCommand.Value.HasHeader) {<span class="package-manager-command-header">
                             @installPackageCommand.Value.Header
                         </span>
                         }<button id="@installPackageCommand.Key-button" class="btn btn-brand-icon" type="button"
-                                data-toggle="popover" data-placement="bottom" data-content="Copied."
-                                aria-label="@packageManager.CopyLabel" role="button">
-                            <span class="ms-Icon ms-Icon--Copy" aria-hidden="true"></span>
-                            <span>Copy</span>
+                                 data-toggle="popover" data-placement="bottom" data-content="Copied."
+                                 aria-label="@packageManager.CopyLabel" role="button">
+                <span class="ms-Icon ms-Icon--Copy" aria-hidden="true"></span>
+                <span>Copy</span>
                         </button>
                     </div>
                 </pre>
@@ -294,15 +294,15 @@
         {
             case AlertLevel.Info:
                 @ViewHelpers.AlertInfo(
-                    @<text>
-                        @Html.Raw(packageManager.AlertMessage)
-                    </text>);
+                                @<text>
+                                    @Html.Raw(packageManager.AlertMessage)
+                                </text>);
                 break;
             case AlertLevel.Warning:
                 @ViewHelpers.AlertWarning(
-                    @<text>
-                        @Html.Raw(packageManager.AlertMessage)
-                    </text>, true);
+                                @<text>
+                                    @Html.Raw(packageManager.AlertMessage)
+                                </text>, true);
                 break;
             default:
                 break;
@@ -321,8 +321,9 @@
 
 @* The following two helpers must be on a single line each so no extra whitespace is introduced in the expression when rendered. *@
 @* Helpers themselves are needed not to introduce that extra whitespce, which happens if they are inlined. *@
-@helper MakeLicenseLink(CompositeLicenseExpressionSegment segment) {<a href="@LicenseExpressionRedirectUrlHelper.GetLicenseExpressionRedirectUrl(segment.Value)" aria-label="License @segment.Value">@segment.Value license</a>}
-@helper MakeLicenseSpan(CompositeLicenseExpressionSegment segment) {<span>@segment.Value license</span>}
+@helper MakeLicenseLink(CompositeLicenseExpressionSegment segment){<a href="@LicenseExpressionRedirectUrlHelper.GetLicenseExpressionRedirectUrl(segment.Value)" aria-label="License @segment.Value">@segment.Value license</a>}
+@helper MakeExceptionLink(CompositeLicenseExpressionSegment segment){<a href="@LicenseExpressionRedirectUrlHelper.GetLicenseExpressionRedirectUrl(segment.Value)" aria-label="License @segment.Value">@segment.Value</a>}
+@helper MakePlainSpan(CompositeLicenseExpressionSegment segment){<span>@segment.Value</span>}
 
 <section role="main" class="container main-container page-package-details">
     <div class="row">
@@ -360,9 +361,9 @@
                 {
                     <div class="content-hidden-notice">
                         @ViewHelpers.AlertDanger(
-                            @<text>
-                                This package's content is hidden as it violates our <a href="https://www.nuget.org/policies/terms" title="Terms of Use">Terms of Use</a>.
-                            </text>)
+                                        @<text>
+                                            This package's content is hidden as it violates our <a href="https://www.nuget.org/policies/terms" title="Terms of Use">Terms of Use</a>.
+                                        </text>)
                     </div>
                 }
 
@@ -374,63 +375,63 @@
                 @if (Model.Validating)
                 {
                     @ViewHelpers.AlertWarning(
-                        @<text>
-                            <strong>This package has not been published yet.</strong> It will appear in search results and
-                            will be available for install/restore after both validation and indexing are complete. Package
-                            validation and indexing may take up to an hour. <a href="https://aka.ms/NuGetPackageValidation">Read more</a>.
-                        </text>
-                    )
+                                    @<text>
+                                        <strong>This package has not been published yet.</strong> It will appear in search results and
+                                        will be available for install/restore after both validation and indexing are complete. Package
+                                        validation and indexing may take up to an hour. <a href="https://aka.ms/NuGetPackageValidation">Read more</a>.
+                                    </text>
+)
                     if (Model.EmbeddedLicenseType != EmbeddedLicenseFileType.Absent)
                     {
                         @ViewHelpers.AlertWarning(
-                            @<text>
-                                The license link will become available once package validation has completed successfully.
-                            </text>
-                        )
+                                        @<text>
+                                            The license link will become available once package validation has completed successfully.
+                                        </text>
+)
                     }
 
                     if (Model.ValidatingTooLong)
                     {
                         @ViewHelpers.AlertWarning(
-                            @<text>
-                                <strong>Package validation is taking longer than expected.</strong> This is not normal, but we are on it!
-                            </text>
-                        )
+                                        @<text>
+                                            <strong>Package validation is taking longer than expected.</strong> This is not normal, but we are on it!
+                                        </text>
+)
                     }
                 }
 
                 @if (Model.FailedValidation)
                 {
                     @ViewHelpers.AlertDanger(
-                        @<text>
-                            <strong>Package publishing failed.</strong> This package could not be published due to the following reason(s):
-                            <ul class="failed-validation-alert-list">
-                                @foreach (var issue in Model.PackageValidationIssues)
-                                {
-                                    <li>@Html.Partial("_ValidationIssue", issue)</li>
-                                }
-                            </ul>
-                            @if (!Model.PackageValidationIssues.Any(i => i.IssueCode == ValidationIssueCode.Unknown))
-                            {
-                                var issuePluralString = Model.PackageValidationIssues.Count > 1 ? "all the issues" : "the issue";
-                                <text>Once you've fixed @issuePluralString with your package, you can reupload it with the same ID and version.</text>
-                            }
-                            else
-                            {
-                                <text>Please contact <a href="mailto:support@nuget.org">support@nuget.org</a> to help fix your package.</text>
-                            }
-                        </text>
-                    )
+                                    @<text>
+                                        <strong>Package publishing failed.</strong> This package could not be published due to the following reason(s):
+                                        <ul class="failed-validation-alert-list">
+                                            @foreach (var issue in Model.PackageValidationIssues)
+                                            {
+                                                <li>@Html.Partial("_ValidationIssue", issue)</li>
+                                            }
+                                        </ul>
+                                        @if (!Model.PackageValidationIssues.Any(i => i.IssueCode == ValidationIssueCode.Unknown))
+                                        {
+                                            var issuePluralString = Model.PackageValidationIssues.Count > 1 ? "all the issues" : "the issue";
+                                            <text>Once you've fixed @issuePluralString with your package, you can reupload it with the same ID and version.</text>
+                                        }
+                                        else
+                                        {
+                                            <text>Please contact <a href="mailto:support@nuget.org">support@nuget.org</a> to help fix your package.</text>
+                                        }
+                                    </text>
+)
                 }
 
                 @if (Model.Deleted)
                 {
                     @ViewHelpers.AlertDanger(
-                        @<text>
-                            <strong>This package has been deleted from the gallery.</strong> It is no longer available
-                            for install/restore.
-                        </text>
-                    )
+                                    @<text>
+                                        <strong>This package has been deleted from the gallery.</strong> It is no longer available
+                                        for install/restore.
+                                    </text>
+)
                 }
 
                 @if (Model.IsPackageVulnerabilitiesEnabled && Model.Vulnerabilities != null)
@@ -453,67 +454,67 @@
                     if (Model.Prerelease)
                     {
                         @ViewHelpers.AlertInfo(
-                            @<text>
-                                This is a prerelease version of @(Model.Id).
-                            </text>
-                        )
+                                        @<text>
+                                            This is a prerelease version of @(Model.Id).
+                                        </text>
+)
                     }
-                    
+
                     if (Model.NuGetVersion.HasMetadata)
                     {
                         @ViewHelpers.AlertInfo(
-                            @<text>
-                                This package has a SemVer 2.0.0 package version: @(Model.FullVersion).
-                            </text>
-                        )
+                                        @<text>
+                                            This package has a SemVer 2.0.0 package version: @(Model.FullVersion).
+                                        </text>
+)
                     }
-                    
+
                     if (Model.VersionRequestedWasNotFound)
                     {
                         @ViewHelpers.AlertWarning(
-                            @<text>
-                                The specified version @Model.VersionRequested was not found. You have been taken to version @(Model.Version).
-                            </text>
-                        )
+                                        @<text>
+                                            The specified version @Model.VersionRequested was not found. You have been taken to version @(Model.Version).
+                                        </text>
+)
                     }
-                    
+
                     if (Model.HasNewerRelease)
                     {
                         @ViewHelpers.AlertInfo(
-                            @<text>
-                                There is a newer version of this package available.
-                                <br /> See the version list below for details.
-                            </text>
-                        )
+                                        @<text>
+                                            There is a newer version of this package available.
+                                            <br /> See the version list below for details.
+                                        </text>
+)
                     }
                     else if (Model.HasNewerPrerelease)
                     {
                         @ViewHelpers.AlertInfo(
-                            @<text>
-                                There is a newer prerelease version of this package available.
-                                <br /> See the version list below for details.
-                            </text>
-                        )
+                                        @<text>
+                                            There is a newer prerelease version of this package available.
+                                            <br /> See the version list below for details.
+                                        </text>
+)
                     }
 
                     if (Model.Listed && Model.IsIndexed.HasValue && !Model.IsIndexed.Value && Model.Available)
                     {
                         @ViewHelpers.AlertWarning(
-                            @<text>
-                                <strong>This package has not been indexed yet.</strong> It will appear in search results
-                                and will be available for install/restore after indexing is complete.
-                            </text>
-                        )
+                                        @<text>
+                                            <strong>This package has not been indexed yet.</strong> It will appear in search results
+                                            and will be available for install/restore after indexing is complete.
+                                        </text>
+)
                     }
                 }
 
                 @if (Model.HasEmbeddedIcon && Model.ShowDetailsAndLinks && Model.IsIndexed.HasValue && !Model.IsIndexed.Value && (Model.Available || Model.Validating))
                 {
                     @ViewHelpers.AlertWarning(
-                        @<text>
-                            The package icon will become available after this package is indexed.
-                        </text>
-                    )
+                                    @<text>
+                                        The package icon will become available after this package is indexed.
+                                    </text>
+)
                 }
 
                 @if (Model.CanDisplayPrivateMetadata && showSymbolsPackageStatus)
@@ -521,39 +522,39 @@
                     if (Model.LatestSymbolsPackage.StatusKey == PackageStatus.Validating)
                     {
                         @ViewHelpers.AlertWarning(
-                            @<text>
-                                <strong>The symbols for this package have not been indexed yet.</strong> They are not available
-                                for download from the NuGet.org symbol server. Symbols will be available for download after both validation and indexing are complete.
-                                Symbols validation and indexing may take up to an hour. <a href="https://aka.ms/NuGetSymbolsPackageValidation">Read more</a>.
+                                        @<text>
+                                            <strong>The symbols for this package have not been indexed yet.</strong> They are not available
+                                            for download from the NuGet.org symbol server. Symbols will be available for download after both validation and indexing are complete.
+                                            Symbols validation and indexing may take up to an hour. <a href="https://aka.ms/NuGetSymbolsPackageValidation">Read more</a>.
 
-                                @AppendAvailableSymbolsMessage(hasSymbolsPackageAvailable)
-                            </text>
-                        )
+                                            @AppendAvailableSymbolsMessage(hasSymbolsPackageAvailable)
+                                        </text>
+)
                     }
                     else if (Model.LatestSymbolsPackage.StatusKey == PackageStatus.FailedValidation)
                     {
                         @ViewHelpers.AlertDanger(
-                            @<text>
-                                <strong>Symbols package publishing failed.</strong> The associated symbols package could not be published due to the following reason(s):
-                                <ul class="failed-validation-alert-list">
-                                    @foreach (var issue in Model.SymbolsPackageValidationIssues)
-                                    {
-                                        <li>@Html.Partial("_ValidationIssue", issue)</li>
-                                    }
-                                </ul>
-                                @if (!Model.SymbolsPackageValidationIssues.Any(i => i.IssueCode == ValidationIssueCode.Unknown))
-                                {
-                                    var issuePluralString = Model.SymbolsPackageValidationIssues.Count() > 1 ? "all the issues" : "the issue";
-                                    <text>Once you've fixed @issuePluralString with your symbols package, you can re-upload it.</text>
-                                }
-                                else
-                                {
-                                    <text>Please contact <a href="mailto:support@nuget.org">support@nuget.org</a> to help fix your symbols package.</text>
-                                }
+                                        @<text>
+                                            <strong>Symbols package publishing failed.</strong> The associated symbols package could not be published due to the following reason(s):
+                                            <ul class="failed-validation-alert-list">
+                                                @foreach (var issue in Model.SymbolsPackageValidationIssues)
+                                                {
+                                                    <li>@Html.Partial("_ValidationIssue", issue)</li>
+                                                }
+                                            </ul>
+                                            @if (!Model.SymbolsPackageValidationIssues.Any(i => i.IssueCode == ValidationIssueCode.Unknown))
+                                            {
+                                                var issuePluralString = Model.SymbolsPackageValidationIssues.Count() > 1 ? "all the issues" : "the issue";
+                                                <text>Once you've fixed @issuePluralString with your symbols package, you can re-upload it.</text>
+                                            }
+                                            else
+                                            {
+                                                <text>Please contact <a href="mailto:support@nuget.org">support@nuget.org</a> to help fix your symbols package.</text>
+                                            }
 
-                                @AppendAvailableSymbolsMessage(hasSymbolsPackageAvailable)
-                            </text>
-                        )
+                                            @AppendAvailableSymbolsMessage(hasSymbolsPackageAvailable)
+                                        </text>
+)
                     }
                 }
 
@@ -562,21 +563,21 @@
                     if (Model.CanDisplayPrivateMetadata)
                     {
                         @ViewHelpers.AlertWarning(
-                            @<text>
-                                This package is unlisted and hidden from package listings.
-                                You can see the package because you are one of its owners. To list the package again,
-                                <a href="@Url.ManagePackage(Model)">change its listing setting</a>.
-                            </text>
-                        )
+                                        @<text>
+                                            This package is unlisted and hidden from package listings.
+                                            You can see the package because you are one of its owners. To list the package again,
+                                            <a href="@Url.ManagePackage(Model)">change its listing setting</a>.
+                                        </text>
+)
                     }
                     else
                     {
                         @ViewHelpers.AlertWarning(
-                            @<text>
-                                The owner has unlisted this package.
-                                This could mean that the package is deprecated, has security vulnerabilities or shouldn't be used anymore.
-                            </text>
-                        )
+                                        @<text>
+                                            The owner has unlisted this package.
+                                            This could mean that the package is deprecated, has security vulnerabilities or shouldn't be used anymore.
+                                        </text>
+)
                     }
                 }
 
@@ -629,7 +630,7 @@
                                 @if (Model.CanDisplayReadmeWarning && Model.CanDisplayPrivateMetadata)
                                 {
                                     <i class="ms-Icon ms-Icon--Warning" aria-hidden="true"></i>
-                                } 
+                                }
                                 else
                                 {
                                     <i class="ms-Icon ms-Icon--Dictionary" aria-hidden="true"></i>
@@ -638,24 +639,24 @@
                             </a>
                         </li>
 
-                     if (Model.CanDisplayTargetFrameworks())
-                     {
-                        activeBodyTab = activeBodyTab ?? "supportedframeworks";
-                        <li role="presentation" id="show-supportedframeworks-container">
-                            <a href="#supportedframeworks-body-tab"
-                                role="tab"
-                                data-toggle="tab"
-                                data-target="#supportedframeworks-tab"
-                                id="supportedframeworks-body-tab"
-                                class="body-tab"
-                                aria-controls="supportedframeworks-tab"
-                                aria-selected="@(activeBodyTab == "supportedframeworks" ? "true" : "false")"
-                                tabindex="@(activeBodyTab == "supportedframeworks" ? "0" : "-1")">
-                                <i class="ms-Icon ms-Icon--Package" aria-hidden="true"></i>
-                                Frameworks
-                            </a>
-                        </li>
-                     }
+                        if (Model.CanDisplayTargetFrameworks())
+                        {
+                            activeBodyTab = activeBodyTab ?? "supportedframeworks";
+                            <li role="presentation" id="show-supportedframeworks-container">
+                                <a href="#supportedframeworks-body-tab"
+                                   role="tab"
+                                   data-toggle="tab"
+                                   data-target="#supportedframeworks-tab"
+                                   id="supportedframeworks-body-tab"
+                                   class="body-tab"
+                                   aria-controls="supportedframeworks-tab"
+                                   aria-selected="@(activeBodyTab == "supportedframeworks" ? "true" : "false")"
+                                   tabindex="@(activeBodyTab == "supportedframeworks" ? "0" : "-1")">
+                                    <i class="ms-Icon ms-Icon--Package" aria-hidden="true"></i>
+                                    Frameworks
+                                </a>
+                            </li>
+                        }
 
                         activeBodyTab = activeBodyTab ?? "dependencies";
                         <li role="presentation">
@@ -737,9 +738,9 @@
                         @if ((Model.Validating || Model.FailedValidation) && Model.HasEmbeddedReadmeFile)
                         {
                             @ViewHelpers.AlertWarning(
-                                @<text>
-                                    The readme will become available once package validation has completed successfully.
-                                </text>)
+                                            @<text>
+                                                The readme will become available once package validation has completed successfully.
+                                            </text>)
                         }
                         else if (Model.ReadMeHtml != null)
                         {
@@ -776,17 +777,17 @@
 
                     if (Model.CanDisplayTargetFrameworks())
                     {
-                    <div role="tabpanel" class="tab-pane @(activeBodyTab == "supportedframeworks" ? "active" : "")" id="supportedframeworks-tab" aria-label="Supported frameworks tab content">
-                        @if (Model.PackageFrameworkCompatibility.Table.Count > 0)
-                        {
-                            @Html.Partial("_SupportedFrameworksTable", Model.PackageFrameworkCompatibility.Table)
-                        }
-                        else
-                        {
+                        <div role="tabpanel" class="tab-pane @(activeBodyTab == "supportedframeworks" ? "active" : "")" id="supportedframeworks-tab" aria-label="Supported frameworks tab content">
+                            @if (Model.PackageFrameworkCompatibility.Table.Count > 0)
+                            {
+                                @Html.Partial("_SupportedFrameworksTable", Model.PackageFrameworkCompatibility.Table)
+                            }
+                            else
+                            {
                             <span tabindex="0">There are no supported framework assets in this package.</span><br/>
-                            <p class="frameworktableinfo-text"><i>Learn more about <a href='https://docs.microsoft.com/dotnet/standard/frameworks' aria-label="Learn more about Target Frameworks">Target Frameworks</a> and <a href='https://docs.microsoft.com/dotnet/standard/net-standard' aria-label="Learn more about .NET Standard">.NET Standard</a>.</i></p>
-                        }
-                    </div>
+                                <p class="frameworktableinfo-text"><i>Learn more about <a href='https://docs.microsoft.com/dotnet/standard/frameworks' aria-label="Learn more about Target Frameworks">Target Frameworks</a> and <a href='https://docs.microsoft.com/dotnet/standard/net-standard' aria-label="Learn more about .NET Standard">.NET Standard</a>.</i></p>
+                            }
+                        </div>
                     }
 
                     <div role="tabpanel" class="tab-pane @(activeBodyTab == "dependencies" ? "active" : "")" id="dependencies-tab" aria-label="Dependencies tab content">
@@ -1163,22 +1164,29 @@
                                 {
                                     foreach (var segment in Model.LicenseExpressionSegments)
                                     {
-                                        if (@ViewHelpers.IsLicenseOrException(segment))
+                                        if (@ViewHelpers.IsLicense(segment))
                                         {
                                             @MakeLicenseLink(segment);
                                         }
                                         else
                                         {
-                                            @MakeLicenseSpan(segment);
+                                            if (ViewHelpers.IsException(segment))
+                                            {
+                                                @MakeExceptionLink(segment);
+                                            }
+                                            else
+                                            {
+                                                @MakePlainSpan(segment);
+                                            }
                                         }
                                     }
                                 }
                                 else
                                 {
-                                    <a href="@Model.LicenseUrl"
-                                        data-track="outbound-license-url" title="Make sure you agree with the license" rel="nofollow">
-                                        License Info
-                                    </a>
+                                <a href="@Model.LicenseUrl"
+                                   data-track="outbound-license-url" title="Make sure you agree with the license" rel="nofollow">
+                                    License Info
+                                </a>
                                 }
                             </li>
                         }
@@ -1208,8 +1216,8 @@
                         <li>
                             <i class="ms-Icon ms-Icon--FabricFolderSearch" aria-hidden="true" aria-label="@disclaimer" title="@disclaimer"></i>
                             <a href="@Model.NuGetPackageExplorerUrl" data-track="outbound-nugetpackageexplorer-url"
-                                aria-label="open in NuGet Package Explorer"
-                                title="Explore additional package info on NuGet Package Explorer" target="_blank" rel="nofollow noreferrer">
+                               aria-label="open in NuGet Package Explorer"
+                               title="Explore additional package info on NuGet Package Explorer" target="_blank" rel="nofollow noreferrer">
                                 Open in NuGet Package Explorer
                             </a>
                         </li>
@@ -1221,12 +1229,12 @@
 
                         <li>
                             <img class="icon"
-                                    aria-label="@disclaimer" title="@disclaimer"
-                                    src="@Url.Absolute("~/Content/gallery/img/fuget.svg")"
-                                    @ViewHelpers.ImageFallback(Url.Absolute("~/Content/gallery/img/fuget-32x32.png")) />
+                                 aria-label="@disclaimer" title="@disclaimer"
+                                 src="@Url.Absolute("~/Content/gallery/img/fuget.svg")"
+                                 @ViewHelpers.ImageFallback(Url.Absolute("~/Content/gallery/img/fuget-32x32.png")) />
                             <a href="@Model.FuGetUrl" data-track="outbound-fuget-url"
-                                aria-label="open in fuget.org explorer"
-                                title="Explore additional package info on fuget.org" target="_blank" rel="nofollow noreferrer">
+                               aria-label="open in fuget.org explorer"
+                               title="Explore additional package info on fuget.org" target="_blank" rel="nofollow noreferrer">
                                 Open in FuGet Package Explorer
                             </a>
                         </li>
@@ -1399,7 +1407,7 @@
 
 
             </div>
-                
+
             @if (!Model.Deleted && Model.ShowDetailsAndLinks)
             {
 
@@ -1425,20 +1433,20 @@
                 <p class="share-buttons">
                     <a href="https://www.facebook.com/sharer/sharer.php?u=@absolutePackageUrl&t=@encodedText" target="_blank" rel="nofollow noreferrer">
                         <img width="24" height="24" alt="Share this package on Facebook"
-                                src="@Url.Absolute("~/Content/gallery/img/facebook.svg")"
-                                @ViewHelpers.ImageFallback(Url.Absolute("~/Content/gallery/img/facebook-24x24.png")) />
+                             src="@Url.Absolute("~/Content/gallery/img/facebook.svg")"
+                             @ViewHelpers.ImageFallback(Url.Absolute("~/Content/gallery/img/facebook-24x24.png")) />
                     </a>
                     <a href="https://twitter.com/intent/tweet?url=@absolutePackageUrl&text=@encodedText" target="_blank" rel="nofollow noreferrer">
                         <img width="24" height="24" alt="Tweet this package"
-                                src="@Url.Absolute("~/Content/gallery/img/twitter.svg")"
-                                @ViewHelpers.ImageFallback(Url.Absolute("~/Content/gallery/img/twitter-24x24.png")) />
+                             src="@Url.Absolute("~/Content/gallery/img/twitter.svg")"
+                             @ViewHelpers.ImageFallback(Url.Absolute("~/Content/gallery/img/twitter-24x24.png")) />
                     </a>
                     @if (Model.IsAtomFeedEnabled)
                     {
                         <a href="@Url.PackageAtomFeed(Model.Id)" data-track="atom-feed">
                             <img width="24" height="24" alt="Use the Atom feed to subscribe to new versions of @Model.Id"
-                                    src="@Url.Absolute("~/Content/gallery/img/rss.svg")"
-                                    @ViewHelpers.ImageFallback(Url.Absolute("~/Content/gallery/img/rss-24x24.png")) />
+                                 src="@Url.Absolute("~/Content/gallery/img/rss.svg")"
+                                 @ViewHelpers.ImageFallback(Url.Absolute("~/Content/gallery/img/rss-24x24.png")) />
                         </a>
                     }
                 </p>
@@ -1481,16 +1489,16 @@
                              );
     </script>
 
-    @if (Model.IsMarkdigMdSyntaxHighlightEnabled) 
-    { 
+    @if (Model.IsMarkdigMdSyntaxHighlightEnabled)
+    {
         @ViewHelpers.IncludeSyntaxHighlightScript();
 
         <script>
-        document.addEventListener('DOMContentLoaded', (event) => {
-            document.querySelectorAll('pre code').forEach((el) => {
-                hljs.highlightElement(el);
+            document.addEventListener('DOMContentLoaded', (event) => {
+                document.querySelectorAll('pre code').forEach((el) => {
+                    hljs.highlightElement(el);
+                });
             });
-        });
         </script>
     }
 


### PR DESCRIPTION
- Added `IsLicense` and `IsException` methods to improve license checking.
- Introduced `MakeExceptionLink` and `MakePlainSpan` helpers .
- Updated rendering logic for license links using new methods.


Addresses https://github.com/NuGet/NuGetGallery/issues/10341

Before:
![image](https://github.com/user-attachments/assets/cd440489-abe1-418a-946e-c32539b265a5)

After:
![image](https://github.com/user-attachments/assets/7ea4cf01-e16e-47b1-9fbf-37e538ef96d4)
