### PR TITLE
Fix guardian false positive

### DIFF
--- a/CredScanSuppressions.json
+++ b/CredScanSuppressions.json
@@ -16,6 +16,10 @@
         {
             "file": "tests/NuGet.Services.KeyVault.Tests/KeyVaultReaderFormatterFacts.cs",
             "_justification": "Test file containing fake credentials"
+        },
+        {
+            "file": "src/NuGetGallery.Services/Authentication/ApiKeyV5.cs",
+            "_justification": "File containing fake credentials"
         }
     ]
 }

--- a/src/NuGetGallery.Services/Authentication/ApiKeyV5.cs
+++ b/src/NuGetGallery.Services/Authentication/ApiKeyV5.cs
@@ -51,7 +51,7 @@ namespace NuGetGallery.Infrastructure.Authentication
     /// The value stored in the database is base64 encoded SHA-512 hash of the plaintext API key. The corresponding
     /// database value for the example plaintext API key above is:
     ///
-    /// guardian-disable-next-line
+    ///   cspell:disable-next-line
     ///   BWqhR33SkX0/BxG34nEZtByLp5uRz/H3lD89EDnFylq+peJ1EtGolGiUqOa44+5t0vlHd1joByP3rojeTF5scQ==
     ///
     /// The user ID is included in the API key so that a rate-limiting (i.e. throttling) layer can use the value as a

--- a/src/NuGetGallery.Services/Authentication/ApiKeyV5.cs
+++ b/src/NuGetGallery.Services/Authentication/ApiKeyV5.cs
@@ -51,7 +51,6 @@ namespace NuGetGallery.Infrastructure.Authentication
     /// The value stored in the database is base64 encoded SHA-512 hash of the plaintext API key. The corresponding
     /// database value for the example plaintext API key above is:
     ///
-    ///   cspell:disable-next-line
     ///   BWqhR33SkX0/BxG34nEZtByLp5uRz/H3lD89EDnFylq+peJ1EtGolGiUqOa44+5t0vlHd1joByP3rojeTF5scQ==
     ///
     /// The user ID is included in the API key so that a rate-limiting (i.e. throttling) layer can use the value as a

--- a/src/NuGetGallery.Services/Authentication/ApiKeyV5.cs
+++ b/src/NuGetGallery.Services/Authentication/ApiKeyV5.cs
@@ -51,6 +51,7 @@ namespace NuGetGallery.Infrastructure.Authentication
     /// The value stored in the database is base64 encoded SHA-512 hash of the plaintext API key. The corresponding
     /// database value for the example plaintext API key above is:
     ///
+    /// guardian-disable-next-line
     ///   BWqhR33SkX0/BxG34nEZtByLp5uRz/H3lD89EDnFylq+peJ1EtGolGiUqOa44+5t0vlHd1joByP3rojeTF5scQ==
     ///
     /// The user ID is included in the API key so that a rate-limiting (i.e. throttling) layer can use the value as a


### PR DESCRIPTION
We kept getting build errors that flag [this file](https://github.com/NuGet/NuGetGallery/blob/4b37d4d6bba949d81768f914bf99ea14e31168db/src/NuGetGallery.Services/Authentication/ApiKeyV5.cs#L54) for containing a secret. This is how the errors looked like:

![image](https://github.com/user-attachments/assets/cf21c060-163e-4e42-91dd-e347a9d01150)

The secret is false positive, and this code change tells credential scanner to suppress it.

NOTE: This PR is made against main branch and not dev, because the change is really small and requires fast action, since it's blocking wave 1 work.