### PR TITLE
Update PackagesDisplayed from 5 to 20 to match GH repos

### DIFF
--- a/src/NuGetGallery.Services/PackageManagement/PackageService.cs
+++ b/src/NuGetGallery.Services/PackageManagement/PackageService.cs
@@ -30,7 +30,7 @@ namespace NuGetGallery
         private readonly IEntitiesContext _entitiesContext;
         private readonly IContentObjectService _contentObjectService;
         private readonly IFeatureFlagService _featureFlagService;
-        private const int packagesDisplayed = 5;
+        private const int packagesDisplayed = 20;
 
         public PackageService(
             IEntityRepository<PackageRegistration> packageRegistrationRepository,


### PR DESCRIPTION
https://github.com/NuGet/NuGetGallery/pull/10357 updated the GH repos displayed from 5 to 20. This makes the nuget package dependencies match as well (I think).