### PR TITLE
[HotFix] Temporary limit to ascii only

### DIFF
--- a/src/AccountDeleter/EmptyFeatureFlagService.cs
+++ b/src/AccountDeleter/EmptyFeatureFlagService.cs
@@ -328,5 +328,10 @@ namespace NuGetGallery.AccountDeleter
         {
             throw new NotImplementedException();
         }
+
+        public bool IsAsciiOnlyPackageIdEnabled()
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/src/GitHubVulnerabilities2Db/Fakes/FakeFeatureFlagService.cs
+++ b/src/GitHubVulnerabilities2Db/Fakes/FakeFeatureFlagService.cs
@@ -329,5 +329,10 @@ namespace GitHubVulnerabilities2Db.Fakes
         {
             throw new NotImplementedException();
         }
+
+        public bool IsAsciiOnlyPackageIdEnabled()
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/src/NuGetGallery.Core/Packaging/PackageIdValidator.cs
+++ b/src/NuGetGallery.Core/Packaging/PackageIdValidator.cs
@@ -14,6 +14,10 @@ namespace NuGetGallery.Packaging
             @"^\w+([.-]\w+)*$",
             RegexOptions.IgnoreCase | RegexOptions.ExplicitCapture);
 
+        private static readonly Regex AllAsciiRegex = RegexEx.CreateWithTimeout(
+            @"^[A-Za-z0-9\-_\.]+$",
+            RegexOptions.IgnoreCase | RegexOptions.ExplicitCapture);
+
         public static bool IsValidPackageId(string packageId)
         {
             if (packageId == null)
@@ -27,6 +31,21 @@ namespace NuGetGallery.Packaging
             }
 
             return IdRegex.IsMatch(packageId);
+        }
+
+        public static bool IsAsciiOnlyPackageId(string packageId)
+        {
+            if (packageId == null)
+            {
+                throw new ArgumentNullException(nameof(packageId));
+            }
+
+            if (String.Equals(packageId, "$id$", StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+
+            return AllAsciiRegex.IsMatch(packageId);
         }
 
         public static void ValidatePackageId(string packageId)
@@ -45,7 +64,7 @@ namespace NuGetGallery.Packaging
             {
                 throw new ArgumentException(string.Format(
                     CultureInfo.CurrentCulture,
-                    "The package ID '{0}' contains invalid characters. Examples of valid package IDs include 'MyPackage' and 'MyPackage.Sample'.",
+                    "The package ID '{0}' contains invalid characters. Package ID can only contain alphanumeric characters, hyphens, underscores, and periods.",
                     packageId));
             }
         }

--- a/src/NuGetGallery.Core/Packaging/PackageIdValidator.cs
+++ b/src/NuGetGallery.Core/Packaging/PackageIdValidator.cs
@@ -25,7 +25,7 @@ namespace NuGetGallery.Packaging
                 throw new ArgumentNullException(nameof(packageId));
             }
 
-            if (String.Equals(packageId, "$id$", StringComparison.OrdinalIgnoreCase))
+            if (string.Equals(packageId, "$id$", StringComparison.OrdinalIgnoreCase))
             {
                 return false;
             }
@@ -40,7 +40,7 @@ namespace NuGetGallery.Packaging
                 throw new ArgumentNullException(nameof(packageId));
             }
 
-            if (String.Equals(packageId, "$id$", StringComparison.OrdinalIgnoreCase))
+            if (string.Equals(packageId, "$id$", StringComparison.OrdinalIgnoreCase))
             {
                 return false;
             }

--- a/src/NuGetGallery.Services/Configuration/FeatureFlagService.cs
+++ b/src/NuGetGallery.Services/Configuration/FeatureFlagService.cs
@@ -64,6 +64,7 @@ namespace NuGetGallery
         private const string DisplayTfmBadgesFeatureName = GalleryPrefix + "DisplayTfmBadges";
         private const string AdvancedFrameworkFilteringFeatureName = GalleryPrefix + "AdvancedFrameworkFiltering";
         private const string FederatedCredentialsFeatureName = GalleryPrefix + "FederatedCredentials";
+        private const string AsciiOnlyPackageIdFeatureName = GalleryPrefix + "AsciiOnlyPackageId";
 
         private const string ODataV1GetAllNonHijackedFeatureName = GalleryPrefix + "ODataV1GetAllNonHijacked";
         private const string ODataV1GetAllCountNonHijackedFeatureName = GalleryPrefix + "ODataV1GetAllCountNonHijacked";
@@ -426,6 +427,11 @@ namespace NuGetGallery
         public bool CanUseFederatedCredentials(User user)
         {
             return _client.IsEnabled(FederatedCredentialsFeatureName, user, defaultValue: false);
+        }
+
+        public bool IsAsciiOnlyPackageIdEnabled()
+        {
+            return _client.IsEnabled(AsciiOnlyPackageIdFeatureName, defaultValue: false);
         }
     }
 }

--- a/src/NuGetGallery.Services/Configuration/IFeatureFlagService.cs
+++ b/src/NuGetGallery.Services/Configuration/IFeatureFlagService.cs
@@ -347,5 +347,10 @@ namespace NuGetGallery
         /// Whether or not the user specified in a package owner scope can use federated credentials.
         /// </summary>
         bool CanUseFederatedCredentials(User user);
+
+        /// <summary>
+        /// Whether or not only ASCII characters are allowed in PackageId, used for temporary block unicode.
+        /// </summary>
+        bool IsAsciiOnlyPackageIdEnabled();
     }
 }

--- a/src/NuGetGallery/Controllers/ApiController.cs
+++ b/src/NuGetGallery/Controllers/ApiController.cs
@@ -237,10 +237,13 @@ namespace NuGetGallery
                 return new HttpStatusCodeWithBodyResult(HttpStatusCode.BadRequest, "The format of the package id is invalid");
             }
 
-            // Temporary blocking for unicode package IDs
-            if (!PackageIdValidator.IsAsciiOnlyPackageId(id ?? string.Empty))
+            if (FeatureFlagService.IsAsciiOnlyPackageIdEnabled())
             {
-                return new HttpStatusCodeWithBodyResult(HttpStatusCode.BadRequest, "The unicode characters in package Id is temporary blocked, please check our announcement board for update.");
+                // Temporary blocking for unicode package IDs
+                if (!PackageIdValidator.IsAsciiOnlyPackageId(id ?? string.Empty))
+                {
+                    return new HttpStatusCodeWithBodyResult(HttpStatusCode.BadRequest, "The unicode characters in package Id is temporary blocked, please check our announcement board for update.");
+                }
             }
 
             Package package = null;

--- a/src/NuGetGallery/Controllers/ApiController.cs
+++ b/src/NuGetGallery/Controllers/ApiController.cs
@@ -237,6 +237,12 @@ namespace NuGetGallery
                 return new HttpStatusCodeWithBodyResult(HttpStatusCode.BadRequest, "The format of the package id is invalid");
             }
 
+            // Temporary blocking for unicode package IDs
+            if (!PackageIdValidator.IsAsciiOnlyPackageId(id ?? string.Empty))
+            {
+                return new HttpStatusCodeWithBodyResult(HttpStatusCode.BadRequest, "The unicode characters in package Id is temporary blocked, please check our announcement board for update.");
+            }
+
             Package package = null;
             try
             {

--- a/src/NuGetGallery/Controllers/ApiController.cs
+++ b/src/NuGetGallery/Controllers/ApiController.cs
@@ -237,15 +237,6 @@ namespace NuGetGallery
                 return new HttpStatusCodeWithBodyResult(HttpStatusCode.BadRequest, "The format of the package id is invalid");
             }
 
-            if (FeatureFlagService.IsAsciiOnlyPackageIdEnabled())
-            {
-                // Temporary blocking for unicode package IDs
-                if (!PackageIdValidator.IsAsciiOnlyPackageId(id ?? string.Empty))
-                {
-                    return new HttpStatusCodeWithBodyResult(HttpStatusCode.BadRequest, "The unicode characters in package Id is temporary blocked, please check our announcement board for update.");
-                }
-            }
-
             Package package = null;
             try
             {
@@ -626,7 +617,7 @@ namespace NuGetGallery
 
                             NuspecReader nuspec;
                             PackageMetadata packageMetadata;
-                            var errors = ManifestValidator.Validate(packageToPush.GetNuspec(), out nuspec, out packageMetadata).ToArray();
+                            var errors = ManifestValidator.Validate(packageToPush.GetNuspec(), FeatureFlagService.IsAsciiOnlyPackageIdEnabled(), out nuspec, out packageMetadata).ToArray();
                             if (errors.Length > 0)
                             {
                                 var errorsString = string.Join("', '", errors.Select(error => error.ErrorMessage));

--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -420,7 +420,7 @@ namespace NuGetGallery
                     PackageArchiveReader packageArchiveReader = CreatePackage(uploadStream);
                     NuspecReader nuspec;
                     PackageMetadata packageMetadata;
-                    var errors = ManifestValidator.Validate(packageArchiveReader.GetNuspec(), out nuspec, out packageMetadata).ToArray();
+                    var errors = ManifestValidator.Validate(packageArchiveReader.GetNuspec(), _featureFlagService.IsAsciiOnlyPackageIdEnabled(), out nuspec, out packageMetadata).ToArray();
                     if (errors.Length > 0)
                     {
                         var errorStrings = new List<JsonValidationMessage>();

--- a/src/NuGetGallery/Services/SymbolPackageService.cs
+++ b/src/NuGetGallery/Services/SymbolPackageService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -120,7 +120,7 @@ namespace NuGetGallery
             PackageHelper.ValidateNuGetPackageMetadata(metadata);
 
             // Validate nuspec manifest.
-            var errors = ManifestValidator.Validate(symbolPackage.GetNuspec(), out var nuspec, out var packageMetadata).ToArray();
+            var errors = ManifestValidator.Validate(symbolPackage.GetNuspec(), false, out var nuspec, out var packageMetadata).ToArray();
             if (errors.Length > 0)
             {
                 var errorsString = string.Join("', '", errors.Select(error => error.ErrorMessage));

--- a/src/VerifyMicrosoftPackage/Fakes/FakeFeatureFlagService.cs
+++ b/src/VerifyMicrosoftPackage/Fakes/FakeFeatureFlagService.cs
@@ -137,5 +137,7 @@ namespace NuGet.VerifyMicrosoftPackage.Fakes
         public bool IsAdvancedFrameworkFilteringEnabled(User user) => throw new NotImplementedException();
 
         public bool CanUseFederatedCredentials(User user) => throw new NotImplementedException();
+
+        public bool IsAsciiOnlyPackageIdEnabled() => throw new NotImplementedException();
     }
 }

--- a/tests/NuGetGallery.Core.Facts/Packaging/ManifestValidatorFacts.cs
+++ b/tests/NuGetGallery.Core.Facts/Packaging/ManifestValidatorFacts.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -364,6 +364,22 @@ namespace NuGetGallery.Packaging
                   </metadata>
                 </package>";
 
+        private const string NuSpecNonAsciiId = @"<?xml version=""1.0""?>
+                <package xmlns=""http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd"">
+                    <metadata>
+                    <id>пакет</id>
+                    <version>1.0.1-alpha</version>
+                    <title>Package A</title>
+                    <authors>ownera, ownerb</authors>
+                    <owners>ownera, ownerb</owners>
+                    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+                    <description>package A description.</description>
+                    <language>en-US</language>
+                    <dependencies />
+                    </metadata>
+                </package>";
+
+
         [Fact]
         public void ReturnsErrorIfIdNotPresent()
         {
@@ -561,23 +577,37 @@ namespace NuGetGallery.Packaging
             var nuspecStream = CreateNuspecStream(NuSpecSemVer200);
 
             // Act
-            ManifestValidator.Validate(nuspecStream, out var reader, out var packageMetadata);
+            ManifestValidator.Validate(nuspecStream, false, out var reader, out var packageMetadata);
 
             // Assert
             Assert.NotNull(packageMetadata);
         }
 
+        [Fact]
+        public void BlocksNonAsciiPackageIdsIfEnabled()
+        {
+            // Arrange
+            var nuspecStream = CreateNuspecStream(NuSpecNonAsciiId);
+
+            // Act
+            var errors = ManifestValidator.Validate(nuspecStream, true, out var reader, out var packageMetadata).ToList();
+
+            // Assert
+            Assert.NotEmpty(errors);
+            Assert.Contains(errors, error => error.ErrorMessage.Contains("ASCII"));
+        }
+
         private static string[] GetErrors(Stream nuspecStream)
         {
             return ManifestValidator
-                .Validate(nuspecStream, out var reader, out var metadata)
+                .Validate(nuspecStream, false, out var reader, out var metadata)
                 .Select(r => r.ErrorMessage)
                 .ToArray();
         }
 
         private static Stream CreateNuspecStream(string nuspec)
         {
-            byte[] byteArray = Encoding.ASCII.GetBytes(nuspec);
+            byte[] byteArray = Encoding.UTF8.GetBytes(nuspec);
             return new MemoryStream(byteArray);
         }
     }

--- a/tests/NuGetGallery.Core.Facts/Packaging/PackageIdValidatorTest.cs
+++ b/tests/NuGetGallery.Core.Facts/Packaging/PackageIdValidatorTest.cs
@@ -53,7 +53,7 @@ namespace NuGetGallery.Packaging
             Assert.False(isValid);
         }
 
-        [Theory(Skip = "Temporary skipping all none ascii characters")]
+        [Theory()]
         [InlineData("  Invalid  . Woo   .")]
         [InlineData("(/.__.)/ \\(.__.\\)")]
         public void ValidatePackageIdInvalidIdThrows(string packageId)
@@ -70,7 +70,7 @@ namespace NuGetGallery.Packaging
             }
 
             Assert.NotNull(thrownException);
-            Assert.Equal("The package ID '" + packageId + "' contains invalid characters. Examples of valid package IDs include 'MyPackage' and 'MyPackage.Sample'.", thrownException.Message);
+            Assert.Equal("The package ID '" + packageId + "' contains invalid characters. Package ID can only contain alphanumeric characters, hyphens, underscores, and periods.", thrownException.Message);
         }
 
         [Theory]

--- a/tests/NuGetGallery.Core.Facts/Packaging/PackageIdValidatorTest.cs
+++ b/tests/NuGetGallery.Core.Facts/Packaging/PackageIdValidatorTest.cs
@@ -96,5 +96,60 @@ namespace NuGetGallery.Packaging
             Assert.NotNull(thrownException);
             Assert.Equal("Id must not exceed " + Constants.MaxPackageIdLength + " characters.", thrownException.Message);
         }
+
+        [Fact]
+        public void IsAsciiPackageId_WithNull_ThrowsArgumentNullException()
+        {
+            // Arrange & Act & Assert
+            var exception = Assert.Throws<ArgumentNullException>(() => PackageIdValidator.IsAsciiOnlyPackageId(null));
+            Assert.Equal("packageId", exception.ParamName);
+        }
+
+        [Fact]
+        public void IsAsciiPackageId_WithTemplateId_ReturnsFalse()
+        {
+            // Arrange & Act
+            var result = PackageIdValidator.IsAsciiOnlyPackageId("$id$");
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Theory]
+        [InlineData("package")]
+        [InlineData("package.id")]
+        [InlineData("package-id")]
+        [InlineData("package_id")]
+        [InlineData("package.id-with_various.symbols")]
+        [InlineData("123456789")]
+        public void IsAsciiPackageId_WithAsciiOnlyCharacters_ReturnsTrue(string packageId)
+        {
+            // Arrange & Act
+            var result = PackageIdValidator.IsAsciiOnlyPackageId(packageId);
+
+            // Assert
+            Assert.True(result);
+        }
+
+        [Theory]
+        [InlineData("packageá")]
+        [InlineData("包")]
+        [InlineData("пакет")]
+        [InlineData("패키지")]
+        [InlineData("الحزمة")]
+        [InlineData("package™")]
+        [InlineData("package©")]
+        [InlineData("package£")]
+        [InlineData("elsökning")]
+        [InlineData("件")]
+        [InlineData("valoniα")]
+        public void IsAsciiPackageId_WithUnicodeCharacters_ReturnsFalse(string packageId)
+        {
+            // Arrange & Act
+            var result = PackageIdValidator.IsAsciiOnlyPackageId(packageId);
+
+            // Assert
+            Assert.False(result);
+        }
     }
 }

--- a/tests/NuGetGallery.Core.Facts/Packaging/PackageIdValidatorTest.cs
+++ b/tests/NuGetGallery.Core.Facts/Packaging/PackageIdValidatorTest.cs
@@ -53,7 +53,7 @@ namespace NuGetGallery.Packaging
             Assert.False(isValid);
         }
 
-        [Theory]
+        [Theory(Skip = "Temporary skipping all none ascii characters")]
         [InlineData("  Invalid  . Woo   .")]
         [InlineData("(/.__.)/ \\(.__.\\)")]
         public void ValidatePackageIdInvalidIdThrows(string packageId)


### PR DESCRIPTION
Related issue: https://github.com/NuGet/Engineering/issues/5850
Temporarily limit IDs to ASCII characters only until a fix is implemented.