### PR TITLE
Reduce number of database roundtrips from 5 to 1 (warm) for PackageDetails page

### DIFF
--- a/src/NuGetGallery.Core/Services/CorePackageService.cs
+++ b/src/NuGetGallery.Core/Services/CorePackageService.cs
@@ -332,7 +332,9 @@ namespace NuGetGallery
                 includeSymbolPackages: true,
                 includeDeprecations: includeDeprecations,
                 includeDeprecationRelationships: includeDeprecationRelationships,
-                includeSupportedFrameworks: false);
+                includeSupportedFrameworks: false,
+                includePackageDependencies: false,
+                includePackageTypes: false);
         }
 
         protected IQueryable<Package> GetPackagesByIdQueryable(
@@ -343,7 +345,9 @@ namespace NuGetGallery
             bool includeSymbolPackages,
             bool includeDeprecations,
             bool includeDeprecationRelationships,
-            bool includeSupportedFrameworks)
+            bool includeSupportedFrameworks,
+            bool includePackageDependencies,
+            bool includePackageTypes)
         {
             var packages = _packageRepository
                 .GetAll()
@@ -383,6 +387,16 @@ namespace NuGetGallery
             if (includeSupportedFrameworks)
             {
                 packages = packages.Include(p => p.SupportedFrameworks);
+            }
+
+            if (includePackageTypes)
+            {
+                packages = packages.Include(p => p.PackageTypes);
+            }
+
+            if (includePackageDependencies)
+            {
+                packages = packages.Include(p => p.Dependencies);
             }
 
             return packages;

--- a/src/NuGetGallery.Core/Services/CorePackageService.cs
+++ b/src/NuGetGallery.Core/Services/CorePackageService.cs
@@ -360,7 +360,7 @@ namespace NuGetGallery
 
             if (includePackageRegistration)
             {
-                packages = packages.Include(p => p.PackageRegistration);
+                packages = packages.Include(p => p.PackageRegistration.Owners);
             }
 
             if (includeUser)

--- a/src/NuGetGallery.Services/PackageManagement/IPackageService.cs
+++ b/src/NuGetGallery.Services/PackageManagement/IPackageService.cs
@@ -48,12 +48,18 @@ namespace NuGetGallery
         /// Includes the <see cref="Package.PackageRegistration"/> fields based on <paramref name="includePackageRegistration"/>.
         /// Includes the <see cref="Package.Deprecations"/> fields based on <paramref name="includeDeprecations"/>.
         /// Includes the <see cref="Package.SupportedFrameworks"/> fields based on <paramref name="includeSupportedFrameworks);"/>.
+        /// Includes the <see cref="Package.SymbolPackages"/> fields based on <paramref name="includeSymbolPackages);"/>.
+        /// Includes the <see cref="Package.Dependencies"/> fields based on <paramref name="includePackageDependencies);"/>.
+        /// Includes the <see cref="Package.PackageTypes"/> fields based on <paramref name="includePackageTypes);"/>.
         /// </summary>
         IReadOnlyCollection<Package> FindPackagesById(
             string id,
             bool includePackageRegistration,
             bool includeDeprecations,
-            bool includeSupportedFrameworks);
+            bool includeSupportedFrameworks,
+            bool includeSymbolPackages = false,
+            bool includePackageDependencies = false,
+            bool inlcudePackageTypes = false);
 
         /// <summary>
         /// Gets the package with the given ID and version when exists;

--- a/src/NuGetGallery.Services/PackageManagement/IPackageService.cs
+++ b/src/NuGetGallery.Services/PackageManagement/IPackageService.cs
@@ -59,7 +59,7 @@ namespace NuGetGallery
             bool includeSupportedFrameworks,
             bool includeSymbolPackages = false,
             bool includePackageDependencies = false,
-            bool inlcudePackageTypes = false);
+            bool includePackageTypes = false);
 
         /// <summary>
         /// Gets the package with the given ID and version when exists;

--- a/src/NuGetGallery.Services/PackageManagement/PackageService.cs
+++ b/src/NuGetGallery.Services/PackageManagement/PackageService.cs
@@ -241,7 +241,9 @@ namespace NuGetGallery
                 includeSymbolPackages: false,
                 includeDeprecations: false,
                 includeDeprecationRelationships: false,
-                includeSupportedFrameworks: false);
+                includeSupportedFrameworks: false,
+                includePackageDependencies: false,
+                includePackageTypes: false);
 
             return packages.ToList();
         }
@@ -250,7 +252,10 @@ namespace NuGetGallery
             string id,
             bool includePackageRegistration,
             bool includeDeprecations,
-            bool includeSupportedFrameworks)
+            bool includeSupportedFrameworks,
+            bool includeSymbolPackages = false,
+            bool includePackageDependencies = false,
+            bool inlcudePackageTypes = false)
         {
             if (id == null)
             {
@@ -262,10 +267,12 @@ namespace NuGetGallery
                 includeLicenseReports: false,
                 includePackageRegistration: includePackageRegistration,
                 includeUser: false,
-                includeSymbolPackages: false,
+                includeSymbolPackages: includeSymbolPackages,
                 includeDeprecations: includeDeprecations,
                 includeDeprecationRelationships: false,
-                includeSupportedFrameworks: includeSupportedFrameworks);
+                includeSupportedFrameworks: includeSupportedFrameworks,
+                includePackageDependencies: includePackageDependencies,
+                includePackageTypes: inlcudePackageTypes);
 
             return packages.ToList();
         }

--- a/src/NuGetGallery.Services/PackageManagement/PackageService.cs
+++ b/src/NuGetGallery.Services/PackageManagement/PackageService.cs
@@ -255,7 +255,7 @@ namespace NuGetGallery
             bool includeSupportedFrameworks,
             bool includeSymbolPackages = false,
             bool includePackageDependencies = false,
-            bool inlcudePackageTypes = false)
+            bool includePackageTypes = false)
         {
             if (id == null)
             {
@@ -272,7 +272,7 @@ namespace NuGetGallery
                 includeDeprecationRelationships: false,
                 includeSupportedFrameworks: includeSupportedFrameworks,
                 includePackageDependencies: includePackageDependencies,
-                includePackageTypes: inlcudePackageTypes);
+                includePackageTypes: includePackageTypes);
 
             return packages.ToList();
         }

--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -927,7 +927,10 @@ namespace NuGetGallery
             var allVersions = _packageService.FindPackagesById(id,
                 includePackageRegistration: true,
                 includeDeprecations: true,
-                includeSupportedFrameworks: true);
+                includeSupportedFrameworks: true,
+                includeSymbolPackages: true,
+                includePackageDependencies: true,
+                inlcudePackageTypes: true);
 
             var filterContext = new PackageFilterContext(RouteData?.Route, version);
             var package = _packageFilter.GetFiltered(allVersions, filterContext);

--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -930,7 +930,7 @@ namespace NuGetGallery
                 includeSupportedFrameworks: true,
                 includeSymbolPackages: true,
                 includePackageDependencies: true,
-                inlcudePackageTypes: true);
+                includePackageTypes: true);
 
             var filterContext = new PackageFilterContext(RouteData?.Route, version);
             var package = _packageFilter.GetFiltered(allVersions, filterContext);

--- a/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
@@ -513,7 +513,9 @@ namespace NuGetGallery
                     /*includePackageRegistration:*/ true,
                     /*includeDeprecations:*/ true,
                     /*includeSupportedFrameworks:*/ true,
-                    false, false, false))
+                    /*includeSymbolPackages:*/ true,
+                    /*includePackageDependencies:*/ true,
+                    /*includePackageTypes:*/ true))
                     .Returns(packages);
                 packageService
                     .Setup(p => p.FilterExactPackage(It.IsAny<IReadOnlyCollection<Package>>(), It.IsAny<string>()))
@@ -722,7 +724,9 @@ namespace NuGetGallery
                     /*includePackageRegistration:*/ true,
                     /*includeDeprecations:*/ true,
                     /*includeSupportedFrameworks:*/ true,
-                    false, false, false))
+                    /*includeSymbolPackages:*/ true,
+                    /*includePackageDependencies:*/ true,
+                    /*includePackageTypes:*/ true))
                     .Returns(packages);
 
                 packageService
@@ -853,7 +857,9 @@ namespace NuGetGallery
                     /*includePackageRegistration:*/ true,
                     /*includeDeprecations:*/ true,
                     /*includeSupportedFrameworks:*/ true,
-                    false, false, false))
+                    /*includeSymbolPackages:*/ true,
+                    /*includePackageDependencies:*/ true,
+                    /*includePackageTypes:*/ true))
                     .Returns(packages);
 
                 packageService
@@ -928,7 +934,9 @@ namespace NuGetGallery
                     /*includePackageRegistration:*/ true,
                     /*includeDeprecations:*/ true,
                     /*includeSupportedFrameworks:*/ true,
-                    false, false, false))
+                    /*includeSymbolPackages:*/ true,
+                    /*includePackageDependencies:*/ true,
+                    /*includePackageTypes:*/ true))
                     .Returns(new[] { notLatestPackage, latestPackage, latestButNotPackage });
 
                 indexingService.Setup(i => i.GetLastWriteTime()).Returns(Task.FromResult((DateTime?)DateTime.UtcNow));
@@ -977,7 +985,9 @@ namespace NuGetGallery
                     /*includePackageRegistration:*/ true,
                     /*includeDeprecations:*/ true,
                     /*includeSupportedFrameworks:*/ true,
-                    false, false, false))
+                    /*includeSymbolPackages:*/ true,
+                    /*includePackageDependencies:*/ true,
+                    /*includePackageTypes:*/ true))
                     .Returns(packages);
 
                 packageService
@@ -1027,7 +1037,9 @@ namespace NuGetGallery
                     /*includePackageRegistration:*/ true,
                     /*includeDeprecations:*/ true,
                     /*includeSupportedFrameworks:*/ true,
-                    false, false, false))
+                    /*includeSymbolPackages:*/ true,
+                    /*includePackageDependencies:*/ true,
+                    /*includePackageTypes:*/ true))
                     .Returns(packages);
 
                 packageService
@@ -1130,7 +1142,9 @@ namespace NuGetGallery
                     /*includePackageRegistration:*/ true,
                     /*includeDeprecations:*/ true,
                     /*includeSupportedFrameworks:*/ true,
-                    false, false, false))
+                    /*includeSymbolPackages:*/ true,
+                    /*includePackageDependencies:*/ true,
+                    /*includePackageTypes:*/ true))
                     .Returns(packages);
 
                 packageService
@@ -1182,7 +1196,9 @@ namespace NuGetGallery
                     /*includePackageRegistration:*/ true,
                     /*includeDeprecations:*/ true,
                     /*includeSupportedFrameworks:*/ true,
-                    false, false, false))
+                    /*includeSymbolPackages:*/ true,
+                    /*includePackageDependencies:*/ true,
+                    /*includePackageTypes:*/ true))
                     .Returns(packages);
 
                 packageService.Setup(p => p.FilterLatestPackage(packages, SemVerLevelKey.SemVer2, true))
@@ -1242,7 +1258,9 @@ namespace NuGetGallery
                     /*includePackageRegistration:*/ true,
                     /*includeDeprecations:*/ true,
                     /*includeSupportedFrameworks:*/ true,
-                    false, false, false))
+                    /*includeSymbolPackages:*/ true,
+                    /*includePackageDependencies:*/ true,
+                    /*includePackageTypes:*/ true))
                     .Returns(packages);
 
                 packageService
@@ -1298,7 +1316,9 @@ namespace NuGetGallery
                     /*includePackageRegistration:*/ true,
                     /*includeDeprecations:*/ true,
                     /*includeSupportedFrameworks:*/ true,
-                    false, false, false))
+                    /*includeSymbolPackages:*/ true,
+                    /*includePackageDependencies:*/ true,
+                    /*includePackageTypes:*/ true))
                     .Returns(packages);
 
                 packageService
@@ -1361,7 +1381,9 @@ namespace NuGetGallery
                     /*includePackageRegistration:*/ true,
                     /*includeDeprecations:*/ true,
                     /*includeSupportedFrameworks:*/ true,
-                    false, false, false))
+                    /*includeSymbolPackages:*/ true,
+                    /*includePackageDependencies:*/ true,
+                    /*includePackageTypes:*/ true))
                     .Returns(packages);
 
                 packageService
@@ -1439,7 +1461,9 @@ namespace NuGetGallery
                     /*includePackageRegistration:*/ true,
                     /*includeDeprecations:*/ true,
                     /*includeSupportedFrameworks:*/ true,
-                    false, false, false))
+                    /*includeSymbolPackages:*/ true,
+                    /*includePackageDependencies:*/ true,
+                    /*includePackageTypes:*/ true))
                     .Returns(packages);
 
                 packageService
@@ -1536,7 +1560,9 @@ namespace NuGetGallery
                     /*includePackageRegistration:*/ true,
                     /*includeDeprecations:*/ true,
                     /*includeSupportedFrameworks:*/ true,
-                    false, false, false))
+                    /*includeSymbolPackages:*/ true,
+                    /*includePackageDependencies:*/ true,
+                    /*includePackageTypes:*/ true))
                     .Returns(packages);
 
                 packageService
@@ -1646,7 +1672,9 @@ namespace NuGetGallery
                     /*includePackageRegistration:*/ true,
                     /*includeDeprecations:*/ true,
                     /*includeSupportedFrameworks:*/ true,
-                    false, false, false))
+                    /*includeSymbolPackages:*/ true,
+                    /*includePackageDependencies:*/ true,
+                    /*includePackageTypes:*/ true))
                     .Returns(packages);
 
                 packageService
@@ -1733,7 +1761,9 @@ namespace NuGetGallery
                     /*includePackageRegistration:*/ true,
                     /*includeDeprecations:*/ true,
                     /*includeSupportedFrameworks:*/ true,
-                    false, false, false))
+                    /*includeSymbolPackages:*/ true,
+                    /*includePackageDependencies:*/ true,
+                    /*includePackageTypes:*/ true))
                     .Returns(packages);
 
                 packageService
@@ -1804,7 +1834,9 @@ namespace NuGetGallery
                     /*includePackageRegistration:*/ true,
                     /*includeDeprecations:*/ true,
                     /*includeSupportedFrameworks:*/ true,
-                    false, false, false))
+                    /*includeSymbolPackages:*/ true,
+                    /*includePackageDependencies:*/ true,
+                    /*includePackageTypes:*/ true))
                     .Returns(packages);
 
                 packageService
@@ -1866,7 +1898,9 @@ namespace NuGetGallery
                     /*includePackageRegistration:*/ true,
                     /*includeDeprecations:*/ true,
                     /*includeSupportedFrameworks:*/ true,
-                    false, false, false))
+                    /*includeSymbolPackages:*/ true,
+                    /*includePackageDependencies:*/ true,
+                    /*includePackageTypes:*/ true))
                     .Returns(packages);
 
                 packageService
@@ -1918,7 +1952,9 @@ namespace NuGetGallery
                     /*includePackageRegistration:*/ true,
                     /*includeDeprecations:*/ true,
                     /*includeSupportedFrameworks:*/ true,
-                    false, false, false))
+                    /*includeSymbolPackages:*/ true,
+                    /*includePackageDependencies:*/ true,
+                    /*includePackageTypes:*/ true))
                     .Returns(packages);
                 packageService
                     .Setup(p => p.FilterLatestPackage(It.IsAny<IReadOnlyCollection<Package>>(), It.IsAny<int?>(), true))
@@ -1971,7 +2007,9 @@ namespace NuGetGallery
                     /*includePackageRegistration:*/ true,
                     /*includeDeprecations:*/ true,
                     /*includeSupportedFrameworks:*/ true,
-                    false, false, false))
+                    /*includeSymbolPackages:*/ true,
+                    /*includePackageDependencies:*/ true,
+                    /*includePackageTypes:*/ true))
                     .Returns(packages);
                 packageService
                     .Setup(p => p.FilterLatestPackage(It.IsAny<IReadOnlyCollection<Package>>(), It.IsAny<int?>(), true))
@@ -2029,7 +2067,9 @@ namespace NuGetGallery
                     /*includePackageRegistration:*/ true,
                     /*includeDeprecations:*/ true,
                     /*includeSupportedFrameworks:*/ true,
-                    false, false, false))
+                    /*includeSymbolPackages:*/ true,
+                    /*includePackageDependencies:*/ true,
+                    /*includePackageTypes:*/ true))
                     .Returns(packages);
 
                 packageService
@@ -2090,7 +2130,9 @@ namespace NuGetGallery
                     /*includePackageRegistration:*/ true,
                     /*includeDeprecations:*/ true,
                     /*includeSupportedFrameworks:*/ true,
-                    false, false, false))
+                    /*includeSymbolPackages:*/ true,
+                    /*includePackageDependencies:*/ true,
+                    /*includePackageTypes:*/ true))
                     .Returns(packages);
                 packageService
                     .Setup(p => p.FilterLatestPackage(It.IsAny<IReadOnlyCollection<Package>>(), It.IsAny<int?>(), true))
@@ -2158,7 +2200,9 @@ namespace NuGetGallery
                     /*includePackageRegistration:*/ true,
                     /*includeDeprecations:*/ true,
                     /*includeSupportedFrameworks:*/ true,
-                    false, false, false))
+                    /*includeSymbolPackages:*/ true,
+                    /*includePackageDependencies:*/ true,
+                    /*includePackageTypes:*/ true))
                     .Returns(packages);
                 packageService
                     .Setup(p => p.FilterLatestPackage(It.IsAny<IReadOnlyCollection<Package>>(), It.IsAny<int?>(), true))
@@ -2228,7 +2272,9 @@ namespace NuGetGallery
                     /*includePackageRegistration:*/ true,
                     /*includeDeprecations:*/ true,
                     /*includeSupportedFrameworks:*/ true,
-                    false, false, false))
+                    /*includeSymbolPackages:*/ true,
+                    /*includePackageDependencies:*/ true,
+                    /*includePackageTypes:*/ true))
                     .Returns(packages);
                 packageService
                     .Setup(p => p.FilterLatestPackage(It.IsAny<IReadOnlyCollection<Package>>(), It.IsAny<int?>(), true))
@@ -2286,7 +2332,9 @@ namespace NuGetGallery
                     /*includePackageRegistration:*/ true,
                     /*includeDeprecations:*/ true,
                     /*includeSupportedFrameworks:*/ true,
-                    false, false, false))
+                    /*includeSymbolPackages:*/ true,
+                    /*includePackageDependencies:*/ true,
+                    /*includePackageTypes:*/ true))
                     .Returns(packages);
 
                 packageService
@@ -2352,7 +2400,9 @@ namespace NuGetGallery
                     /*includePackageRegistration:*/ true,
                     /*includeDeprecations:*/ true,
                     /*includeSupportedFrameworks:*/ true,
-                    false, false, false))
+                    /*includeSymbolPackages:*/ true,
+                    /*includePackageDependencies:*/ true,
+                    /*includePackageTypes:*/ true))
                     .Returns(packages);
 
                 packageService

--- a/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
@@ -512,7 +512,8 @@ namespace NuGetGallery
                     .Setup(p => p.FindPackagesById(id,
                     /*includePackageRegistration:*/ true,
                     /*includeDeprecations:*/ true,
-                    /*includeSupportedFrameworks:*/ true))
+                    /*includeSupportedFrameworks:*/ true,
+                    false, false, false))
                     .Returns(packages);
                 packageService
                     .Setup(p => p.FilterExactPackage(It.IsAny<IReadOnlyCollection<Package>>(), It.IsAny<string>()))
@@ -720,7 +721,8 @@ namespace NuGetGallery
                     .Setup(p => p.FindPackagesById(id,
                     /*includePackageRegistration:*/ true,
                     /*includeDeprecations:*/ true,
-                    /*includeSupportedFrameworks:*/ true))
+                    /*includeSupportedFrameworks:*/ true,
+                    false, false, false))
                     .Returns(packages);
 
                 packageService
@@ -850,7 +852,8 @@ namespace NuGetGallery
                     .Setup(p => p.FindPackagesById(id,
                     /*includePackageRegistration:*/ true,
                     /*includeDeprecations:*/ true,
-                    /*includeSupportedFrameworks:*/ true))
+                    /*includeSupportedFrameworks:*/ true,
+                    false, false, false))
                     .Returns(packages);
 
                 packageService
@@ -924,7 +927,8 @@ namespace NuGetGallery
                     .Setup(p => p.FindPackagesById(id,
                     /*includePackageRegistration:*/ true,
                     /*includeDeprecations:*/ true,
-                    /*includeSupportedFrameworks:*/ true))
+                    /*includeSupportedFrameworks:*/ true,
+                    false, false, false))
                     .Returns(new[] { notLatestPackage, latestPackage, latestButNotPackage });
 
                 indexingService.Setup(i => i.GetLastWriteTime()).Returns(Task.FromResult((DateTime?)DateTime.UtcNow));
@@ -972,7 +976,8 @@ namespace NuGetGallery
                     .Setup(p => p.FindPackagesById(id,
                     /*includePackageRegistration:*/ true,
                     /*includeDeprecations:*/ true,
-                    /*includeSupportedFrameworks:*/ true))
+                    /*includeSupportedFrameworks:*/ true,
+                    false, false, false))
                     .Returns(packages);
 
                 packageService
@@ -1021,7 +1026,8 @@ namespace NuGetGallery
                     .Setup(p => p.FindPackagesById("Foo",
                     /*includePackageRegistration:*/ true,
                     /*includeDeprecations:*/ true,
-                    /*includeSupportedFrameworks:*/ true))
+                    /*includeSupportedFrameworks:*/ true,
+                    false, false, false))
                     .Returns(packages);
 
                 packageService
@@ -1123,7 +1129,8 @@ namespace NuGetGallery
                     .Setup(p => p.FindPackagesById(id,
                     /*includePackageRegistration:*/ true,
                     /*includeDeprecations:*/ true,
-                    /*includeSupportedFrameworks:*/ true))
+                    /*includeSupportedFrameworks:*/ true,
+                    false, false, false))
                     .Returns(packages);
 
                 packageService
@@ -1174,7 +1181,8 @@ namespace NuGetGallery
                     .Setup(p => p.FindPackagesById("Foo",
                     /*includePackageRegistration:*/ true,
                     /*includeDeprecations:*/ true,
-                    /*includeSupportedFrameworks:*/ true))
+                    /*includeSupportedFrameworks:*/ true,
+                    false, false, false))
                     .Returns(packages);
 
                 packageService.Setup(p => p.FilterLatestPackage(packages, SemVerLevelKey.SemVer2, true))
@@ -1233,7 +1241,8 @@ namespace NuGetGallery
                     .Setup(p => p.FindPackagesById(id,
                     /*includePackageRegistration:*/ true,
                     /*includeDeprecations:*/ true,
-                    /*includeSupportedFrameworks:*/ true))
+                    /*includeSupportedFrameworks:*/ true,
+                    false, false, false))
                     .Returns(packages);
 
                 packageService
@@ -1288,7 +1297,8 @@ namespace NuGetGallery
                     .Setup(p => p.FindPackagesById(id,
                     /*includePackageRegistration:*/ true,
                     /*includeDeprecations:*/ true,
-                    /*includeSupportedFrameworks:*/ true))
+                    /*includeSupportedFrameworks:*/ true,
+                    false, false, false))
                     .Returns(packages);
 
                 packageService
@@ -1350,7 +1360,8 @@ namespace NuGetGallery
                     .Setup(p => p.FindPackagesById(id,
                     /*includePackageRegistration:*/ true,
                     /*includeDeprecations:*/ true,
-                    /*includeSupportedFrameworks:*/ true))
+                    /*includeSupportedFrameworks:*/ true,
+                    false, false, false))
                     .Returns(packages);
 
                 packageService
@@ -1427,7 +1438,8 @@ namespace NuGetGallery
                     .Setup(p => p.FindPackagesById(id,
                     /*includePackageRegistration:*/ true,
                     /*includeDeprecations:*/ true,
-                    /*includeSupportedFrameworks:*/ true))
+                    /*includeSupportedFrameworks:*/ true,
+                    false, false, false))
                     .Returns(packages);
 
                 packageService
@@ -1523,7 +1535,8 @@ namespace NuGetGallery
                     .Setup(p => p.FindPackagesById(id,
                     /*includePackageRegistration:*/ true,
                     /*includeDeprecations:*/ true,
-                    /*includeSupportedFrameworks:*/ true))
+                    /*includeSupportedFrameworks:*/ true,
+                    false, false, false))
                     .Returns(packages);
 
                 packageService
@@ -1632,7 +1645,8 @@ namespace NuGetGallery
                     .Setup(p => p.FindPackagesById(id,
                     /*includePackageRegistration:*/ true,
                     /*includeDeprecations:*/ true,
-                    /*includeSupportedFrameworks:*/ true))
+                    /*includeSupportedFrameworks:*/ true,
+                    false, false, false))
                     .Returns(packages);
 
                 packageService
@@ -1718,7 +1732,8 @@ namespace NuGetGallery
                     .Setup(p => p.FindPackagesById(id,
                     /*includePackageRegistration:*/ true,
                     /*includeDeprecations:*/ true,
-                    /*includeSupportedFrameworks:*/ true))
+                    /*includeSupportedFrameworks:*/ true,
+                    false, false, false))
                     .Returns(packages);
 
                 packageService
@@ -1788,7 +1803,8 @@ namespace NuGetGallery
                     .Setup(p => p.FindPackagesById(id,
                     /*includePackageRegistration:*/ true,
                     /*includeDeprecations:*/ true,
-                    /*includeSupportedFrameworks:*/ true))
+                    /*includeSupportedFrameworks:*/ true,
+                    false, false, false))
                     .Returns(packages);
 
                 packageService
@@ -1849,7 +1865,8 @@ namespace NuGetGallery
                     .Setup(p => p.FindPackagesById(id,
                     /*includePackageRegistration:*/ true,
                     /*includeDeprecations:*/ true,
-                    /*includeSupportedFrameworks:*/ true))
+                    /*includeSupportedFrameworks:*/ true,
+                    false, false, false))
                     .Returns(packages);
 
                 packageService
@@ -1900,7 +1917,8 @@ namespace NuGetGallery
                     .Setup(p => p.FindPackagesById(id,
                     /*includePackageRegistration:*/ true,
                     /*includeDeprecations:*/ true,
-                    /*includeSupportedFrameworks:*/ true))
+                    /*includeSupportedFrameworks:*/ true,
+                    false, false, false))
                     .Returns(packages);
                 packageService
                     .Setup(p => p.FilterLatestPackage(It.IsAny<IReadOnlyCollection<Package>>(), It.IsAny<int?>(), true))
@@ -1952,7 +1970,8 @@ namespace NuGetGallery
                     .Setup(p => p.FindPackagesById(id,
                     /*includePackageRegistration:*/ true,
                     /*includeDeprecations:*/ true,
-                    /*includeSupportedFrameworks:*/ true))
+                    /*includeSupportedFrameworks:*/ true,
+                    false, false, false))
                     .Returns(packages);
                 packageService
                     .Setup(p => p.FilterLatestPackage(It.IsAny<IReadOnlyCollection<Package>>(), It.IsAny<int?>(), true))
@@ -2009,7 +2028,8 @@ namespace NuGetGallery
                     .Setup(p => p.FindPackagesById(id,
                     /*includePackageRegistration:*/ true,
                     /*includeDeprecations:*/ true,
-                    /*includeSupportedFrameworks:*/ true))
+                    /*includeSupportedFrameworks:*/ true,
+                    false, false, false))
                     .Returns(packages);
 
                 packageService
@@ -2069,7 +2089,8 @@ namespace NuGetGallery
                     .Setup(p => p.FindPackagesById(id,
                     /*includePackageRegistration:*/ true,
                     /*includeDeprecations:*/ true,
-                    /*includeSupportedFrameworks:*/ true))
+                    /*includeSupportedFrameworks:*/ true,
+                    false, false, false))
                     .Returns(packages);
                 packageService
                     .Setup(p => p.FilterLatestPackage(It.IsAny<IReadOnlyCollection<Package>>(), It.IsAny<int?>(), true))
@@ -2136,7 +2157,8 @@ namespace NuGetGallery
                     .Setup(p => p.FindPackagesById(It.IsAny<string>(),
                     /*includePackageRegistration:*/ true,
                     /*includeDeprecations:*/ true,
-                    /*includeSupportedFrameworks:*/ true))
+                    /*includeSupportedFrameworks:*/ true,
+                    false, false, false))
                     .Returns(packages);
                 packageService
                     .Setup(p => p.FilterLatestPackage(It.IsAny<IReadOnlyCollection<Package>>(), It.IsAny<int?>(), true))
@@ -2205,7 +2227,8 @@ namespace NuGetGallery
                     .Setup(p => p.FindPackagesById(id,
                     /*includePackageRegistration:*/ true,
                     /*includeDeprecations:*/ true,
-                    /*includeSupportedFrameworks:*/ true))
+                    /*includeSupportedFrameworks:*/ true,
+                    false, false, false))
                     .Returns(packages);
                 packageService
                     .Setup(p => p.FilterLatestPackage(It.IsAny<IReadOnlyCollection<Package>>(), It.IsAny<int?>(), true))
@@ -2262,7 +2285,8 @@ namespace NuGetGallery
                     .Setup(p => p.FindPackagesById(id,
                     /*includePackageRegistration:*/ true,
                     /*includeDeprecations:*/ true,
-                    /*includeSupportedFrameworks:*/ true))
+                    /*includeSupportedFrameworks:*/ true,
+                    false, false, false))
                     .Returns(packages);
 
                 packageService
@@ -2327,7 +2351,8 @@ namespace NuGetGallery
                     .Setup(p => p.FindPackagesById(id,
                     /*includePackageRegistration:*/ true,
                     /*includeDeprecations:*/ true,
-                    /*includeSupportedFrameworks:*/ true))
+                    /*includeSupportedFrameworks:*/ true,
+                    false, false, false))
                     .Returns(packages);
 
                 packageService


### PR DESCRIPTION
fixes #5942

* Ran SQL profiler against my local database populated with som .nuspecs meta data, and saw 4 lazy loading calls, that can be avoided.

Addresses https://github.com/NuGet/NuGetGallery/issues/5942