### PR TITLE
Make local dev script longer lived, recreate when expired

### DIFF
--- a/tools/Setup-DevEnvironment.ps1
+++ b/tools/Setup-DevEnvironment.ps1
@@ -117,12 +117,6 @@ Write-Host "[DONE] Setting up IIS Express" -ForegroundColor Cyan
 Write-Host "[BEGIN] Setting up SSL certificate" -ForegroundColor Cyan
 
 $siteCert = Get-SiteCertificate
-
-
-if ($null -eq $siteCert) { 
-    $siteCert = Initialize-SiteCertificate
-}
-
 Write-Host "Using SSL Certificate: $($siteCert.Thumbprint)"
 Invoke-Netsh http delete sslcert ipport="0.0.0.0:443"
 Invoke-Netsh http delete sslcert hostnameport="$(Get-SiteHttpsHost)"

--- a/tools/Setup-DevEnvironment.ps1
+++ b/tools/Setup-DevEnvironment.ps1
@@ -1,33 +1,40 @@
 param([string]$SiteName = "NuGet Gallery", [string]$SitePhysicalPath, [string]$AppCmdPath)
 
-function Get-SiteFQDN() {return "localhost"} # DevSkim: ignore DS162092
-function Get-SiteHttpHost() {return "$(Get-SiteFQDN):80"}
-function Get-SiteHttpsHost() {return "$(Get-SiteFQDN):443"}
+function Get-SiteFQDN() { return "localhost" } # DevSkim: ignore DS162092
+function Get-SiteHttpHost() { return "$(Get-SiteFQDN):80" }
+function Get-SiteHttpsHost() { return "$(Get-SiteFQDN):443" }
 
 function Get-SiteCertificate() {
-    return @(Get-ChildItem -l "Cert:\LocalMachine\Root" `
-        | Where-Object {$_.Subject -eq "CN=$(Get-SiteFQDN)"}) `
+    $cert = @(Get-ChildItem -l "Cert:\LocalMachine\Root" `
+        | Where-Object { $_.Subject -eq "CN=$(Get-SiteFQDN)" }) `
+        | Sort-Object -Property NotAfter -Descending `
         | Select-Object -First 1
-}
 
-function Initialize-SiteCertificate() {
-    Write-Host "Generating a Self-Signed SSL Certificate for $(Get-SiteFQDN)"
-
-    # Create a new self-signed certificate. New-SelfSignedCertificate can only create
-    # certificates into the My certificate store.
-    $myCert = New-SelfSignedCertificate -DnsName $(Get-SiteFQDN) -CertStoreLocation "Cert:\LocalMachine\My" -NotAfter (Get-Date).AddYears(10)
+    if (($null -ne $cert) -and ($cert.NotAfter -lt (Get-Date))) {
+        Write-Host "Site certificate is expired. Recreating it. If you encounter issues, restart your computer." -ForegroundColor Yellow
+        $cert = $null
+    }
     
-    # Move the newly created self-signed certificate to the Root store.
-    $rootStore = New-Object System.Security.Cryptography.X509Certificates.X509Store("Root", "LocalMachine")
-    $rootStore.Open([System.Security.Cryptography.X509Certificates.OpenFlags]::ReadWrite)
-    $rootStore.Add($myCert)
-    $rootStore.Close()
+    if ($null -eq $cert) {
+        Write-Host "Generating a self-signed SSL certificate for $(Get-SiteFQDN)"
 
-    # Return the self-signed certificate from the Root store.
-    $cert = Get-SiteCertificate
+        # Create a new self-signed certificate. New-SelfSignedCertificate can only create
+        # certificates into the My certificate store.
+        $newCert = New-SelfSignedCertificate -DnsName $(Get-SiteFQDN) -CertStoreLocation "Cert:\LocalMachine\My" -NotAfter (Get-Date).AddYears(10)
+        
+        # Move the newly created self-signed certificate to the Root store.
+        $rootStore = New-Object System.Security.Cryptography.X509Certificates.X509Store("Root", "LocalMachine")
+        $rootStore.Open([System.Security.Cryptography.X509Certificates.OpenFlags]::ReadWrite)
+        $rootStore.Add($newCert)
+        $rootStore.Close()
 
-    if($null -eq $cert) {
-        throw "Failed to create an SSL Certificate"
+        # Return the self-signed certificate from the Root store.
+        $cert = @(Get-ChildItem -l "Cert:\LocalMachine\Root" `
+            | Where-Object { $_.Thumbprint -eq $newCert.Thumbprint }) `
+            | Select-Object -First 1
+        if ($null -eq $cert) {
+            throw "Failed to create an SSL certificate"
+        }
     }
 
     return $cert
@@ -38,51 +45,53 @@ function Invoke-Netsh() {
     $result = (netsh @args | Out-String).Trim()
     $parsed = [Regex]::Match($result, ".*Error: (\d+).*")
 
-    if($parsed.Success) {
+    if ($parsed.Success) {
         $err = $parsed.Groups[1].Value
-        if(($err -ne "183") -and ($err -ne "2")) {
+        if (($err -ne "183") -and ($err -ne "2")) {
             throw $result
         }
-    } elseif ($result -eq "The parameter is incorrect.") {
+    }
+    elseif ($result -eq "The parameter is incorrect.") {
         throw "Parameters for netsh are incorrect:`r`n  $argStr"
-    } else {
+    }
+    else {
         Write-Host $result
     }
 }
 
-if(!(([Security.Principal.WindowsPrincipal]([System.Security.Principal.WindowsIdentity]::GetCurrent())).IsInRole([Security.Principal.WindowsBuiltInRole]"Administrator"))) {
+if (!(([Security.Principal.WindowsPrincipal]([System.Security.Principal.WindowsIdentity]::GetCurrent())).IsInRole([Security.Principal.WindowsBuiltInRole]"Administrator"))) {
     throw "This script must be run as an admin."
 }
 
 Write-Host "[BEGIN] Setting up IIS Express" -ForegroundColor Cyan
 
 $ScriptRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
-if(!$SitePhysicalPath) {
+if (!$SitePhysicalPath) {
     $SitePhysicalPath = Join-Path $ScriptRoot "..\src\NuGetGallery"
 }
-if(!(Test-Path $SitePhysicalPath)) {
+if (!(Test-Path $SitePhysicalPath)) {
     throw "Could not find site at $SitePhysicalPath. Use -SitePhysicalPath argument to specify the path."
 }
 $SitePhysicalPath = Convert-Path $SitePhysicalPath
 
 # Find IIS Express
-if(!$AppCmdPath) {
+if (!$AppCmdPath) {
     $IISXVersion = Get-ChildItem 'HKLM:\Software\Microsoft\IISExpress' | 
-        ForEach-Object { New-Object System.Version ($_.PSChildName) } |
-        Sort-Object -desc |
-        Select-Object -first 1
-    if(!$IISXVersion) {
+    ForEach-Object { New-Object System.Version ($_.PSChildName) } |
+    Sort-Object -desc |
+    Select-Object -first 1
+    if (!$IISXVersion) {
         throw "Could not find IIS Express. Please install IIS Express before running this script, or use -AppCmdPath to specify the path to appcmd.exe for your IIS environment"
     }
     $IISRegKey = (Get-ItemProperty "HKLM:\Software\Microsoft\IISExpress\$IISXVersion")
     $IISExpressDir = $IISRegKey.InstallPath
-    if(!(Test-Path $IISExpressDir)) {
+    if (!(Test-Path $IISExpressDir)) {
         throw "Can't find IIS Express in $IISExpressDir. Please install IIS Express"
     }
     $AppCmdPath = "$IISExpressDir\appcmd.exe"
 }
 
-if(!(Test-Path $AppCmdPath)) {
+if (!(Test-Path $AppCmdPath)) {
     throw "Could not find appcmd.exe in $AppCmdPath!"
 }
 
@@ -96,7 +105,7 @@ Invoke-Netsh http add urlacl "url=https://$(Get-SiteHttpsHost)/" "sddl=D:(A;;GX;
 $SiteFullName = "$SiteName ($(Get-SiteFQDN))"
 
 $sites = @(& $AppCmdPath list site $SiteFullName)
-if($sites.Length -gt 0) {
+if ($sites.Length -gt 0) {
     Write-Warning "Site '$SiteFullName' already exists. Deleting and recreating."
     & $AppCmdPath delete site "$SiteFullName"
 }
@@ -109,11 +118,6 @@ Write-Host "[BEGIN] Setting up SSL certificate" -ForegroundColor Cyan
 
 $siteCert = Get-SiteCertificate
 
-if ($siteCert.NotAfter -lt (Get-Date)) {
-    Write-Host "Site certificate is expired. Recreating it. If you encounter issues, restart your computer." -ForegroundColor Yellow
-    $siteCert | Remove-Item
-    $siteCert = $null
-}
 
 if ($null -eq $siteCert) { 
     $siteCert = Initialize-SiteCertificate
@@ -128,6 +132,6 @@ Write-Host "[DONE] Setting up SSL certificate" -ForegroundColor Cyan
 
 Write-Host "[BEGIN] Running Entity Framework migrations" -ForegroundColor Cyan
 
-& "$ScriptRoot\Update-Databases.ps1" -MigrationTargets NuGetGallery,NuGetGallerySupportRequest -NuGetGallerySitePath $SitePhysicalPath
+& "$ScriptRoot\Update-Databases.ps1" -MigrationTargets NuGetGallery, NuGetGallerySupportRequest -NuGetGallerySitePath $SitePhysicalPath
 
 Write-Host "[DONE] Running Entity Framework migrations" -ForegroundColor Cyan


### PR DESCRIPTION
Summary of changes:
- make localhost SSL cert last 10 years
- refresh cert if it is expired
- fix powershell linter warnings