### PR TITLE
[HotFix]: Fix double encoding

### DIFF
--- a/src/Catalog/Persistence/Storage.cs
+++ b/src/Catalog/Persistence/Storage.cs
@@ -188,7 +188,9 @@ namespace NuGet.Services.Metadata.Catalog.Persistence
             }
 
             if (BaseAddress is null)
+            {
                 throw new InvalidOperationException("BaseAddress must be set.");
+            }
 
             string address = Uri.UnescapeDataString(BaseAddress.GetLeftPart(UriPartial.Path));
             if (!address.EndsWith("/"))

--- a/src/Catalog/Persistence/Storage.cs
+++ b/src/Catalog/Persistence/Storage.cs
@@ -183,7 +183,9 @@ namespace NuGet.Services.Metadata.Catalog.Persistence
         protected string GetName(Uri uri)
         {
             if (uri is null)
+            { 
                 throw new ArgumentNullException(nameof(uri));
+            }
 
             if (BaseAddress is null)
                 throw new InvalidOperationException("BaseAddress must be set.");
@@ -205,9 +207,10 @@ namespace NuGet.Services.Metadata.Catalog.Persistence
             // decode back previous encoding in case of Unicode characters, otherwise it will be double encoded later
             string name = Uri.UnescapeDataString(encodedName);
 
-            int hash = name.IndexOf('#');
-            if (hash >= 0)
-                name = name[..hash];
+            if (name.Contains("#"))
+            {
+                name = name.Substring(0, name.IndexOf("#"));
+            }
 
             return name;
         }

--- a/tests/CatalogTests/Persistence/StorageTests.cs
+++ b/tests/CatalogTests/Persistence/StorageTests.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using NuGet.Services.Metadata.Catalog.Persistence;
+using Xunit;
+
+namespace CatalogTests.Persistence
+{
+    public class StorageTests
+    {
+        [Theory]
+        [InlineData("http://contoso.blob.core.windows.net/packages/package.1.0.0.nupkg", "package.1.0.0.nupkg")]
+        [InlineData("http://contoso.blob.core.windows.net/packages/another-package123.2.0.0.nupkg", "another-package123.2.0.0.nupkg")]
+        public void GetName_NonUnicodeUri_ReturnsCorrectName(string uriString, string expectedName)
+        {
+            // Arrange
+            Uri baseAddress = new Uri("http://contoso.blob.core.windows.net/packages/");
+            var storage = new Mock<Storage>(baseAddress) { CallBase = true };
+            var uri = new Uri(uriString);
+
+            // Act
+            var name = storage.Object.GetUri(expectedName).ToString();
+
+            // Assert
+            Assert.EndsWith(expectedName, name);
+        }
+
+        [Theory]
+        [InlineData("http://contoso.blob.core.windows.net/packages/邮件.1.0.0.nupkg", "邮件.1.0.0.nupkg")]
+        [InlineData("http://contoso.blob.core.windows.net/packages/пакет.2.0.0.nupkg", "пакет.2.0.0.nupkg")]
+        [InlineData("http://contoso.blob.core.windows.net/packages/パッケージ.3.0.0.nupkg", "パッケージ.3.0.0.nupkg")]
+        public void GetName_UnicodeUri_ReturnsCorrectName(string uriString, string expectedName)
+        {
+            // Arrange
+            Uri baseAddress = new Uri("http://contoso.blob.core.windows.net/packages/");
+            var storage = new Mock<Storage>(baseAddress) { CallBase = true };
+            var uri = new Uri(uriString);
+
+            // Act
+            var name = storage.Object.GetUri(expectedName).ToString();
+
+            // Assert
+            Assert.EndsWith(expectedName, name);
+        }
+    }
+}


### PR DESCRIPTION
Address: https://github.com/NuGet/Engineering/issues/5850
`uri.GetLeftPart` does encoding under the hood, which is causing the problem.
New change decode to make sure it is not double encoded later, tested on INT.

Companion PR: https://github.com/NuGet/NuGet.Services.EndToEnd/pull/131