### PR TITLE
Use Microsoft.EntityFramework.SqlServer with the modern SqlClient

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -23,9 +23,8 @@
     <PackageVersion Include="CommonMark.NET" Version="0.15.1" />
     <PackageVersion Include="CsvHelper" Version="7.1.1" />
     <PackageVersion Include="d3" Version="5.4.0" />
-    <PackageVersion Include="Dapper.StrongName" Version="1.50.2" />
+    <PackageVersion Include="Dapper.StrongName" Version="2.1.66" />
     <PackageVersion Include="dotNetRDF" Version="1.0.8.3533" />
-    <PackageVersion Include="EntityFramework" Version="6.5.1" />
     <PackageVersion Include="FluentAssertions" Version="5.5.0" />
     <PackageVersion Include="FluentLinkChecker" Version="1.0.0.10" />
     <PackageVersion Include="HtmlSanitizer" Version="8.1.870" />
@@ -63,6 +62,8 @@
     <PackageVersion Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" Version="3.6.0" />
     <PackageVersion Include="Microsoft.Data.Services.Client" Version="5.8.4" />
     <PackageVersion Include="Microsoft.Data.Services" Version="5.8.4" />
+    <PackageVersion Include="Microsoft.Data.SqlClient" Version="5.1.6" />
+    <PackageVersion Include="Microsoft.EntityFramework.SqlServer" Version="6.5.1" />
     <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />
     <PackageVersion Include="Microsoft.Extensions.CommandLineUtils" Version="1.1.1" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
@@ -134,7 +135,6 @@
     <PackageVersion Include="Strathweb.CacheOutput.WebApi2.StrongName" Version="0.9.0" />
     <PackageVersion Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageVersion Include="System.ComponentModel.EventBasedAsync" Version="4.0.11" />
-    <PackageVersion Include="System.Data.SqlClient" Version="4.8.6" />
     <PackageVersion Include="System.Diagnostics.Debug" Version="4.3.0" />
     <PackageVersion Include="System.Drawing.Common" Version="9.0.0" />
     <PackageVersion Include="System.Formats.Asn1" Version="8.0.2" />

--- a/src/Catalog/Helpers/GalleryDatabaseQueryService.cs
+++ b/src/Catalog/Helpers/GalleryDatabaseQueryService.cs
@@ -1,11 +1,11 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using System.Collections.Generic;
-using System.Data.SqlClient;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.Data.SqlClient;
 using NuGet.Services.Sql;
 
 namespace NuGet.Services.Metadata.Catalog.Helpers

--- a/src/DatabaseMigrationTools/DatabaseMigrationTools.csproj
+++ b/src/DatabaseMigrationTools/DatabaseMigrationTools.csproj
@@ -7,7 +7,7 @@
     <Description>Database migration tools for NuGet Gallery/Support Requests/Validation databases</Description>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="EntityFramework" />
+    <PackageReference Include="Microsoft.EntityFramework.SqlServer" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NuGet.Services.DatabaseMigration\NuGet.Services.DatabaseMigration.csproj" />

--- a/src/DatabaseMigrationTools/GalleryDbMigrationContext.cs
+++ b/src/DatabaseMigrationTools/GalleryDbMigrationContext.cs
@@ -1,9 +1,9 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using System.Data.Entity.Migrations;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using NuGet.Services.DatabaseMigration;
 using NuGetGallery.Migrations;
 

--- a/src/DatabaseMigrationTools/SupportRequestDbMigrationContext.cs
+++ b/src/DatabaseMigrationTools/SupportRequestDbMigrationContext.cs
@@ -1,9 +1,9 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using System.Data.Entity.Migrations;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using NuGet.Services.DatabaseMigration;
 using NuGetGallery.Areas.Admin;
 using NuGetGallery.Areas.Admin.Models;

--- a/src/DatabaseMigrationTools/ValidationDbMigrationContext.cs
+++ b/src/DatabaseMigrationTools/ValidationDbMigrationContext.cs
@@ -1,9 +1,9 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using System.Data.Entity.Migrations;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using NuGet.Services.DatabaseMigration;
 using NuGet.Services.Validation;
 

--- a/src/GalleryTools/Commands/BackfillCommand.cs
+++ b/src/GalleryTools/Commands/BackfillCommand.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Autofac;
@@ -13,7 +13,6 @@ using NuGetGallery;
 using System;
 using System.Collections.Generic;
 using System.Data.Entity;
-using System.Data.SqlClient;
 using System.IO;
 using System.Linq;
 using System.Linq.Expressions;
@@ -23,6 +22,7 @@ using System.Threading.Tasks;
 using System.Xml;
 using System.Xml.Linq;
 using GalleryTools.Utils;
+using Microsoft.Data.SqlClient;
 using NuGet.Services.Sql;
 using NuGet.Packaging.Core;
 using NuGet.Versioning;

--- a/src/GalleryTools/Commands/UpdateIsLatestCommand.cs
+++ b/src/GalleryTools/Commands/UpdateIsLatestCommand.cs
@@ -1,10 +1,10 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Data.SqlClient;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.CommandLineUtils;
 using NuGet.Services.Entities;
 using NuGetGallery;

--- a/src/NuGet.Jobs.Common/DelegateSqlConnectionFactory.cs
+++ b/src/NuGet.Jobs.Common/DelegateSqlConnectionFactory.cs
@@ -1,9 +1,9 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Data.SqlClient;
 using System.Threading.Tasks;
+using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.Logging;
 using NuGet.Jobs.Configuration;
 

--- a/src/NuGet.Jobs.Common/Extensions/DapperExtensions.cs
+++ b/src/NuGet.Jobs.Common/Extensions/DapperExtensions.cs
@@ -1,13 +1,15 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
+using System.Data;
 using System.Threading.Tasks;
 using Dapper;
 using NuGet.Jobs;
 
 // ReSharper disable once CheckNamespace
-namespace System.Data.SqlClient
+namespace Microsoft.Data.SqlClient
 {
     public static class DapperExtensions
     {

--- a/src/NuGet.Jobs.Common/ISqlConnectionFactory.cs
+++ b/src/NuGet.Jobs.Common/ISqlConnectionFactory.cs
@@ -1,7 +1,7 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using System.Threading.Tasks;
 using NuGet.Jobs.Configuration;
 

--- a/src/NuGet.Jobs.Common/JobBase.cs
+++ b/src/NuGet.Jobs.Common/JobBase.cs
@@ -1,12 +1,12 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.Design;
-using System.Data.SqlClient;
 using System.Diagnostics.Tracing;
 using System.Threading.Tasks;
+using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;

--- a/src/NuGet.Jobs.Common/NuGet.Jobs.Common.csproj
+++ b/src/NuGet.Jobs.Common/NuGet.Jobs.Common.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="Dapper.StrongName" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" />
-    <PackageReference Include="System.Data.SqlClient" />
+    <PackageReference Include="Microsoft.Data.SqlClient" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net472'">

--- a/src/NuGet.Jobs.Common/SqlRetryUtility.cs
+++ b/src/NuGet.Jobs.Common/SqlRetryUtility.cs
@@ -1,11 +1,11 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using System.Collections.Generic;
-using System.Data.SqlClient;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.Data.SqlClient;
 
 namespace NuGet.Jobs
 {

--- a/src/NuGet.Services.AzureSearch/DatabaseAuxiliaryDataFetcher.cs
+++ b/src/NuGet.Services.AzureSearch/DatabaseAuxiliaryDataFetcher.cs
@@ -1,14 +1,14 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Data.Entity;
-using System.Data.SqlClient;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.Logging;
 using NuGet.Jobs;
 using NuGet.Jobs.Configuration;

--- a/src/NuGet.Services.DatabaseMigration/BaseDbMigrationContext.cs
+++ b/src/NuGet.Services.DatabaseMigration/BaseDbMigrationContext.cs
@@ -1,10 +1,10 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using System.Data;
 using System.Data.Entity.Migrations;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 
 namespace NuGet.Services.DatabaseMigration
 {

--- a/src/NuGet.Services.DatabaseMigration/IMigrationContext.cs
+++ b/src/NuGet.Services.DatabaseMigration/IMigrationContext.cs
@@ -1,9 +1,9 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using System.Data.Entity.Migrations;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 
 namespace NuGet.Services.DatabaseMigration
 {

--- a/src/NuGet.Services.DatabaseMigration/Job.cs
+++ b/src/NuGet.Services.DatabaseMigration/Job.cs
@@ -1,15 +1,15 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using System.Linq;
-using System.Data.SqlClient;
 using System.Threading.Tasks;
 using System.Data.Entity.Migrations;
 using System.Data.Entity.Migrations.Infrastructure;
 using System.ComponentModel.Design;
 using System.Collections.Generic;
 using Autofac;
+using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;

--- a/src/NuGet.Services.DatabaseMigration/NuGet.Services.DatabaseMigration.csproj
+++ b/src/NuGet.Services.DatabaseMigration/NuGet.Services.DatabaseMigration.csproj
@@ -7,8 +7,8 @@
     <Description>Core support library for NuGet database migration</Description>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="EntityFramework" />
-    <PackageReference Include="System.Data.SqlClient" />
+    <PackageReference Include="Microsoft.EntityFramework.SqlServer" />
+    <PackageReference Include="Microsoft.Data.SqlClient" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NuGet.Jobs.Common\NuGet.Jobs.Common.csproj" />

--- a/src/NuGet.Services.Entities/Extensions/ExceptionExtensions.cs
+++ b/src/NuGet.Services.Entities/Extensions/ExceptionExtensions.cs
@@ -3,7 +3,7 @@
 
 using System;
 using System.Data;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 
 namespace NuGet.Services.Entities
 {

--- a/src/NuGet.Services.Entities/NuGet.Services.Entities.csproj
+++ b/src/NuGet.Services.Entities/NuGet.Services.Entities.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="NuGet.Frameworks" />
     <PackageReference Include="System.ComponentModel.Annotations" />
     <!-- This was lifted to a top-level dependency to resolve a Component Governance alert. -->
-    <PackageReference Include="System.Data.SqlClient" />
+    <PackageReference Include="Microsoft.Data.SqlClient" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NuGet.Services.Sql/AzureSqlConnectionFactory.cs
+++ b/src/NuGet.Services.Sql/AzureSqlConnectionFactory.cs
@@ -1,9 +1,9 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Data.SqlClient;
 using System.Threading.Tasks;
+using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.Logging;
 using NuGet.Services.KeyVault;
 

--- a/src/NuGet.Services.Sql/AzureSqlConnectionStringBuilder.cs
+++ b/src/NuGet.Services.Sql/AzureSqlConnectionStringBuilder.cs
@@ -1,11 +1,11 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using System.ComponentModel;
 using System.Data.Common;
-using System.Data.SqlClient;
 using System.Globalization;
+using Microsoft.Data.SqlClient;
 
 namespace NuGet.Services.Sql
 {

--- a/src/NuGet.Services.Sql/ISqlConnectionFactory.cs
+++ b/src/NuGet.Services.Sql/ISqlConnectionFactory.cs
@@ -1,8 +1,8 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Data.SqlClient;
 using System.Threading.Tasks;
+using Microsoft.Data.SqlClient;
 
 namespace NuGet.Services.Sql
 {

--- a/src/NuGet.Services.Sql/NuGet.Services.Sql.csproj
+++ b/src/NuGet.Services.Sql/NuGet.Services.Sql.csproj
@@ -6,11 +6,8 @@
     <Description>Azure SQL access for NuGet services</Description>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="System.Data.SqlClient" />
-  </ItemGroup>
-
   <ItemGroup>
+    <PackageReference Include="Microsoft.Data.SqlClient" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
     <PackageReference Include="Microsoft.Identity.Client" />
   </ItemGroup>

--- a/src/NuGet.Services.Validation/Entities/EntitiesConfiguration.cs
+++ b/src/NuGet.Services.Validation/Entities/EntitiesConfiguration.cs
@@ -18,8 +18,8 @@ namespace NuGet.Services.Validation
             // Configure Connection Resiliency / Retry Logic
             // See https://msdn.microsoft.com/en-us/data/dn456835.aspx and https://msdn.microsoft.com/en-us/data/dn307226
             SetExecutionStrategy(
-                "System.Data.SqlClient",
-                () => SuspendExecutionStrategy ? (IDbExecutionStrategy)new DefaultExecutionStrategy() : new SqlAzureExecutionStrategy());
+                MicrosoftSqlProviderServices.ProviderInvariantName,
+                () => SuspendExecutionStrategy ? (IDbExecutionStrategy)new DefaultExecutionStrategy() : new MicrosoftSqlAzureExecutionStrategy());
         }
 
         public static bool SuspendExecutionStrategy
@@ -30,7 +30,7 @@ namespace NuGet.Services.Validation
 #else
         public EntitiesConfiguration()
         {
-            SetExecutionStrategy("System.Data.SqlClient", () => new SqlAzureExecutionStrategy());
+            SetExecutionStrategy(MicrosoftSqlProviderServices.ProviderInvariantName, () => new MicrosoftSqlAzureExecutionStrategy());
         }
 #endif
     }

--- a/src/NuGet.Services.Validation/NuGet.Services.Validation.csproj
+++ b/src/NuGet.Services.Validation/NuGet.Services.Validation.csproj
@@ -15,7 +15,7 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Core" />
-    <PackageReference Include="EntityFramework" />
+    <PackageReference Include="Microsoft.EntityFramework.SqlServer" />
     <PackageReference Include="NuGet.Versioning" />
     <PackageReference Include="System.Text.Json" />
   </ItemGroup>

--- a/src/NuGet.Services.Validation/app.config
+++ b/src/NuGet.Services.Validation/app.config
@@ -1,6 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8" ?>
 <configuration>
   <connectionStrings>
-    <add name="Validation.SqlServer" connectionString="Data Source=(localdb)\mssqllocaldb; Initial Catalog=Validation; Integrated Security=True; MultipleActiveResultSets=True" providerName="System.Data.SqlClient" />
+    <add name="Validation.SqlServer" connectionString="Data Source=(localdb)\mssqllocaldb; Initial Catalog=Validation; Integrated Security=True; MultipleActiveResultSets=True" providerName="Microsoft.Data.SqlClient" />
   </connectionStrings>
 </configuration>

--- a/src/NuGetGallery.Core/Entities/DatabaseWrapper.cs
+++ b/src/NuGetGallery.Core/Entities/DatabaseWrapper.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -33,7 +33,7 @@ namespace NuGetGallery
         /// </summary>
         /// <param name="name">Resource name</param>
         /// <param name="parameters">SQL parameters</param>
-        /// <returns>Resulting <see cref="System.Data.SqlClient.SqlDataReader.RecordsAffected"/></returns>
+        /// <returns>Resulting <see cref="Microsoft.Data.SqlClient.SqlDataReader.RecordsAffected"/></returns>
         public async Task<int> ExecuteSqlResourceAsync(string name, params object[] parameters)
         {
             string sqlCommand;

--- a/src/NuGetGallery.Core/Entities/EntitiesConfiguration.cs
+++ b/src/NuGetGallery.Core/Entities/EntitiesConfiguration.cs
@@ -18,8 +18,10 @@ namespace NuGetGallery
         {
             // Configure Connection Resiliency / Retry Logic
             // See https://msdn.microsoft.com/en-us/data/dn456835.aspx and msdn.microsoft.com/en-us/data/dn307226
-            SetExecutionStrategy("System.Data.SqlClient", () => SuspendExecutionStrategy
-                ? (IDbExecutionStrategy)new DefaultExecutionStrategy() : new SqlAzureExecutionStrategy());
+            SetExecutionStrategy(MicrosoftSqlProviderServices.ProviderInvariantName, () => SuspendExecutionStrategy
+                ? (IDbExecutionStrategy)new DefaultExecutionStrategy() : new MicrosoftSqlAzureExecutionStrategy());
+            SetProviderFactory(MicrosoftSqlProviderServices.ProviderInvariantName, Microsoft.Data.SqlClient.SqlClientFactory.Instance);
+            SetProviderServices(MicrosoftSqlProviderServices.ProviderInvariantName, MicrosoftSqlProviderServices.Instance);
         }
 
         public static bool SuspendExecutionStrategy
@@ -38,7 +40,7 @@ namespace NuGetGallery
         {
             // Configure Connection Resiliency / Retry Logic
             // See https://msdn.microsoft.com/en-us/data/dn456835.aspx and msdn.microsoft.com/en-us/data/dn307226
-            SetExecutionStrategy("System.Data.SqlClient", () => new SqlAzureExecutionStrategy());
+            SetExecutionStrategy(MicrosoftSqlProviderServices.ProviderInvariantName, () => new MicrosoftSqlAzureExecutionStrategy());
         }
 #endif
     }

--- a/src/NuGetGallery.Core/Extensions/EntitiesContextExtensions.cs
+++ b/src/NuGetGallery.Core/Extensions/EntitiesContextExtensions.cs
@@ -1,9 +1,9 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Data.SqlClient;
 using System.Threading.Tasks;
+using Microsoft.Data.SqlClient;
 using NuGet.Services.Entities;
 
 namespace NuGetGallery

--- a/src/NuGetGallery.Core/NuGetGallery.Core.csproj
+++ b/src/NuGetGallery.Core/NuGetGallery.Core.csproj
@@ -43,7 +43,7 @@
     <PackageReference Include="Azure.Core" />
     <PackageReference Include="Azure.Identity" />
     <PackageReference Include="Azure.Storage.Blobs" />
-    <PackageReference Include="EntityFramework" />
+    <PackageReference Include="Microsoft.EntityFramework.SqlServer" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" />
     <PackageReference Include="NuGet.Packaging" />
     <PackageReference Include="System.Formats.Asn1" />

--- a/src/NuGetGallery/Areas/Admin/DynamicData/DynamicDataManager.cs
+++ b/src/NuGetGallery/Areas/Admin/DynamicData/DynamicDataManager.cs
@@ -1,12 +1,12 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Data;
 using System.Data.Common;
-using System.Data.SqlClient;
 using System.Threading.Tasks;
 using System.Web.DynamicData;
 using System.Web.Routing;
+using Microsoft.Data.SqlClient;
 using Microsoft.AspNet.DynamicData.ModelProviders;
 using NuGet.Services.Sql;
 

--- a/src/NuGetGallery/Controllers/ApiController.cs
+++ b/src/NuGetGallery/Controllers/ApiController.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Collections.Generic;
 using System.Data;
-using System.Data.SqlClient;
 using System.Globalization;
 using System.IO;
 using System.IO.Compression;
@@ -14,6 +13,7 @@ using System.Net;
 using System.Threading.Tasks;
 using System.Web;
 using System.Web.Mvc;
+using Microsoft.Data.SqlClient;
 using Newtonsoft.Json.Linq;
 using NuGet.Frameworks;
 using NuGet.Packaging;

--- a/src/NuGetGallery/Infrastructure/Lucene/LuceneIndexingJob.cs
+++ b/src/NuGetGallery/Infrastructure/Lucene/LuceneIndexingJob.cs
@@ -1,10 +1,10 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using System.Data;
-using System.Data.SqlClient;
 using System.Threading.Tasks;
+using Microsoft.Data.SqlClient;
 using WebBackgrounder;
 
 namespace NuGetGallery

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -2214,7 +2214,6 @@
     <PackageReference Include="NuGet.StrongName.DynamicData.EFCodeFirstProvider" />
     <PackageReference Include="NuGet.StrongName.elmah.sqlserver" />
     <PackageReference Include="NuGet.StrongName.elmah" />
-    <PackageReference Include="EntityFramework" />
     <PackageReference Include="HtmlSanitizer" />
     <PackageReference Include="Lucene.Net" />
     <PackageReference Include="Lucene.Net.Contrib" />
@@ -2236,6 +2235,8 @@
     <PackageReference Include="Microsoft.AspNetCore.Cryptography.Internal" />
     <PackageReference Include="Microsoft.Bcl.Compression" />
     <PackageReference Include="Microsoft.Data.Services" />
+    <PackageReference Include="Microsoft.Data.SqlClient" />
+    <PackageReference Include="Microsoft.EntityFramework.SqlServer" />
     <PackageReference Include="Microsoft.Extensions.Logging" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
     <PackageReference Include="Microsoft.Net.Http" />
@@ -2249,7 +2250,6 @@
     <PackageReference Include="RouteMagic" />
     <PackageReference Include="SharpZipLib" />
     <PackageReference Include="Strathweb.CacheOutput.WebApi2.StrongName" />
-    <PackageReference Include="System.Data.SqlClient" />
     <PackageReference Include="System.Diagnostics.Debug" />
     <PackageReference Include="System.Linq.Expressions" />
     <PackageReference Include="System.Net.Http" />

--- a/src/NuGetGallery/Services/PackageDeleteService.cs
+++ b/src/NuGetGallery/Services/PackageDeleteService.cs
@@ -3,9 +3,9 @@
 
 using System;
 using System.Collections.Generic;
-using System.Data.SqlClient;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.Data.SqlClient;
 using NuGet.Services.Entities;
 using NuGet.Versioning;
 using NuGetGallery.Auditing;

--- a/src/NuGetGallery/Services/PackageUploadService.cs
+++ b/src/NuGetGallery/Services/PackageUploadService.cs
@@ -3,9 +3,9 @@
 
 using System;
 using System.Data.Entity.Infrastructure;
-using System.Data.SqlClient;
 using System.IO;
 using System.Threading.Tasks;
+using Microsoft.Data.SqlClient;
 using NuGet.Packaging;
 using NuGet.Services.Entities;
 using NuGetGallery.Diagnostics;

--- a/src/NuGetGallery/Web.config
+++ b/src/NuGetGallery/Web.config
@@ -214,9 +214,9 @@
     <add key="Gallery.CspReportUri" value=""/>
   </appSettings>
   <connectionStrings>
-    <add name="Gallery.SqlServer" connectionString="Data Source=(localdb)\mssqllocaldb; Initial Catalog=NuGetGallery; Integrated Security=True; MultipleActiveResultSets=True" providerName="System.Data.SqlClient"/>
-    <add name="Gallery.SupportRequestSqlServer" connectionString="Data Source=(localdb)\mssqllocaldb; Initial Catalog=SupportRequest; Integrated Security=True; MultipleActiveResultSets=True" providerName="System.Data.SqlClient"/>
-    <add name="Gallery.ValidationSqlServer" connectionString="Data Source=(localdb)\mssqllocaldb; Initial Catalog=Validation; Integrated Security=True; MultipleActiveResultSets=True" providerName="System.Data.SqlClient"/>
+    <add name="Gallery.SqlServer" connectionString="Data Source=(localdb)\mssqllocaldb; Initial Catalog=NuGetGallery; Integrated Security=True; MultipleActiveResultSets=True" providerName="Microsoft.Data.SqlClient"/>
+    <add name="Gallery.SupportRequestSqlServer" connectionString="Data Source=(localdb)\mssqllocaldb; Initial Catalog=SupportRequest; Integrated Security=True; MultipleActiveResultSets=True" providerName="Microsoft.Data.SqlClient"/>
+    <add name="Gallery.ValidationSqlServer" connectionString="Data Source=(localdb)\mssqllocaldb; Initial Catalog=Validation; Integrated Security=True; MultipleActiveResultSets=True" providerName="Microsoft.Data.SqlClient"/>
   </connectionStrings>
   <!-- Configure paths containing static files -->
   <location path="Content">
@@ -283,7 +283,7 @@
   -->
   <system.web>
     <httpCookies requireSSL="true" httpOnlyCookies="true"/>
-    <compilation debug="false" targetFramework="4.7.2">
+    <compilation debug="true" targetFramework="4.7.2">
       <assemblies>
         <add assembly="netstandard, Version=2.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51"/>
       </assemblies>
@@ -518,13 +518,8 @@
     </extensions>
   </system.serviceModel>
   <entityFramework codeConfigurationType="NuGetGallery.EntitiesConfiguration, NuGetGallery.Core">
-    <defaultConnectionFactory type="System.Data.Entity.Infrastructure.SqlConnectionFactory, EntityFramework">
-      <parameters>
-        <parameter value="Data Source=(LocalDB)\mssqllocaldb;Initial Catalog=NuGetGallery;Integrated Security=SSPI"/>
-      </parameters>
-    </defaultConnectionFactory>
     <providers>
-      <provider invariantName="System.Data.SqlClient" type="System.Data.Entity.SqlServer.SqlProviderServices, EntityFramework.SqlServer"/>
+      <provider invariantName="Microsoft.Data.SqlClient" type="System.Data.Entity.SqlServer.MicrosoftSqlProviderServices, Microsoft.EntityFramework.SqlServer"/>
     </providers>
   </entityFramework>
   <system.diagnostics>
@@ -536,6 +531,10 @@
   </system.diagnostics>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+			<dependentAssembly>
+				<assemblyIdentity name="System.Security.AccessControl" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0"/>
+			</dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Identity.Client" publicKeyToken="0A613F4DD989E8AE" culture="neutral"/>
         <bindingRedirect oldVersion="0.0.0.0-4.67.2.0" newVersion="4.67.2.0"/>

--- a/src/Validation.Common.Job/ExceptionExtensions.cs
+++ b/src/Validation.Common.Job/ExceptionExtensions.cs
@@ -1,9 +1,9 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Data.Entity.Infrastructure;
-using System.Data.SqlClient;
 using System.Linq;
+using Microsoft.Data.SqlClient;
 
 namespace NuGet.Jobs.Validation
 {

--- a/tests/NuGet.Services.DatabaseMigration.Facts/PendingMigrationsFacts.cs
+++ b/tests/NuGet.Services.DatabaseMigration.Facts/PendingMigrationsFacts.cs
@@ -1,13 +1,13 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using System.Collections.Generic;
 using System.Data.Entity.Migrations.Design;
-using System.Data.SqlClient;
 using System.Linq;
 using System.Threading.Tasks;
 using Moq;
+using Microsoft.Data.SqlClient;
 using NuGet.Jobs;
 using NuGet.Jobs.Configuration;
 using NuGetGallery.DatabaseMigrationTools;

--- a/tests/NuGet.Services.Sql.Tests/AzureSqlConnectionFactoryFacts.cs
+++ b/tests/NuGet.Services.Sql.Tests/AzureSqlConnectionFactoryFacts.cs
@@ -1,9 +1,9 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Data.SqlClient;
 using System.Threading.Tasks;
+using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Xunit;

--- a/tests/NuGet.Services.Sql.Tests/AzureSqlConnectionStringBuilderFacts.cs
+++ b/tests/NuGet.Services.Sql.Tests/AzureSqlConnectionStringBuilderFacts.cs
@@ -1,7 +1,7 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using Xunit;
 
 namespace NuGet.Services.Sql.Tests

--- a/tests/NuGet.Services.Sql.Tests/MockFactory.cs
+++ b/tests/NuGet.Services.Sql.Tests/MockFactory.cs
@@ -1,9 +1,9 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Data.SqlClient;
 using System.Threading.Tasks;
 using Moq;
+using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.Logging;
 using NuGet.Services.KeyVault;
 

--- a/tests/NuGet.Services.Validation.Tests/PendingMigrationsTests.cs
+++ b/tests/NuGet.Services.Validation.Tests/PendingMigrationsTests.cs
@@ -1,13 +1,13 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using System.Data.Entity.Infrastructure;
 using System.Data.Entity.Migrations;
 using System.Data.Entity.Migrations.Design;
-using System.Data.SqlClient;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.Data.SqlClient;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -58,7 +58,7 @@ namespace NuGet.Services.Validation.Tests
 
             var migrationsConfiguration = new ValidationMigrationsConfiguration
             {
-                TargetDatabase = new DbConnectionInfo(connectionString, "System.Data.SqlClient"),
+                TargetDatabase = new DbConnectionInfo(connectionString, "Microsoft.Data.SqlClient"),
             };
 
             var dbMigrator = new DbMigrator(migrationsConfiguration);

--- a/tests/NuGetGallery.Core.Facts/app.config
+++ b/tests/NuGetGallery.Core.Facts/app.config
@@ -8,13 +8,8 @@
     <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2"/>
   </startup>
   <entityFramework>
-    <defaultConnectionFactory type="System.Data.Entity.Infrastructure.LocalDbConnectionFactory, EntityFramework">
-      <parameters>
-        <parameter value="mssqllocaldb"/>
-      </parameters>
-    </defaultConnectionFactory>
     <providers>
-      <provider invariantName="System.Data.SqlClient" type="System.Data.Entity.SqlServer.SqlProviderServices, EntityFramework.SqlServer"/>
+      <provider invariantName="Microsoft.Data.SqlClient" type="System.Data.Entity.SqlServer.MicrosoftSqlProviderServices, Microsoft.EntityFramework.SqlServer" />
     </providers>
   </entityFramework>
 </configuration>

--- a/tests/NuGetGallery.Facts/App_Start/DefaultDependenciesModuleFacts.cs
+++ b/tests/NuGetGallery.Facts/App_Start/DefaultDependenciesModuleFacts.cs
@@ -1,9 +1,8 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using System.Collections.Generic;
-using System.Data.SqlClient;
 using Microsoft.ApplicationInsights.DependencyCollector;
 using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.ApplicationInsights.Extensibility.Implementation.ApplicationId;
@@ -11,6 +10,7 @@ using Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector.QuickPuls
 using Microsoft.ApplicationInsights.Web;
 using Microsoft.ApplicationInsights.WindowsServer;
 using Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel;
+using Microsoft.Data.SqlClient;
 using Moq;
 using NuGet.Services.Logging;
 using NuGet.Services.Sql;

--- a/tests/NuGetGallery.Facts/Authentication/Federated/FederatedCredentialServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Authentication/Federated/FederatedCredentialServiceFacts.cs
@@ -5,10 +5,10 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Data.Entity.Infrastructure;
-using System.Data.SqlClient;
 using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
+using Microsoft.Data.SqlClient;
 using Moq;
 using NuGet.Services.Entities;
 using NuGetGallery.Auditing;
@@ -563,7 +563,16 @@ namespace NuGetGallery.Services.Authentication
                 typeof(SqlError),
                 BindingFlags.NonPublic | BindingFlags.Instance,
                 binder: null,
-                args: [sqlErrorCode, (byte)2, (byte)3, "server", "error", "procedure", 4],
+                args: [
+                    sqlErrorCode, /* infoNumber */
+                    (byte)2, /* errorState */
+                    (byte)3, /* errorClass */
+                    "server", /* server */
+                    "error", /* errorMessage */
+                    "procedure", /* procedure */
+                    4, /* lineNumber */
+                    null /* exception */
+                    ],
                 culture: null);
             var sqlErrorCollection = (SqlErrorCollection)Activator.CreateInstance(typeof(SqlErrorCollection), nonPublic: true);
             typeof(SqlErrorCollection)

--- a/tests/NuGetGallery.Facts/Services/PackageDeleteServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/PackageDeleteServiceFacts.cs
@@ -1,12 +1,12 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using System.Collections.Generic;
-using System.Data.SqlClient;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.Data.SqlClient;
 using Moq;
 using NuGet.Services.Entities;
 using NuGetGallery.Auditing;

--- a/tools/AzureSqlConnectionTest/TestRunner.cs
+++ b/tools/AzureSqlConnectionTest/TestRunner.cs
@@ -1,13 +1,13 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using System.Collections.Generic;
 using System.Data;
-using System.Data.SqlClient;
 using System.Linq;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
+using Microsoft.Data.SqlClient;
 using Microsoft.Identity.Client;
 using NuGet.Services.KeyVault;
 using NuGet.Services.Sql;


### PR DESCRIPTION
Summary of the changes (in less than 80 characters):

* Use the "modern" Entity Framework SQL Server provider
* Could enable NuGet.Services.Sql to be removed?

Addresses https://github.com/NuGet/NuGetGallery/issues/10416