### PR TITLE
[HotFix]: Fix base address and blob uri decoding mismatch

### DIFF
--- a/src/Catalog/Persistence/Storage.cs
+++ b/src/Catalog/Persistence/Storage.cs
@@ -192,22 +192,22 @@ namespace NuGet.Services.Metadata.Catalog.Persistence
                 throw new InvalidOperationException("BaseAddress must be set.");
             }
 
-            string address = Uri.UnescapeDataString(BaseAddress.GetLeftPart(UriPartial.Path));
+            // The GetLeftPart method performs encoding under the hood, which could be problematic if it contains Unicode characters.
+            // It doesn't perform double encoding; the Uri object knows if it's already encoded and skips encoding it again.
+            // Decoding the base address to remove any encoded characters.
+            string address = Uri.UnescapeDataString(BaseAddress.GetLeftPart(UriPartial.Path)); // Remove potential query or SAS from the URI
             if (!address.EndsWith("/"))
             {
                 address += "/";
             }
 
-            // This method does encoding under the hood, could be a problem if it contains Unicode characters.
-            string fullPath = uri.GetLeftPart(UriPartial.Path); // Remove potential SAS token from the URI
+            // Do the same with the above to get it decoded.
+            string fullPath = Uri.UnescapeDataString(uri.GetLeftPart(UriPartial.Path)); // Remove potential query or SAS from the URI
 
             // handle mismatched scheme (http vs https)
             int schemeLengthDifference = uri.Scheme.Length - BaseAddress.Scheme.Length;
 
-            string encodedName = fullPath.Substring(address.Length + schemeLengthDifference);
-
-            // decode back previous encoding in case of Unicode characters, otherwise it will be double encoded later
-            string name = Uri.UnescapeDataString(encodedName);
+            string name = fullPath.Substring(address.Length + schemeLengthDifference);
 
             if (name.Contains("#"))
             {

--- a/src/Catalog/Persistence/Storage.cs
+++ b/src/Catalog/Persistence/Storage.cs
@@ -180,7 +180,7 @@ namespace NuGet.Services.Metadata.Catalog.Persistence
             return Task.FromResult(false);
         }
 
-        protected string GetName(Uri uri)
+        public string GetName(Uri uri)
         {
             if (uri is null)
             { 

--- a/tests/CatalogTests/Persistence/StorageTests.cs
+++ b/tests/CatalogTests/Persistence/StorageTests.cs
@@ -11,8 +11,24 @@ namespace CatalogTests.Persistence
     public class StorageTests
     {
         [Theory]
+        [InlineData("package.1.0.0.nupkg", "http://contoso.blob.core.windows.net/packages/package.1.0.0.nupkg")]
+        [InlineData("123.8.0.0-preview.7.23368.14.nupkg", "http://contoso.blob.core.windows.net/packages/123.8.0.0-preview.7.23368.14.nupkg")]
+        public void GetUri_ReturnsCorrectUri(string name, string expectedUri)
+        {
+            // Arrange
+            Uri baseAddress = new Uri("http://contoso.blob.core.windows.net/packages/");
+            var storage = new Mock<Storage>(baseAddress) { CallBase = true };
+
+            // Act
+            string uri = storage.Object.GetUri(name).AbsoluteUri;
+
+            // Assert
+            Assert.Equal(expectedUri, uri);
+        }
+
+        [Theory]
         [InlineData("http://contoso.blob.core.windows.net/packages/package.1.0.0.nupkg", "package.1.0.0.nupkg")]
-        [InlineData("http://contoso.blob.core.windows.net/packages/another-package123.2.0.0.nupkg", "another-package123.2.0.0.nupkg")]
+        [InlineData("http://contoso.blob.core.windows.net/packages/123.8.0.0-preview.7.23368.14.nupkg", "123.8.0.0-preview.7.23368.14.nupkg")]
         public void GetName_NonUnicodeUri_ReturnsCorrectName(string uriString, string expectedName)
         {
             // Arrange
@@ -21,10 +37,10 @@ namespace CatalogTests.Persistence
             var uri = new Uri(uriString);
 
             // Act
-            var name = storage.Object.GetUri(expectedName).ToString();
+            var name = storage.Object.GetName(uri).ToString();
 
             // Assert
-            Assert.EndsWith(expectedName, name);
+            Assert.Equal(expectedName, name);
         }
 
         [Theory]
@@ -39,10 +55,113 @@ namespace CatalogTests.Persistence
             var uri = new Uri(uriString);
 
             // Act
-            var name = storage.Object.GetUri(expectedName).ToString();
+            var name = storage.Object.GetName(uri).ToString();
 
             // Assert
-            Assert.EndsWith(expectedName, name);
+            Assert.Equal(expectedName, name);
+        }
+
+        [Theory]
+        [InlineData(
+            "https://contoso.blob.core.windows.net/v3-flatcontainer/package123/",
+            "https://contoso.blob.core.windows.net/v3-flatcontainer/package123/2.1.0/package123.nuspec",
+            "2.1.0/package123.nuspec")]
+        [InlineData(
+            "https://contoso.blob.core.windows.net/v3-flatcontainer/пакет123/",
+            "https://contoso.blob.core.windows.net/v3-flatcontainer/пакет123/2.1.0/пакет123.nuspec",
+            "2.1.0/пакет123.nuspec")]
+        [InlineData(
+            "https://contoso.blob.core.windows.net/v3-flatcontainer/%D0%BF%D0%B0%D0%BA%D0%B5%D1%82123/",
+            "https://contoso.blob.core.windows.net/v3-flatcontainer/%D0%BF%D0%B0%D0%BA%D0%B5%D1%82123/2.1.0/%D0%BF%D0%B0%D0%BA%D0%B5%D1%82123.nuspec",
+            "2.1.0/пакет123.nuspec")]
+        [InlineData(
+            "https://contoso.blob.core.windows.net/v3-flatcontainer/пакет123/",
+            "https://contoso.blob.core.windows.net/v3-flatcontainer/%D0%BF%D0%B0%D0%BA%D0%B5%D1%82123/2.1.0/%D0%BF%D0%B0%D0%BA%D0%B5%D1%82123.nuspec",
+            "2.1.0/пакет123.nuspec")]
+        [InlineData(
+            "https://contoso.blob.core.windows.net/v3-flatcontainer/%D0%BF%D0%B0%D0%BA%D0%B5%D1%82123/",
+            "https://contoso.blob.core.windows.net/v3-flatcontainer/пакет123/2.1.0/%D0%BF%D0%B0%D0%BA%D0%B5%D1%82123.nuspec",
+            "2.1.0/пакет123.nuspec")]
+        [InlineData(
+            "https://contoso.blob.core.windows.net/v3-flatcontainer/%D0%BF%D0%B0%D0%BA%D0%B5%D1%82123/",
+            "https://contoso.blob.core.windows.net/v3-flatcontainer/пакет123/2.1.0/пакет123.nuspec",
+            "2.1.0/пакет123.nuspec")]
+        [InlineData(
+            "https://contoso.blob.core.windows.net/v3-flatcontainer/пакет123/",
+            "https://contoso.blob.core.windows.net/v3-flatcontainer/%D0%BF%D0%B0%D0%BA%D0%B5%D1%82123/2.1.0/пакет123.nuspec",
+            "2.1.0/пакет123.nuspec")]
+        public void GetName_EncodedAndDecodedUnicodeUris_ReturnsCorrectName(string baseAddressString, string uriString, string expectedName)
+        {
+            // Arrange
+            Uri baseAddress = new Uri(baseAddressString);
+            var storage = new Mock<Storage>(baseAddress) { CallBase = true };
+            var uri = new Uri(uriString);
+
+            // Act
+            var name = storage.Object.GetName(uri).ToString();
+
+            // Assert
+            Assert.Equal(expectedName, name);
+        }
+
+
+        [Theory]
+        [InlineData(
+            "https://contoso.blob.core.windows.net/v3-flatcontainer/package123/",
+            "https://contoso.blob.core.windows.net/v3-flatcontainer/package123/2.1.0/package123.nuspec?sv=2019-12-12&ss=b&srt=co&sp=rlx&se=2023-01-01T00:00:00Z&st=2022-01-01T00:00:00Z&spr=https&sig=abcdef123456",
+            "2.1.0/package123.nuspec")]
+        [InlineData(
+            "https://contoso.blob.core.windows.net/v3-flatcontainer/пакет123/",
+            "https://contoso.blob.core.windows.net/v3-flatcontainer/пакет123/2.1.0/пакет123.nuspec?sv=2019-12-12&ss=b&srt=co&sp=rlx&se=2023-01-01T00:00:00Z&st=2022-01-01T00:00:00Z&spr=https&sig=abcdef123456",
+            "2.1.0/пакет123.nuspec")]
+        public void GetName_UriWithSasToken_RemovesSasTokenAndReturnsCorrectName(string baseAddressString, string uriString, string expectedName)
+        {
+            // Arrange
+            Uri baseAddress = new Uri(baseAddressString);
+            var storage = new Mock<Storage>(baseAddress) { CallBase = true };
+            var uri = new Uri(uriString);
+
+            // Act
+            var name = storage.Object.GetName(uri).ToString();
+
+            // Assert
+            Assert.Equal(expectedName, name);
+        }
+
+        [Theory]
+        [InlineData("http://contoso.blob.core.windows.net/packages/", "https://contoso.blob.core.windows.net/packages/package.1.0.0.nupkg", "package.1.0.0.nupkg")]
+        [InlineData("https://contoso.blob.core.windows.net/packages/", "http://contoso.blob.core.windows.net/packages/package.1.0.0.nupkg", "package.1.0.0.nupkg")]
+        public void GetName_DifferentSchemes_HandlesSchemeDifferenceCorrectly(string baseAddressString, string uriString, string expectedName)
+        {
+            // Arrange
+            Uri baseAddress = new Uri(baseAddressString);
+            var storage = new Mock<Storage>(baseAddress) { CallBase = true };
+            var uri = new Uri(uriString);
+
+            // Act
+            var name = storage.Object.GetName(uri).ToString();
+
+            // Assert
+            Assert.Equal(expectedName, name);
+        }
+
+        [Theory]
+        [InlineData("https://contoso.blob.core.windows.net/v3-flatcontainer/пакет.2.0.0.nupkg#/metadata/core-properties", "пакет.2.0.0.nupkg")]
+        [InlineData("https://contoso.blob.core.windows.net/v3-flatcontainer/пакет.2.0.0.nupkg#/metadata/core-properties/", "пакет.2.0.0.nupkg")]
+        [InlineData("https://contoso.blob.core.windows.net/v3-flatcontainer/package123.2.0.0.nupkg#/metadata/core-properties", "package123.2.0.0.nupkg")]
+        [InlineData("https://contoso.blob.core.windows.net/v3-flatcontainer/package123.2.0.0.nupkg#/metadata/core-properties/", "package123.2.0.0.nupkg")]
+        public void GetName_UriWithFragment_RemovesFragmentAndReturnsCorrectName(string uriString, string expectedName)
+        {
+            // Arrange
+            Uri baseAddress = new Uri("https://contoso.blob.core.windows.net/v3-flatcontainer/");
+            var storage = new Mock<Storage>(baseAddress) { CallBase = true };
+            var uri = new Uri(uriString);
+
+            // Act
+            var name = storage.Object.GetName(uri).ToString();
+
+            // Assert
+            Assert.Equal(expectedName, name);
         }
     }
 }


### PR DESCRIPTION
Fix https://github.com/NuGet/Engineering/issues/5850

Follow up on https://github.com/NuGet/NuGetGallery/discussions/10410#discussioncomment-12947574
Previously https://github.com/NuGet/NuGetGallery/pull/10417 fixed double encoding problem for blob name for `db2catalog` job, but the `catalog2dnx` job was getting miscalculated length blob name because the base address was still encoded while the blob URI was decoded. Now, we decode/unescape both of them to avoid such mismatches.

Added matrix unit tests ensure that, regardless of whether the base address or blob URI have the same or mismatched encoding, we can still get the correct blob name. 
We leverage the fact that .GetLeftPart doesn't encode characters that are already encoded, although this behavior is not documented https://github.com/dotnet/dotnet-api-docs/issues/11254

Tested on `dev` deployment: 
Unicode package: https://dev.nugettest.org/packages/%E9%82%AE%E4%BB%B63/1.1.0 
![image](https://github.com/user-attachments/assets/d01f3b5e-ab16-4400-a6fc-51508e7d737f)

