### PR TITLE
Handle 404 exceptions in StatusAggregator

### DIFF
--- a/tests/StatusAggregator.Tests/Messages/MessageFactoryTests.cs
+++ b/tests/StatusAggregator.Tests/Messages/MessageFactoryTests.cs
@@ -1,13 +1,15 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using System.Threading.Tasks;
+using Azure;
 using Azure.Data.Tables;
 using Microsoft.Extensions.Logging;
 using Moq;
 using NuGet.Services.Status;
 using NuGet.Services.Status.Table;
+using Serilog.Core;
 using StatusAggregator.Messages;
 using StatusAggregator.Table;
 using Xunit;
@@ -101,10 +103,10 @@ namespace StatusAggregator.Tests.Messages
                 Builder
                     .Setup(x => x.Build(type, component, expectedStatus))
                     .Returns(contents);
-                
+
                 Table
                     .Setup(x => x.RetrieveAsync<MessageEntity>(MessageEntity.GetRowKey(EventEntity, Time)))
-                    .ReturnsAsync((MessageEntity)null)
+                    .ThrowsAsync(new RequestFailedException(404, "Not Found"))
                     .Verifiable();
 
                 Table
@@ -129,6 +131,70 @@ namespace StatusAggregator.Tests.Messages
 
                 Table.Verify();
             }
+
+            /*
+            [Fact]
+            public async Task CreateMessageAsync_HandlesRequestFailedException_WhenMessageNotFound()
+            {
+                // Arrange
+                var type = (MessageType)99;
+                var status = (ComponentStatus)100;
+                var component = new TestComponent("component")
+                {
+                    Status = ComponentStatus.Up
+                };
+
+                Table
+                    .Setup(x => x.RetrieveAsync<MessageEntity>(MessageEntity.GetRowKey(EventEntity, Time)))
+                    .ThrowsAsync(new RequestFailedException(404, "Not Found"))
+                    .Verifiable();
+
+                Logger
+                    .Setup(x => x.LogInformation(
+                        It.IsAny<string>(),
+                        It.IsAny<object[]>()
+                    ))
+                    .Verifiable();
+
+                // Act
+                await Factory.CreateMessageAsync(EventEntity, Time, type, component, status);
+
+                // Assert
+                Table.Verify();
+                Logger.Verify(x => x.LogInformation("No existing message found."), Times.Once());
+            }
+
+            [Fact]
+            public async Task CreateMessageAsync_DoesNotRecreate_WhenMessageExists()
+            {
+                // Arrange
+                var type = (MessageType)99;
+                var status = (ComponentStatus)100;
+                var component = new TestComponent("component")
+                {
+                    Status = ComponentStatus.Up
+                };
+
+                var existingMessage = new MessageEntity(EventEntity, Time, "existing", (MessageType)98);
+
+                Table
+                    .Setup(x => x.RetrieveAsync<MessageEntity>(MessageEntity.GetRowKey(EventEntity, Time)))
+                    .ReturnsAsync(existingMessage)
+                    .Verifiable();
+
+                // Act
+                await Factory.CreateMessageAsync(EventEntity, Time, type, component, status);
+
+                // Assert
+                Table.Verify();
+                Builder.Verify(
+                    x => x.Build(It.IsAny<MessageType>(), It.IsAny<IComponent>(), It.IsAny<ComponentStatus>()),
+                    Times.Never());
+                Table.Verify(
+                    x => x.InsertAsync(It.IsAny<MessageEntity>()),
+                    Times.Never());
+            }
+            */
 
             protected abstract Task InvokeMethod(
                 EventEntity eventEntity,

--- a/tests/StatusAggregator.Tests/Messages/MessageFactoryTests.cs
+++ b/tests/StatusAggregator.Tests/Messages/MessageFactoryTests.cs
@@ -9,7 +9,6 @@ using Microsoft.Extensions.Logging;
 using Moq;
 using NuGet.Services.Status;
 using NuGet.Services.Status.Table;
-using Serilog.Core;
 using StatusAggregator.Messages;
 using StatusAggregator.Table;
 using Xunit;
@@ -131,70 +130,6 @@ namespace StatusAggregator.Tests.Messages
 
                 Table.Verify();
             }
-
-            /*
-            [Fact]
-            public async Task CreateMessageAsync_HandlesRequestFailedException_WhenMessageNotFound()
-            {
-                // Arrange
-                var type = (MessageType)99;
-                var status = (ComponentStatus)100;
-                var component = new TestComponent("component")
-                {
-                    Status = ComponentStatus.Up
-                };
-
-                Table
-                    .Setup(x => x.RetrieveAsync<MessageEntity>(MessageEntity.GetRowKey(EventEntity, Time)))
-                    .ThrowsAsync(new RequestFailedException(404, "Not Found"))
-                    .Verifiable();
-
-                Logger
-                    .Setup(x => x.LogInformation(
-                        It.IsAny<string>(),
-                        It.IsAny<object[]>()
-                    ))
-                    .Verifiable();
-
-                // Act
-                await Factory.CreateMessageAsync(EventEntity, Time, type, component, status);
-
-                // Assert
-                Table.Verify();
-                Logger.Verify(x => x.LogInformation("No existing message found."), Times.Once());
-            }
-
-            [Fact]
-            public async Task CreateMessageAsync_DoesNotRecreate_WhenMessageExists()
-            {
-                // Arrange
-                var type = (MessageType)99;
-                var status = (ComponentStatus)100;
-                var component = new TestComponent("component")
-                {
-                    Status = ComponentStatus.Up
-                };
-
-                var existingMessage = new MessageEntity(EventEntity, Time, "existing", (MessageType)98);
-
-                Table
-                    .Setup(x => x.RetrieveAsync<MessageEntity>(MessageEntity.GetRowKey(EventEntity, Time)))
-                    .ReturnsAsync(existingMessage)
-                    .Verifiable();
-
-                // Act
-                await Factory.CreateMessageAsync(EventEntity, Time, type, component, status);
-
-                // Assert
-                Table.Verify();
-                Builder.Verify(
-                    x => x.Build(It.IsAny<MessageType>(), It.IsAny<IComponent>(), It.IsAny<ComponentStatus>()),
-                    Times.Never());
-                Table.Verify(
-                    x => x.InsertAsync(It.IsAny<MessageEntity>()),
-                    Times.Never());
-            }
-            */
 
             protected abstract Task InvokeMethod(
                 EventEntity eventEntity,


### PR DESCRIPTION
StatusAggregator was throwing exceptions because of 404s.

This method is supposed to check if a message already exists in table storage, and then
- if it does exist, it just noops and moves on
- if it doesn't exist, it creates a new message

Previously, I'm guessing we used to get a null response if the message didn't exist, but with the new SDK, it throws a 404 exception. We need to catch this exception and handle it properly.

Tested, and it's working in dev.