### PR TITLE
Replace Assembly.GetExecutingAssembly() with reliable method

### DIFF
--- a/src/Catalog/Helpers/Utils.cs
+++ b/src/Catalog/Helpers/Utils.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -54,7 +54,7 @@ namespace NuGet.Services.Metadata.Catalog
                 throw new ArgumentException(Strings.ArgumentMustNotBeNullOrEmpty, nameof(resourceName));
             }
 
-            var assembly = Assembly.GetExecutingAssembly();
+            Assembly assembly = typeof(Utils).Assembly;
 
             string name = assembly.GetName().Name;
 

--- a/src/NuGet.Services.Validation.Orchestrator/ValidatorProvider.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/ValidatorProvider.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -102,7 +102,7 @@ namespace NuGet.Services.Validation.Orchestrator
 
         private static IEnumerable<Type> GetCandidateTypes(Assembly callingAssembly)
         {
-            var executingAssembly = Assembly.GetExecutingAssembly();
+            Assembly executingAssembly = typeof(ValidatorProvider).Assembly;
             IEnumerable<Type> candidateTypes = executingAssembly.GetTypes();
             if (callingAssembly != executingAssembly)
             {

--- a/src/NuGetGallery.Core/Entities/DatabaseWrapper.cs
+++ b/src/NuGetGallery.Core/Entities/DatabaseWrapper.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -38,7 +38,7 @@ namespace NuGetGallery
         {
             string sqlCommand;
 
-            var assembly = Assembly.GetExecutingAssembly();
+            Assembly assembly = typeof(DatabaseWrapper).Assembly;
             using (var reader = new StreamReader(assembly.GetManifestResourceStream(name)))
             {
                 sqlCommand = await reader.ReadToEndAsync();

--- a/src/NuGetGallery/App_Start/AutofacConfig.cs
+++ b/src/NuGetGallery/App_Start/AutofacConfig.cs
@@ -15,7 +15,7 @@ namespace NuGetGallery
     {
         public static IAppBuilder UseAutofacInjection(this IAppBuilder app, HttpConfiguration httpConfiguration)
         {
-            var currentAssembly = Assembly.GetExecutingAssembly();
+            Assembly currentAssembly = typeof(AutofacConfig).Assembly;
 
             var builder = new ContainerBuilder();
 

--- a/src/NuGetGallery/OData/QueryAllowed/ODataQueryFilter.cs
+++ b/src/NuGetGallery/OData/QueryAllowed/ODataQueryFilter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -43,7 +43,7 @@ namespace NuGetGallery.OData.QueryFilter
         /// <param name="fileName"></param>
         public ODataQueryFilter(string fileName)
         {
-            var assembly = Assembly.GetExecutingAssembly();
+            Assembly assembly = typeof(ODataQueryFilter).Assembly;
             using (var sr = new StreamReader(assembly.GetManifestResourceStream($"{ResourcesNamespace}.{fileName}")))
             {
                 var json = sr.ReadToEnd();


### PR DESCRIPTION
Addresses https://github.com/NuGet/NuGetGallery/issues/10396

In case code inlining happens then Assembly.GetExecutingAssembly().Location may point to wrong location.
So we need to replace with typeof(T).Assembly.Location for reliability. This concern came up during review of another internal repo.
I'm only doing for product code, not for tests.

Previously I have done same change for https://github.com/NuGet/NuGet.Client/pull/5223