### PR TITLE
Reduce database calls for Microsoft profile page from 21.056 to 42

### DIFF
--- a/src/AccountDeleter/EmptyFeatureFlagService.cs
+++ b/src/AccountDeleter/EmptyFeatureFlagService.cs
@@ -333,5 +333,10 @@ namespace NuGetGallery.AccountDeleter
         {
             throw new NotImplementedException();
         }
+
+        public bool IsProfileLoadOptimizationEnabled()
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/src/GitHubVulnerabilities2Db/Fakes/FakeFeatureFlagService.cs
+++ b/src/GitHubVulnerabilities2Db/Fakes/FakeFeatureFlagService.cs
@@ -334,5 +334,10 @@ namespace GitHubVulnerabilities2Db.Fakes
         {
             throw new NotImplementedException();
         }
+
+        public bool IsProfileLoadOptimizationEnabled()
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/src/NuGetGallery.Services/Configuration/FeatureFlagService.cs
+++ b/src/NuGetGallery.Services/Configuration/FeatureFlagService.cs
@@ -65,6 +65,7 @@ namespace NuGetGallery
         private const string AdvancedFrameworkFilteringFeatureName = GalleryPrefix + "AdvancedFrameworkFiltering";
         private const string FederatedCredentialsFeatureName = GalleryPrefix + "FederatedCredentials";
         private const string AsciiOnlyPackageIdFeatureName = GalleryPrefix + "AsciiOnlyPackageId";
+        private const string ProfileLoadOptimization = GalleryPrefix + "ProfileLoadOptimization";
 
         private const string ODataV1GetAllNonHijackedFeatureName = GalleryPrefix + "ODataV1GetAllNonHijacked";
         private const string ODataV1GetAllCountNonHijackedFeatureName = GalleryPrefix + "ODataV1GetAllCountNonHijacked";
@@ -432,6 +433,11 @@ namespace NuGetGallery
         public bool IsAsciiOnlyPackageIdEnabled()
         {
             return _client.IsEnabled(AsciiOnlyPackageIdFeatureName, defaultValue: false);
+        }
+
+        public bool IsProfileLoadOptimizationEnabled()
+        {
+            return _client.IsEnabled(ProfileLoadOptimization, defaultValue: true);
         }
     }
 }

--- a/src/NuGetGallery.Services/Configuration/IFeatureFlagService.cs
+++ b/src/NuGetGallery.Services/Configuration/IFeatureFlagService.cs
@@ -352,5 +352,9 @@ namespace NuGetGallery
         /// Whether or not only ASCII characters are allowed in PackageId, used for temporary block unicode.
         /// </summary>
         bool IsAsciiOnlyPackageIdEnabled();
+
+        /// <summary>
+        /// Whether or not new paging method is used for the profile page.
+        bool IsProfileLoadOptimizationEnabled();
     }
 }

--- a/src/NuGetGallery.Services/PackageManagement/IPackageService.cs
+++ b/src/NuGetGallery.Services/PackageManagement/IPackageService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -106,6 +106,8 @@ namespace NuGetGallery
         IEnumerable<Package> FindPackagesByAnyMatchingOwner(User user, bool includeUnlisted, bool includeVersions = false);
 
         IQueryable<PackageRegistration> FindPackageRegistrationsByOwner(User user);
+
+        (IReadOnlyCollection<Package> Packages, long TotalDownloadCount, int PackageCount) FindPackagesByProfile(User user, int page, int pageSize);
 
         IQueryable<PackageRegistration> GetAllPackageRegistrations();
 

--- a/src/NuGetGallery.Services/PackageManagement/PackageService.cs
+++ b/src/NuGetGallery.Services/PackageManagement/PackageService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -447,6 +447,51 @@ namespace NuGetGallery
             return GetPackagesForOwners(ownerKeys, includeUnlisted, includeVersions);
         }
 
+        public (IReadOnlyCollection<Package> Packages, long TotalDownloadCount, int PackageCount) FindPackagesByProfile(
+            User user,
+            int page,
+            int pageSize)
+        {
+            if (user == null)
+            {
+                throw new ArgumentNullException(nameof(user));
+            }
+
+            IQueryable<Package> packages = _packageRepository.GetAll()
+                .Where(p => p.PackageRegistration.Owners.Any(o => o.Key == user.Key));
+
+            var packageSummary = packages
+                .Where(p => p.IsLatestSemVer2)
+                .Include(p => p.PackageRegistration)
+                .GroupBy(r => 1)
+                .Select(g => new
+                {
+                    PackageCount = g.Sum(x => 1),
+                    DownloadCount = g.Sum(x => x.PackageRegistration.DownloadCount)
+                })
+                .FirstOrDefault();
+
+            var packageCount = packageSummary != null ? packageSummary.PackageCount : 0;
+            var downloadCount = packageSummary != null ? packageSummary.DownloadCount : 0;
+
+            packages = packages
+                .Where(p => p.Listed
+                    && p.PackageStatusKey == PackageStatus.Available);
+
+            packages = GetLatestVersion(packages);
+
+            return (packages
+                .OrderByDescending(p => p.PackageRegistration.DownloadCount)
+                .ThenBy(p => p.PackageRegistration.Id)
+                .Skip((page-1) * pageSize)
+                .Take(pageSize)
+                .Include(p => p.PackageRegistration.Owners)
+                .Include(p => p.PackageRegistration.RequiredSigners)
+                .ToList(),
+                downloadCount,
+                packageCount);
+        }
+
         private IEnumerable<Package> GetPackagesForOwners(IEnumerable<int> ownerKeys, bool includeUnlisted, bool includeVersions)
         {
             IQueryable<Package> packages = _packageRepository.GetAll()
@@ -459,20 +504,7 @@ namespace NuGetGallery
 
             if (!includeVersions)
             {
-                // Do a best effort of retrieving the latest versions. Note that UpdateIsLatest has had concurrency issues
-                // where sometimes packages no rows with IsLatest set. In this case, we'll just select the last inserted
-                // row (descending [Key]) as opposed to reading all rows into memory and sorting on NuGetVersion.
-                packages = packages
-                    .GroupBy(p => p.PackageRegistrationKey)
-                    .Select(g => g
-                        // order booleans desc so that true (1) comes first
-                        .OrderByDescending(p => p.IsLatestStableSemVer2)
-                        .ThenByDescending(p => p.IsLatestStable)
-                        .ThenByDescending(p => p.IsLatestSemVer2)
-                        .ThenByDescending(p => p.IsLatest)
-                        .ThenByDescending(p => p.Listed)
-                        .ThenByDescending(p => p.Key)
-                        .FirstOrDefault());
+                packages = GetLatestVersion(packages);
             }
 
             return packages
@@ -480,6 +512,25 @@ namespace NuGetGallery
                 .Include(p => p.PackageRegistration.Owners)
                 .Include(p => p.PackageRegistration.RequiredSigners)
                 .ToList();
+        }
+
+        private static IQueryable<Package> GetLatestVersion(IQueryable<Package> packages)
+        {
+            // Do a best effort of retrieving the latest versions. Note that UpdateIsLatest has had concurrency issues
+            // where sometimes packages no rows with IsLatest set. In this case, we'll just select the last inserted
+            // row (descending [Key]) as opposed to reading all rows into memory and sorting on NuGetVersion.
+            packages = packages
+                .GroupBy(p => p.PackageRegistrationKey)
+                .Select(g => g
+                    // order booleans desc so that true (1) comes first
+                    .OrderByDescending(p => p.IsLatestStableSemVer2)
+                    .ThenByDescending(p => p.IsLatestStable)
+                    .ThenByDescending(p => p.IsLatestSemVer2)
+                    .ThenByDescending(p => p.IsLatest)
+                    .ThenByDescending(p => p.Listed)
+                    .ThenByDescending(p => p.Key)
+                    .FirstOrDefault());
+            return packages;
         }
 
         public IQueryable<PackageRegistration> FindPackageRegistrationsByOwner(User user)

--- a/src/NuGetGallery/App_Data/Files/Content/flags.json
+++ b/src/NuGetGallery/App_Data/Files/Content/flags.json
@@ -35,7 +35,8 @@
     "NuGetGallery.ShowReportAbuseSafetyChanges": "Enabled",
     "NuGetGallery.ComputeTargetFramework": "Enabled",
     "NuGetGallery.NewAccount2FAEnforcement": "Disabled",
-    "NuGetGallery.NuGetAccountPasswordLogin": "Enabled"
+    "NuGetGallery.NuGetAccountPasswordLogin": "Enabled",
+    "NuGetGallery.ProfileLoadOptimization": "Enabled"
   },
   "Flights": {
     "NuGetGallery.TyposquattingFlight": {

--- a/src/NuGetGallery/ViewModels/UserProfileModel.cs
+++ b/src/NuGetGallery/ViewModels/UserProfileModel.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
@@ -10,19 +10,31 @@ namespace NuGetGallery
 {
     public class UserProfileModel
     {
-        public UserProfileModel(User user, User currentUser, List<ListPackageItemViewModel> allPackages, int pageIndex, int pageSize, UrlHelper url)
+        public UserProfileModel(User user, User currentUser, List<ListPackageItemViewModel> allPackages, int pageIndex, int pageSize, UrlHelper url, bool usesPaging, long totalDownloadCount, int packageCount)
         {
+
             User = user;
             Username = user.Username;
             EmailAddress = user.EmailAddress;
             UnconfirmedEmailAddress = user.UnconfirmedEmailAddress;
             IsLocked = user.IsLocked;
             AllPackages = allPackages;
-            TotalPackages = allPackages.Count;
             PackagePage = pageIndex;
             PackagePageSize = pageSize;
-
-            TotalPackageDownloadCount = AllPackages.Sum(p => p.TotalDownloadCount);
+            
+            if (usesPaging)
+            {
+                TotalPackages = packageCount;
+                TotalPackageDownloadCount = totalDownloadCount;
+                PagedPackages = AllPackages;
+            }
+            else
+            {
+                TotalPackages = allPackages.Count;
+                TotalPackageDownloadCount = AllPackages.Sum(p => p.TotalDownloadCount);
+                PagedPackages = AllPackages.Skip(PackagePageSize * pageIndex)
+                    .Take(PackagePageSize).ToList();
+            }
 
             PackagePageTotalCount = (TotalPackages + PackagePageSize - 1) / PackagePageSize;
 
@@ -30,8 +42,6 @@ namespace NuGetGallery
                 page => url.User(user, page));
 
             Pager = pager;
-            PagedPackages = AllPackages.Skip(PackagePageSize * pageIndex)
-                                       .Take(PackagePageSize).ToList();
 
             CanManageAccount = ActionsRequiringPermissions.ManageAccount.CheckPermissions(currentUser, user) == PermissionsCheckResult.Allowed;
             CanViewAccount = ActionsRequiringPermissions.ViewAccount.CheckPermissions(currentUser, user) == PermissionsCheckResult.Allowed;

--- a/src/NuGetGallery/Views/Users/Profiles.cshtml
+++ b/src/NuGetGallery/Views/Users/Profiles.cshtml
@@ -25,8 +25,8 @@
                 responsive: true)
             <div class="statistics">
                 <div class="statistic">
-                    <div class="value">@Model.AllPackages.Count.ToNuGetNumberString()</div>
-                    <div class="description">@(Model.AllPackages.Count == 1 ? "Package" : "Packages")</div>
+                    <div class="value">@Model.TotalPackages.ToNuGetNumberString()</div>
+                    <div class="description">@(Model.TotalPackages == 1 ? "Package" : "Packages")</div>
                 </div>
                 <div class="statistic">
                     <div class="value">@Model.TotalPackageDownloadCount.ToNuGetNumberString()</div>

--- a/src/NuGetGallery/Web.config
+++ b/src/NuGetGallery/Web.config
@@ -283,7 +283,7 @@
   -->
   <system.web>
     <httpCookies requireSSL="true" httpOnlyCookies="true"/>
-    <compilation debug="false" targetFramework="4.7.2">
+    <compilation debug="true" targetFramework="4.7.2">
       <assemblies>
         <add assembly="netstandard, Version=2.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51"/>
       </assemblies>

--- a/src/NuGetGallery/Web.config
+++ b/src/NuGetGallery/Web.config
@@ -283,7 +283,7 @@
   -->
   <system.web>
     <httpCookies requireSSL="true" httpOnlyCookies="true"/>
-    <compilation debug="true" targetFramework="4.7.2">
+    <compilation debug="false" targetFramework="4.7.2">
       <assemblies>
         <add assembly="netstandard, Version=2.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51"/>
       </assemblies>

--- a/src/VerifyMicrosoftPackage/Fakes/FakeFeatureFlagService.cs
+++ b/src/VerifyMicrosoftPackage/Fakes/FakeFeatureFlagService.cs
@@ -139,5 +139,7 @@ namespace NuGet.VerifyMicrosoftPackage.Fakes
         public bool CanUseFederatedCredentials(User user) => throw new NotImplementedException();
 
         public bool IsAsciiOnlyPackageIdEnabled() => throw new NotImplementedException();
+
+        public bool IsProfileLoadOptimizationEnabled() => throw new NotImplementedException();
     }
 }

--- a/tests/NuGetGallery.Facts/Services/PackageServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/PackageServiceFacts.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -1398,6 +1398,108 @@ namespace NuGetGallery
                 bool allowPrerelease = true)
             {
                 return CreateService().FilterLatestPackage(packages, semVerLevelKey, allowPrerelease);
+            }
+        }
+
+        public class TheFindPackagesByProfileMethod
+        {
+            protected const string Id = "theId";
+
+            [Fact]
+            public void ReturnsSinglePackageAsExpected()
+            {
+                // Arrange
+                var owner = new User { Key = 1, Username = "owner" };
+
+                var package = new Package
+                {
+                    Version = "1.1.1",
+
+                    PackageRegistration = new PackageRegistration
+                    {
+                        Id = "package",
+                        Owners = new[] { owner },
+                        DownloadCount = 150
+                    },
+
+                    DownloadCount = 100,
+                    PackageStatusKey = PackageStatus.Available,
+                    Listed = true,
+                    IsLatestSemVer2 = true,
+                };
+                var invalidatedPackage = new Package
+                {
+                    Version = "1.0.0",
+
+                    PackageRegistration = new PackageRegistration
+                    {
+                        Id = "packageFailedValidation",
+                        Owners = new[] { owner },
+                        DownloadCount = 0
+                    },
+
+                    DownloadCount = 0,
+                    PackageStatusKey = PackageStatus.FailedValidation,
+                    Listed = true,
+                };
+                var validatingPackage = new Package
+                {
+                    Version = "1.0.0",
+
+                    PackageRegistration = new PackageRegistration
+                    {
+                        Id = "packageValidating",
+                        Owners = new[] { owner },
+                        DownloadCount = 0
+                    },
+
+                    DownloadCount = 0,
+                    PackageStatusKey = PackageStatus.Validating,
+                    Listed = true,
+                };
+                var deletedPackage = new Package
+                {
+                    Version = "1.0.0",
+
+                    PackageRegistration = new PackageRegistration
+                    {
+                        Id = "packageDeleted",
+                        Owners = new[] { owner },
+                        DownloadCount = 0
+                    },
+
+                    DownloadCount = 0,
+                    PackageStatusKey = PackageStatus.Deleted,
+                    Listed = false,
+                };
+
+                var packages = new[] { package, invalidatedPackage, validatingPackage, deletedPackage };
+
+                // Act
+                var result = InvokeMethod(packages, owner);
+
+                // Assert
+                Assert.NotNull(result.Packages);
+                Assert.Single(result.Packages);
+                Assert.Equal(1, result.PackageCount);
+                Assert.Equal(150, result.TotalDownloadCount);
+            }
+
+            [Fact]
+            public void ThrowsIfUserNull()
+            {
+                Assert.Throws<ArgumentNullException>(() => InvokeMethod([], null));
+            }
+
+            protected virtual (IReadOnlyCollection<Package> Packages, long TotalDownloadCount, int PackageCount) InvokeMethod(Package[] packages, User owner)
+            {
+                var repository = new Mock<IEntityRepository<Package>>(MockBehavior.Strict);
+                repository
+                    .Setup(repo => repo.GetAll())
+                    .Returns(packages.AsQueryable());
+                var service = CreateService(packageRepository: repository);
+
+                return service.FindPackagesByProfile(owner, 1, 20);
             }
         }
 

--- a/tests/NuGetGallery.Facts/ViewModels/UserProfileModelFacts.cs
+++ b/tests/NuGetGallery.Facts/ViewModels/UserProfileModelFacts.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
@@ -14,8 +14,10 @@ namespace NuGetGallery.ViewModels
     {
         public class TheTotalDownloadCountProperty : TestContainer
         {
-            [Fact]
-            public void TotalDownloadCount_DoesNotThrowIntegerOverflow()
+            [Theory]
+            [InlineData(true, 4294967294, 2)]
+            [InlineData(false, 0, 0)]
+            public void TotalDownloadCount_DoesNotThrowIntegerOverflow(bool useDatabasePaging, long totalPackageDownloadCount, int packageCount)
             {
                 // Arrange
                 var controller = GetController<UsersController>();
@@ -28,11 +30,12 @@ namespace NuGetGallery.ViewModels
                 };
 
                 // Act
-                var profile = new UserProfileModel(user, currentUser, packages, 0, 10, controller.Url);
+                var profile = new UserProfileModel(user, currentUser, packages, 0, 10, controller.Url, useDatabasePaging, totalPackageDownloadCount, packageCount);
 
                 // Assert
                 long expected = (long)int.MaxValue * 2;
                 Assert.Equal(expected, profile.TotalPackageDownloadCount);
+                Assert.Equal(2, profile.TotalPackages);
             }
 
             [Theory]
@@ -53,7 +56,7 @@ namespace NuGetGallery.ViewModels
                 };
 
                 // Act
-                var profile = new UserProfileModel(user, currentUser, packages, 0, 10, controller.Url);
+                var profile = new UserProfileModel(user, currentUser, packages, 0, 10, controller.Url, false, 0, 0);
 
                 // Assert
                 Assert.Equal(userMfaStatus, profile.HasEnabledMultiFactorAuthentication);
@@ -92,7 +95,7 @@ namespace NuGetGallery.ViewModels
                 };
 
                 // Act
-                var profile = new UserProfileModel(org, currentUser, packages, 0, 10, controller.Url);
+                var profile = new UserProfileModel(org, currentUser, packages, 0, 10, controller.Url, false, 0, 0);
 
                 // Assert
                 Assert.Equal(expectedOrgMfaStatus, profile.HasEnabledMultiFactorAuthentication);


### PR DESCRIPTION
Summary of the changes (in less than 80 characters):

* Added paging to userprofile database call, and added feature flag

Addresses https://github.com/NuGet/NuGetGallery/issues/10221 (partly)

fixes #5877 
fixes #5659 
fixes #10025 

### Details

I used a modified version of the SQL based seeding script shared by @joelverhagen and tested that data are returned for a profile similar to MS within the query timeout.

I also verified locally that the feature flag toggle works as expected.

- it would be nice for contributors to have a better seeding facility and/or database dump

