### PR TITLE
Add Bonsai to the list of known clients

### DIFF
--- a/python/StatsLogParser/loginterpretation/knownclients.yaml
+++ b/python/StatsLogParser/loginterpretation/knownclients.yaml
@@ -115,6 +115,10 @@
   - regex: '(Paket)/?(\d+)?\.?(\d+)?\.?(\d+)?'
     family_replacement: 'Paket'
 
+  # Bonsai (https://bonsai-rx.org/)
+  - regex: '(Bonsai)/(\d+)\.(\d+)\.?(\d+)?'
+    family_replacement: 'Bonsai'
+
   # Xamarin Studio (www.xamarin.com)
   - regex: '(Xamarin Studio)/(\d+)\.(\d+)\.?(\d+)?'
     family_replacement: 'Xamarin Studio'


### PR DESCRIPTION
Following https://github.com/bonsai-rx/bonsai/pull/2266 we request addition of our NuGet client to the list of known clients. We have been a strong consumer of NuGet feeds with over 70 packages and 1M+ downloads which are all incorrectly assigned to "NuGet Client V3".

Related to https://github.com/NuGet/NuGetGallery/issues/5240