### PR TITLE
Bumping package version

### DIFF
--- a/python/StatsLogParser/pyproject.toml
+++ b/python/StatsLogParser/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "loginterpretation"
-version = "0.3.0"
+version = "0.4.0"
 description = "Helper functions for parsing CDN logs to generate statistics"
 authors = ["NuGet Server Team Engineering <nugetservereng@microsoft.com>"]
 readme = "README.md"


### PR DESCRIPTION
Follow up on https://github.com/NuGet/NuGetGallery/issues/10452
Bumping the python package version since the code was updated. Build guide is [here](https://github.com/NuGet/NuGetGallery/blob/main/python/StatsLogParser/README.md).

I'm following https://github.com/NuGet/NuGetGallery/pull/10351 steps