### PR TITLE
Save search filters in local storage

### DIFF
--- a/src/NuGetGallery/Scripts/gallery/page-list-packages.js
+++ b/src/NuGetGallery/Scripts/gallery/page-list-packages.js
@@ -207,6 +207,8 @@ $(function() {
         });
         searchForm.addEventListener('submit', submitSearchForm);
         initializeFrameworkAndTfmCheckboxes();
+        window.nuget.saveSearchFilterParams(window.location.href);
+        window.nuget.updateSearchLinksWithSavedParams();
     }
 
     $(".reserved-indicator").each(window.nuget.setPopovers);

--- a/src/NuGetGallery/Views/Pages/Home.cshtml
+++ b/src/NuGetGallery/Views/Pages/Home.cshtml
@@ -48,7 +48,7 @@ else if (AskUserToEnable2FA)
             </div>
             <div class="row">
                 <div class="col-sm-8 col-sm-offset-2">
-                    <form action="@Url.PackageList()" method="get">
+                    <form name="simple-search" action="@Url.PackageList()" method="get">
                         @Html.Partial("_SearchBar")
                         @Html.Partial("_AutocompleteTemplate")
                     </form>
@@ -96,7 +96,7 @@ else if (AskUserToEnable2FA)
                 </p>
             </div>
             <div class="col-sm-4">
-                <a href="@Url.PackageList()"
+                <a href="@Url.PackageList()" name="Packages"
                    title="Explore packages available on NuGet.org">
                     <div class="home-icons">
                         <img src="@Url.Absolute("~/Content/gallery/img/search-icon.svg")" alt="Find packages" width="96" height="96" />

--- a/src/NuGetGallery/Views/Shared/Gallery/Header.cshtml
+++ b/src/NuGetGallery/Views/Shared/Gallery/Header.cshtml
@@ -38,16 +38,16 @@
 @helper DisplayNavigationItem(string tab, string url, bool bold = false, string title = null)
 {
     <li class="@(ViewBag.Tab == tab ? "active" : string.Empty)" role="presentation">
-        <a role="tab" aria-selected="@(ViewBag.Tab == tab ? "true" : "false")" href="@url" title="@title">
+        <a role="tab" name="@tab" aria-selected="@(ViewBag.Tab == tab ? "true" : "false")" href="@url" title="@title">
             @if (bold)
             {
                 @:<b>
-            }
+                }
             <span>@tab</span>
             @if (bold)
             {
-                @:</b>
-            }
+            @:</b>
+        }
         </a>
     </li>
 }
@@ -173,7 +173,7 @@
     {
         <div id="search-bar-header" class="container search-container">
             <div class="row">
-                <form aria-label="Package search bar" class="col-sm-12" action="@Url.PackageList()" method="get">
+                <form aria-label="Package search bar" class="col-sm-12" name="simple-search" action="@Url.PackageList()" method="get">
                     @Html.Partial("_SearchBar")
                     @Html.Partial("_AutocompleteTemplate")
                 </form>

--- a/src/NuGetGallery/Views/Shared/ListPackages.cshtml
+++ b/src/NuGetGallery/Views/Shared/ListPackages.cshtml
@@ -63,6 +63,8 @@
     };
 }
 
+
+@* IMPORTANT. If you modify this search form then update searchFilterParamNames in commons.js *@
 <form name="search" id="search-form" method="get" class="clearfix advanced-search-panel">
     <div id="search-bar-list-packages" class="navbar navbar-inverse">
         <div class="container search-container" aria-label="Package search bar">
@@ -81,8 +83,9 @@
                 {
                     <div class="toggle-advanced-search-panel">
                         <span>Advanced search filters</span>
-                        <button class ="advanced-search-toggle-button btn-brand-transparent" aria-label="Toggles search filters on narrow screens" aria-expanded="false" aria-controls="advancedSearchToggleButton" tabindex="0" id="advancedSearchToggleButton" type="button">
-                        <i class="ms-Icon ms-Icon--ChevronDown" id="advancedSearchToggleChevron" ></i></button>
+                        <button class="advanced-search-toggle-button btn-brand-transparent" aria-label="Toggles search filters on narrow screens" aria-expanded="false" aria-controls="advancedSearchToggleButton" tabindex="0" id="advancedSearchToggleButton" type="button">
+                            <i class="ms-Icon ms-Icon--ChevronDown" id="advancedSearchToggleChevron"></i>
+                        </button>
                     </div>
                     <div class="row clearfix advanced-search-panel" id="advancedSearchPanel">
                         <input type="text" hidden id="frameworks" name="frameworks" value="@Model.Frameworks">
@@ -176,7 +179,7 @@
                                         <input id="prerel-checkbox" type="checkbox" checked="@Model.IncludePrerelease">
                                         <span>
                                             Include prerelease
-                                         </span>
+                                        </span>
                                     </label>
                                 </div>
                             </fieldset>
@@ -226,12 +229,12 @@
                     @if (Model.IsAdvancedSearchFlightEnabled)
                     {
                         <div class="sortby col-md-4">
-                                <label for="sortby" class="">Sort by</label>
-                                <select name="sortby" id="sortby" form="search-form" aria-label="sort package search results by" class="form-control select-brand">
-                                    <option value="relevance" aria-label="Sort By: Relevance" @(Model.SortBy == "relevance" ? "selected" : "")>Relevance</option>
-                                    <option value="totalDownloads-desc" aria-label="Sort By: Downloads" @(Model.SortBy == "totalDownloads-desc" ? "selected" : "")>Downloads</option>
-                                    <option value="created-desc" aria-label="Sort By: Recently updated" @(Model.SortBy == "created-desc" ? "selected" : "")>Recently updated</option>
-                                </select>
+                            <label for="sortby" class="">Sort by</label>
+                            <select name="sortby" id="sortby" form="search-form" aria-label="sort package search results by" class="form-control select-brand">
+                                <option value="relevance" aria-label="Sort By: Relevance" @(Model.SortBy == "relevance" ? "selected" : "")>Relevance</option>
+                                <option value="totalDownloads-desc" aria-label="Sort By: Downloads" @(Model.SortBy == "totalDownloads-desc" ? "selected" : "")>Downloads</option>
+                                <option value="created-desc" aria-label="Sort By: Recently updated" @(Model.SortBy == "created-desc" ? "selected" : "")>Recently updated</option>
+                            </select>
                         </div>
                     }
                     else
@@ -413,9 +416,10 @@
     });
 
     $('#reset-advanced-search').on('click', function () {
+        window.nuget.resetSearchFilterParams();
         location.href = '?q=@Uri.EscapeDataString(Model.SearchTerm)';
     });
     </script>
 
-    @Scripts.RenderFormat("<script src=\"{0}\" nonce='"+@Html.GetCSPNonce().ToString()+"'></script>", "~/Scripts/gallery/page-list-packages.min.js");
+    @Scripts.RenderFormat("<script src=\"{0}\" nonce='" + @Html.GetCSPNonce().ToString() + "'></script>", "~/Scripts/gallery/page-list-packages.min.js");
 }


### PR DESCRIPTION
Summary of the changes (in less than 80 characters): store locally and reuse search filter params

* When navigating to `Packages`, we store locally URL query params corresponding to the search filters
* When navigating to other pages we update "basic" links to Packages with the saved search filter params
* When navigating to pages containing simple search form (e.g. on home page), we update the search form with the saved search filter params by making sure the form contains input elements matching saved search params.


Addresses https://github.com/NuGet/NuGetGallery/issues/7133