### PR TITLE
Concatenate package authors in atom file w/ feature flag

### DIFF
--- a/src/AccountDeleter/EmptyFeatureFlagService.cs
+++ b/src/AccountDeleter/EmptyFeatureFlagService.cs
@@ -251,7 +251,7 @@ namespace NuGetGallery.AccountDeleter
 
         public bool IsPackagesAtomFeedCombinedAuthorsEnabled()
         {
-             throw new NotImplementedException();
+            throw new NotImplementedException();
         }
 
         public bool IsPreviewHijackEnabled()

--- a/src/AccountDeleter/EmptyFeatureFlagService.cs
+++ b/src/AccountDeleter/EmptyFeatureFlagService.cs
@@ -249,6 +249,11 @@ namespace NuGetGallery.AccountDeleter
             throw new NotImplementedException();
         }
 
+        public bool IsPackagesAtomFeedCombinedAuthorsEnabled()
+        {
+             throw new NotImplementedException();
+        }
+
         public bool IsPreviewHijackEnabled()
         {
             throw new NotImplementedException();

--- a/src/GitHubVulnerabilities2Db/Fakes/FakeFeatureFlagService.cs
+++ b/src/GitHubVulnerabilities2Db/Fakes/FakeFeatureFlagService.cs
@@ -245,6 +245,11 @@ namespace GitHubVulnerabilities2Db.Fakes
             throw new NotImplementedException();
         }
 
+        public bool IsPackagesAtomFeedCombinedAuthorsEnabled()
+        {
+            throw new NotImplementedException();
+        }
+
         public bool IsPreviewHijackEnabled()
         {
             throw new NotImplementedException();

--- a/src/NuGetGallery.Services/Configuration/FeatureFlagService.cs
+++ b/src/NuGetGallery.Services/Configuration/FeatureFlagService.cs
@@ -33,6 +33,7 @@ namespace NuGetGallery
         private const string DisplayNuGetTrendsLinkFeatureName = GalleryPrefix + "DisplayNuGetTrendsLink";
         private const string ODataReadOnlyDatabaseFeatureName = GalleryPrefix + "ODataReadOnlyDatabase";
         private const string PackagesAtomFeedFeatureName = GalleryPrefix + "PackagesAtomFeed";
+        private const string PackagesAtomFeedCombinedAuthorsFeatureName = GalleryPrefix + "PackagesAtomFeedCombinedAuthors";
         private const string SearchSideBySideFlightName = GalleryPrefix + "SearchSideBySide";
         private const string TyposquattingFeatureName = GalleryPrefix + "Typosquatting";
         private const string TyposquattingFlightName = GalleryPrefix + "TyposquattingFlight";
@@ -118,6 +119,11 @@ namespace NuGetGallery
         public bool IsPackagesAtomFeedEnabled()
         {
             return _client.IsEnabled(PackagesAtomFeedFeatureName, defaultValue: false);
+        }
+
+        public bool IsPackagesAtomFeedCombinedAuthorsEnabled()
+        {
+            return _client.IsEnabled(PackagesAtomFeedCombinedAuthorsFeatureName, defaultValue: false);
         }
 
         /// <summary>

--- a/src/NuGetGallery.Services/Configuration/IFeatureFlagService.cs
+++ b/src/NuGetGallery.Services/Configuration/IFeatureFlagService.cs
@@ -48,6 +48,12 @@ namespace NuGetGallery
         bool IsPackagesAtomFeedEnabled();
 
         /// <summary>
+        /// Whether the packages Atom feed xml file returns a combined authors list. If true, the feed will
+        /// return a single author entry for all package authors.
+        /// </summary>
+        bool IsPackagesAtomFeedCombinedAuthorsEnabled();
+
+        /// <summary>
         /// Whether or not the user can manage their package's deprecation state.
         /// </summary>
         bool IsManageDeprecationEnabled(User user, PackageRegistration registration);

--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -1179,9 +1179,17 @@ namespace NuGetGallery
             List<SyndicationItem> feedItems = new List<SyndicationItem>();
 
             List<SyndicationPerson> ownersAsAuthors = new List<SyndicationPerson>();
-            foreach (var packageOwner in packageRegistration.Owners)
+            if (_featureFlagService.IsPackagesAtomFeedCombinedAuthorsEnabled())
             {
-                ownersAsAuthors.Add(new SyndicationPerson() { Name = packageOwner.Username, Uri = Url.User(packageOwner, relativeUrl: false) });
+                var combinedAuthors = string.Join(", ", packageRegistration.Owners.Select(o => o.Username));
+                ownersAsAuthors.Add(new SyndicationPerson() { Name = combinedAuthors });
+            }
+            else
+            {
+                foreach (var packageOwner in packageRegistration.Owners)
+                {
+                    ownersAsAuthors.Add(new SyndicationPerson() { Name = packageOwner.Username, Uri = Url.User(packageOwner, relativeUrl: false) });
+                }
             }
 
             foreach (var packageVersion in packageVersions)

--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -1181,7 +1181,11 @@ namespace NuGetGallery
             List<SyndicationPerson> ownersAsAuthors = new List<SyndicationPerson>();
             if (_featureFlagService.IsPackagesAtomFeedCombinedAuthorsEnabled())
             {
-                var combinedAuthors = string.Join(", ", packageRegistration.Owners.Select(o => o.Username));
+                var sortedOwners = packageRegistration
+                    .Owners
+                    .Select(o => o.Username)
+                    .OrderBy(o => o, StringComparer.OrdinalIgnoreCase);
+                var combinedAuthors = string.Join(", ", sortedOwners);
                 ownersAsAuthors.Add(new SyndicationPerson() { Name = combinedAuthors });
             }
             else

--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -1143,6 +1143,12 @@ namespace NuGetGallery
                 return HttpNotFound();
             }
 
+            // The Atom spec requires that there is at least one author for the feed to be valid.
+            if (packageRegistration.Owners.Count == 0)
+            {
+                return HttpNotFound();
+            }
+
             IEnumerable<Package> packageVersionsQuery = packageRegistration
                 .Packages
                 .Where(x => x.Listed && x.PackageStatusKey == PackageStatus.Available)

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -1442,7 +1442,7 @@
                                 src="@Url.Absolute("~/Content/gallery/img/twitter.svg")"
                                 @ViewHelpers.ImageFallback(Url.Absolute("~/Content/gallery/img/twitter-24x24.png")) />
                     </a>
-                    @if (Model.IsAtomFeedEnabled)
+                    @if (Model.IsAtomFeedEnabled && Model.Owners.Any())
                     {
                         <a href="@Url.PackageAtomFeed(Model.Id)" data-track="atom-feed">
                             <img width="24" height="24" alt="Use the Atom feed to subscribe to new versions of @Model.Id"

--- a/src/VerifyMicrosoftPackage/Fakes/FakeFeatureFlagService.cs
+++ b/src/VerifyMicrosoftPackage/Fakes/FakeFeatureFlagService.cs
@@ -22,6 +22,8 @@ namespace NuGet.VerifyMicrosoftPackage.Fakes
 
         public bool IsPackagesAtomFeedEnabled() => throw new NotImplementedException();
 
+        public bool IsPackagesAtomFeedCombinedAuthorsEnabled() => throw new NotImplementedException();
+
         public bool IsManageDeprecationEnabled(User user, PackageRegistration registration) => throw new NotImplementedException();
 
         public bool IsManageDeprecationEnabled(User user, IEnumerable<Package> allVersions) => throw new NotImplementedException();

--- a/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -2468,6 +2468,7 @@ namespace NuGetGallery
 
                 var packageRegistration = new PackageRegistration();
                 packageRegistration.Id = "Foo";
+                packageRegistration.Owners.Add(TestUtility.FakeUser);
 
                 var onlyVersion = new Package
                 {
@@ -2519,6 +2520,7 @@ namespace NuGetGallery
 
                 var packageRegistration = new PackageRegistration();
                 packageRegistration.Id = "Foo";
+                packageRegistration.Owners.Add(TestUtility.FakeUser);
 
                 var onlyVersion = new Package
                 {
@@ -2599,6 +2601,7 @@ namespace NuGetGallery
 
                 var packageRegistration = new PackageRegistration();
                 packageRegistration.Id = "Foo";
+                packageRegistration.Owners.Add(TestUtility.FakeUser);
 
                 var oldestPackage = new Package
                 {
@@ -2703,7 +2706,7 @@ namespace NuGetGallery
 
                 var packageId = "someId";
                 var packageVersion = "1.2.3-someVersion";
-                var packageRegistration = new PackageRegistration { Id = packageId };
+                var packageRegistration = new PackageRegistration { Id = packageId, Owners = [TestUtility.FakeUser] };
                 var package = new Package
                 {
                     PackageRegistration = packageRegistration,


### PR DESCRIPTION
The Atom RSS schema [allows for multiple `<author>` elements to be specified](https://datatracker.ietf.org/doc/html/rfc4287#section-4.1.2), but popular RSS readers tend to only use one of the authors with varying strategies (picking the first or the last for example).

The Outlook RSS reader is a bit different in that it concatenates the authors all on one line:
![image](https://github.com/user-attachments/assets/436384e8-b32e-482a-acd4-cb7d455a21de)

I looked at the most popular RSS readers in the Microsoft store and the most ones most frequently being used to query NuGet feed data and none of them properly list all authors or use the URI data.

I'm proposing that we just concatenate all the authors into one `<author>` element for maximum compatibility with most RSS readers. I've also hidden the new Atom file format behind a feature flag in case this accidentally breaks anything.

## Before
```xml
<entry>
  <id>https://localhost/packages/Newtonsoft.Json/13.0.5</id>
  <title type="text">Newtonsoft.Json 13.0.5</title>
  <published>2025-05-20T06:09:02-07:00</published>
  <updated>2025-05-20T06:09:02-07:00</updated>
  <author>
    <name>japarson</name>
    <uri>https://localhost/profiles/japarson</uri>
  </author>
  <author>
    <name>testuser1</name>
    <uri>https://localhost/profiles/testuser1</uri>
  </author>
  <author>
    <name>testuser2</name>
    <uri>https://localhost/profiles/testuser2</uri>
  </author>
  <link rel="alternate" href="https://localhost/packages/Newtonsoft.Json/13.0.5" />
  <content type="text">Json.NET is a popular high-performance JSON framework for .NET</content>
</entry>
```

## After
```xml
<entry>
  <id>https://localhost/packages/Newtonsoft.Json/13.0.5</id>
  <title type="text">Newtonsoft.Json 13.0.5</title>
  <published>2025-05-20T06:09:02-07:00</published>
  <updated>2025-05-20T06:09:02-07:00</updated>
  <author>
    <name>japarson, testuser1, testuser2</name>
  </author>
  <link rel="alternate" href="https://localhost/packages/Newtonsoft.Json/13.0.5" />
  <content type="text">Json.NET is a popular high-performance JSON framework for .NET</content>
</entry>
```

I also made the API return a 404 when there are no owners and hid the atom feed button under the same condition. This is because the Atom spec requires that there be at least one author for each entry. It doesn't really make sense to provide an atom file for a feed with no owners anyway.

![image](https://github.com/user-attachments/assets/29dbc282-7bfa-44b0-a55c-64d1741b6677)

Addresses https://github.com/NuGet/NuGetGallery/issues/8395