### PR TITLE
Replacing underscores with dashes in branch name for use in versions.

### DIFF
--- a/.pipelines/NuGetGallery-CI.yml
+++ b/.pipelines/NuGetGallery-CI.yml
@@ -34,7 +34,7 @@ variables:
   - name: NuGetGalleryBranch
     value: $(Build.SourceBranchName)
   - name: SemverFriendlyBranchName
-    value: ${{ replace(variables.NuGetGalleryBranch, '_', '-') }}
+    value: ${{ replace(replace(variables.NuGetGalleryBranch, '_', '-'), '/', '-') }}
 
 resources:
   repositories:

--- a/.pipelines/NuGetGallery-CI.yml
+++ b/.pipelines/NuGetGallery-CI.yml
@@ -34,7 +34,7 @@ variables:
   - name: NuGetGalleryBranch
     value: $(Build.SourceBranchName)
   - name: SemverFriendlyBranchName
-    value: ${{ replace(replace(variables.NuGetGalleryBranch, '_', '-'), '/', '-') }}
+    value: $[ replace(replace(variables['Build.SourceBranchName'], '_', '-'), '/', '-') ]
 
 resources:
   repositories:

--- a/.pipelines/NuGetGallery-CI.yml
+++ b/.pipelines/NuGetGallery-CI.yml
@@ -34,7 +34,7 @@ variables:
   - name: NuGetGalleryBranch
     value: $(Build.SourceBranchName)
   - name: SemverFriendlyBranchName
-    value: $[ replace(replace(variables['Build.SourceBranchName'], '_', '-'), '/', '-') ]
+    value: ${{ replace(replace(variables['Build.SourceBranchName'], '_', '-'), '/', '-') }}
 
 resources:
   repositories:

--- a/.pipelines/NuGetGallery-CI.yml
+++ b/.pipelines/NuGetGallery-CI.yml
@@ -16,15 +16,15 @@ variables:
   - name: nugetMultiFeedWarnLevel
     value: none
   - name: CommonPackageVersion
-    value: $(CommonAssemblyVersion)-$(NuGetGalleryBranch)-$(Build.BuildId)
+    value: $(CommonAssemblyVersion)-$(SemverFriendlyBranchName)-$(Build.BuildId)
   - name: CommonAssemblyVersion
     value: 5.0.0
   - name: GalleryPackageVersion
-    value: $(GalleryAssemblyVersion)-$(NuGetGalleryBranch)-$(Build.BuildId)
+    value: $(GalleryAssemblyVersion)-$(SemverFriendlyBranchName)-$(Build.BuildId)
   - name: GalleryAssemblyVersion
     value: 5.0.0
   - name: JobsPackageVersion
-    value: $(JobsAssemblyVersion)-$(NuGetGalleryBranch)-$(Build.BuildId)
+    value: $(JobsAssemblyVersion)-$(SemverFriendlyBranchName)-$(Build.BuildId)
   - name: JobsAssemblyVersion
     value: 5.0.0
   - name: NuGetGalleryDirectory
@@ -33,6 +33,8 @@ variables:
     value: $(Agent.BuildDirectory)\$(NuGetGalleryDirectory)
   - name: NuGetGalleryBranch
     value: $(Build.SourceBranchName)
+  - name: SemverFriendlyBranchName
+    value: ${{ replace(variables.NuGetGalleryBranch, '_', '-') }}
 
 resources:
   repositories:


### PR DESCRIPTION
Branch may have underscores in their name, we use branch name to construct package version, which must be semver-compliant. Underscores are not allowed in semver pre-release labels which causes CI build failures. Adding transformation that replaces underscores with dashes for the purpose of version string generation.