### PR TITLE
Update RemovedPackages.md

### DIFF
--- a/RemovedPackages.md
+++ b/RemovedPackages.md
@@ -19,6 +19,7 @@ Scanning is not perfect. Community partnership is a very valuable part of the ov
 |      WaffleAuth version  2.2.5    |     4/1/2025      |  Untrustworthy   |
 |      WaffleAuth version 2.2.7    |     4/1/2025    |  Untrustworthy   |
 |      WaffleAuth version 2.2.6    |     4/1/2025    |  Untrustworthy   |
+|     RESXManager 1.7.0  |     5/28/2025    | Spam   |
 
 
 


### PR DESCRIPTION
The project website URL associated with this package RESXManager (1.7.0) is redirecting to unrelated advertising content. Due to security concerns removed this package.

Adding the package details in RemovedPackages.md.

