### PR TITLE
Add function for escaping all markdown special characters

### DIFF
--- a/src/NuGet.Services.Messaging.Email/MarkdownEmailBuilder.cs
+++ b/src/NuGet.Services.Messaging.Email/MarkdownEmailBuilder.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.IO;
+using System.Text;
 using Markdig;
 using NuGet.Services.Messaging.Email.Internal;
 
@@ -13,9 +14,10 @@ namespace NuGet.Services.Messaging.Email
     /// </summary>
     public abstract class MarkdownEmailBuilder : EmailBuilder
     {
-        private static readonly IReadOnlyList<string> SpecialMarkdownChars =
+        // https://www.markdownguide.org/basic-syntax/#characters-you-can-escape
+        private static readonly HashSet<char> SpecialMarkdownChars =
         [
-            "\\", "`", "*", "_", "{", "}", "[", "]", "<", ">", "(", ")", "#", "+", "-", ".", "!", "|"
+            '\\', '`', '*', '_', '{', '}', '[', ']', '<', '>', '(', ')', '#', '+', '-', '.', '!', '|'
         ];
 
         protected override string GetPlainTextBody()
@@ -54,12 +56,18 @@ namespace NuGet.Services.Messaging.Email
                 return text;
             }
 
-            foreach (var ch in SpecialMarkdownChars)
+            StringBuilder sb = new(text.Length + 10);
+            foreach (char c in text)
             {
-                text = text.Replace(ch, "\\" + ch);
+                if (SpecialMarkdownChars.Contains(c))
+                {
+                    sb.Append('\\');
+                }
+
+                sb.Append(c);
             }
 
-            return text;
+            return sb.ToString();
         }
     }
 }

--- a/src/NuGet.Services.Messaging.Email/MarkdownEmailBuilder.cs
+++ b/src/NuGet.Services.Messaging.Email/MarkdownEmailBuilder.cs
@@ -1,6 +1,7 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Collections.Generic;
 using System.IO;
 using Markdig;
 using NuGet.Services.Messaging.Email.Internal;
@@ -12,6 +13,11 @@ namespace NuGet.Services.Messaging.Email
     /// </summary>
     public abstract class MarkdownEmailBuilder : EmailBuilder
     {
+        private static readonly IReadOnlyList<string> SpecialMarkdownChars =
+        [
+            "\\", "`", "*", "_", "{", "}", "[", "]", "<", ">", "(", ")", "#", "+", "-", ".", "!", "|"
+        ];
+
         protected override string GetPlainTextBody()
         {
             var markdown = GetMarkdownBody();
@@ -39,6 +45,21 @@ namespace NuGet.Services.Messaging.Email
         protected override string GetHtmlBody()
         {
             return Markdown.ToHtml(GetMarkdownBody());
+        }
+
+        public static string EscapeMarkdown(string text)
+        {
+            if (string.IsNullOrEmpty(text))
+            {
+                return text;
+            }
+
+            foreach (var ch in SpecialMarkdownChars)
+            {
+                text = text.Replace(ch, "\\" + ch);
+            }
+
+            return text;
         }
     }
 }

--- a/src/NuGetGallery.Core/Infrastructure/Mail/Messages/PackageAddedMessage.cs
+++ b/src/NuGetGallery.Core/Infrastructure/Mail/Messages/PackageAddedMessage.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -78,7 +78,11 @@ namespace NuGetGallery.Infrastructure.Mail.Messages
         {
             var warningMessages = GetWarningMessages();
 
-            var markdown = $@"The package [{Package.PackageRegistration.Id} {Package.Version}]({_packageUrl}) was recently published on {_configuration.GalleryOwner.DisplayName} by {Package.User.Username}. If this was not intended, please [contact support]({_packageSupportUrl}).";
+            var packageRegistrationId = EscapeMarkdown(Package.PackageRegistration.Id);
+            var galleryOwnerDisplayName = EscapeMarkdown(_configuration.GalleryOwner.DisplayName);
+            var packageUsername = EscapeMarkdown(Package.User.Username);
+
+            var markdown = $@"The package [{packageRegistrationId} {Package.Version}]({_packageUrl}) was recently published on {galleryOwnerDisplayName} by {packageUsername}. If this was not intended, please [contact support]({_packageSupportUrl}).";
 
             if (!string.IsNullOrEmpty(warningMessages))
             {

--- a/src/NuGetGallery/Infrastructure/Mail/Messages/ContactOwnersMessage.cs
+++ b/src/NuGetGallery/Infrastructure/Mail/Messages/ContactOwnersMessage.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -66,9 +66,14 @@ namespace NuGetGallery.Infrastructure.Mail.Messages
 
         private string GetBodyInternal(EmailFormat format)
         {
-            var markdown = $@"_User {FromAddress.DisplayName} &lt;{FromAddress.Address}&gt; sends the following message to the owners of Package '[{Package.PackageRegistration.Id} {Package.Version}]({PackageUrl})'._
+            var fromDisplayName = EscapeMarkdown(FromAddress.DisplayName);
+            var packageId = EscapeMarkdown(Package.PackageRegistration.Id);
+            var packageUrl = EscapeMarkdown(PackageUrl);
+            var message = EscapeMarkdown(HtmlEncodedMessage);
 
-{HtmlEncodedMessage}";
+            var markdown = $@"User {fromDisplayName} &lt;{FromAddress.Address}&gt; sends the following message to the owners of Package '[{packageId} {Package.Version}]({packageUrl})'.
+
+_{message}_";
 
             string body;
             switch (format)

--- a/src/NuGetGallery/Infrastructure/Mail/Messages/ReportMyPackageMessage.cs
+++ b/src/NuGetGallery/Infrastructure/Mail/Messages/ReportMyPackageMessage.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -22,35 +22,45 @@ namespace NuGetGallery.Infrastructure.Mail.Messages
 
         protected override string GetMarkdownBody()
         {
-            var userString = string.Empty;
-            if (Request.RequestingUser != null && Request.RequestingUserUrl != null)
+            string emailLine;
+            var fromAddress = EscapeMarkdown(Request.FromAddress.Address);
+            var fromAddressDisplayName = EscapeMarkdown(Request.FromAddress.DisplayName);
+            if (!string.IsNullOrEmpty(fromAddressDisplayName))
             {
-                userString = string.Format(
-                    CultureInfo.CurrentCulture,
-                    "{2}**User:** {0} ({1}){2}{3}",
-                    Request.RequestingUser.Username,
-                    Request.RequestingUser.EmailAddress,
-                    Environment.NewLine,
-                    Request.RequestingUserUrl);
+                emailLine = $"**Email:** {fromAddressDisplayName} ({fromAddress})";
+            }
+            else
+            {
+                emailLine = $"**Email:** {fromAddress}";
             }
 
-            return $@"**Email**: {Request.FromAddress.DisplayName} ({Request.FromAddress.Address})
+            var packageId = EscapeMarkdown(Request.Package.PackageRegistration.Id);
 
-**Package**: {Request.Package.PackageRegistration.Id}
-{Request.PackageUrl}
+            var userLine = string.Empty;
+            if (Request.RequestingUser != null && Request.RequestingUserUrl != null)
+            {
+                var username = EscapeMarkdown(Request.RequestingUser.Username);
+                var email = EscapeMarkdown(Request.RequestingUser.EmailAddress);
+                var url = EscapeMarkdown(Request.RequestingUserUrl);
+                userLine = $"**User:** [{username} ({email})]({url})";
+            }
 
-**Version**: {Request.Package.Version}
-{Request.PackageVersionUrl}
-{userString}
+            var message = EscapeMarkdown(Request.Message);
+            var galleryOwnerDisplayName = EscapeMarkdown(Configuration.GalleryOwner.DisplayName);
 
-**Reason**:
-{Request.Reason}
+            return $@"{emailLine}
 
-**Message**:
-{Request.Message}
+**Package:** [{packageId}]({Request.PackageUrl})
 
+**Version:** [{Request.Package.Version}]({Request.PackageVersionUrl})
 
-Message sent from {Configuration.GalleryOwner.DisplayName}";
+{userLine}
+
+**Reason:** {Request.Reason}
+
+**Message:** {message}
+
+_Message sent from {galleryOwnerDisplayName}_";
         }
     }
 }

--- a/tests/NuGetGallery.Facts/Infrastructure/Mail/MarkdownEmailBuilderFacts.cs
+++ b/tests/NuGetGallery.Facts/Infrastructure/Mail/MarkdownEmailBuilderFacts.cs
@@ -1,0 +1,53 @@
+using Xunit;
+using NuGet.Services.Messaging.Email;
+
+namespace NuGetGallery.Infrastructure.Mail
+{
+    public class MarkdownEmailBuilderFacts
+    {
+        [Theory]
+        [InlineData(null, null)]
+        [InlineData("", "")]
+        public void EscapeMarkdown_ReturnsNullOrEmpty_WhenInputIsNullOrEmpty(string input, string expected)
+        {
+            var result = MarkdownEmailBuilder.EscapeMarkdown(input);
+            Assert.Equal(expected, result);
+        }
+
+        [Theory]
+        [InlineData("Hello World", "Hello World")]
+        [InlineData("NoSpecialChars123", "NoSpecialChars123")]
+        public void EscapeMarkdown_ReturnsUnchanged_WhenNoSpecialChars(string input, string expected)
+        {
+            var result = MarkdownEmailBuilder.EscapeMarkdown(input);
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void EscapeMarkdown_EscapesAllSpecialMarkdownCharacters()
+        {
+            string input = "\\`*_{}[]<>()#+-.!|";
+            string expected = "\\\\\\`\\*\\_\\{\\}\\[\\]\\<\\>\\(\\)\\#\\+\\-\\.\\!\\|";
+            var result = MarkdownEmailBuilder.EscapeMarkdown(input);
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void EscapeMarkdown_EscapesRepeatedSpecialCharacters()
+        {
+            string input = "**bold**";
+            string expected = "\\*\\*bold\\*\\*";
+            var result = MarkdownEmailBuilder.EscapeMarkdown(input);
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void EscapeMarkdown_MixedContent()
+        {
+            string input = "Hello *World*! [Click](link)";
+            string expected = "Hello \\*World\\*\\! \\[Click\\]\\(link\\)";
+            var result = MarkdownEmailBuilder.EscapeMarkdown(input);
+            Assert.Equal(expected, result);
+        }
+    }
+}

--- a/tests/NuGetGallery.Facts/Infrastructure/Mail/MarkdownMessageServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Infrastructure/Mail/MarkdownMessageServiceFacts.cs
@@ -69,8 +69,8 @@ namespace NuGetGallery
                 Assert.Equal(from, message.ReplyToList.Single());
                 Assert.Equal($"[{TestGalleryOwner.DisplayName}] Support Request for 'smangit' version 1.42.0.1 (Reason: Reason!)", message.Subject);
                 Assert.Contains("Reason!", message.Body);
-                Assert.Contains("Abuse!", message.Body);
-                Assert.Contains("too (legit@example.com)", message.Body);
+                Assert.Contains("Abuse\\!", message.Body);
+                Assert.Contains("too (legit@example\\.com)", message.Body);
                 Assert.Contains("smangit", message.Body);
                 Assert.Contains("1.42.0.1", message.Body);
                 Assert.Contains("Yes", message.Body);

--- a/tests/NuGetGallery.Facts/Infrastructure/Mail/Messages/ContactOwnersMessageFacts.cs
+++ b/tests/NuGetGallery.Facts/Infrastructure/Mail/Messages/ContactOwnersMessageFacts.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -124,9 +124,9 @@ namespace NuGetGallery.Infrastructure.Mail.Messages
         }
 
         private const string _expectedMarkdownBody =
-            @"_User Sender &lt;sender@gallery.org&gt; sends the following message to the owners of Package '[PackageId 1.0.0](packageUrl)'._
+            @"User Sender &lt;sender@gallery.org&gt; sends the following message to the owners of Package '[PackageId 1.0.0](packageUrl)'.
 
-user input
+_user input_
 
 -----------------------------------------------
 <em style=""font-size: 0.8em;"">
@@ -144,8 +144,8 @@ user input
     change your email notification settings (emailSettingsUrl).";
 
         private const string _expectedHtmlBody =
-            "<p><em>User Sender &lt;sender@gallery.org&gt; sends the following message to the owners of Package '<a href=\"packageUrl\">PackageId 1.0.0</a>'.</em></p>\n" +
-"<p>user input</p>\n" +
+            "<p>User Sender &lt;sender@gallery.org&gt; sends the following message to the owners of Package '<a href=\"packageUrl\">PackageId 1.0.0</a>'.</p>\n" +
+"<p><em>user input</em></p>\n" +
 @"<hr />
 <em style=""font-size: 0.8em;"">
     To stop receiving contact emails as an owner of this package, sign in to the NuGetGallery and

--- a/tests/NuGetGallery.Facts/Infrastructure/Mail/Messages/ReportAbuseMessageFacts.cs
+++ b/tests/NuGetGallery.Facts/Infrastructure/Mail/Messages/ReportAbuseMessageFacts.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -136,70 +136,52 @@ namespace NuGetGallery.Infrastructure.Mail.Messages
         }
 
         private const string _expectedMarkdownBody =
-            @"**Email**: Sender (sender@gallery.org)
+            @"**Email:** Sender (sender@gallery\.org)
 
-**Signature**: signature
+**Signature:** signature
 
-**Package**: PackageId
-packageUrl
+**Package:** [PackageId](packageUrl)
 
-**Version**: 1.0.0
-packageVersionUrl
+**Version:** [1.0.0](packageVersionUrl)
 
-**User:** requestingUser (requestUser@gallery.org)
-profileUrl
+**User:** [requestingUser (requestUser@gallery\.org)](profileUrl)
 
-**Reason**:
-reason
+**Reason:** reason
 
-**Has the package owner been contacted?**
-No
+**Has the package owner been contacted?** No
 
-**Message:**
-message
+**Message:** message
 
+_Message sent from NuGetGallery_";
 
-Message sent from NuGetGallery";
         private const string _expectedPlainTextBody =
-            @"Email: Sender (sender@gallery.org)
+            @"Email: Sender (sender@gallery\.org)
 
 Signature: signature
 
-Package: PackageId
-packageUrl
+Package: PackageId (packageUrl)
 
-Version: 1.0.0
-packageVersionUrl
+Version: 1.0.0 (packageVersionUrl)
 
-User: requestingUser (requestUser@gallery.org)
-profileUrl
+User: requestingUser (requestUser@gallery\.org) (profileUrl)
 
-Reason:
-reason
+Reason: reason
 
-Has the package owner been contacted?
-No
+Has the package owner been contacted? No
 
-Message:
-message
+Message: message
 
 Message sent from NuGetGallery";
 
         private const string _expectedHtmlBody =
-            "<p><strong>Email</strong>: Sender (sender@gallery.org)</p>\n" +
-"<p><strong>Signature</strong>: signature</p>\n" +
-"<p><strong>Package</strong>: PackageId\n" +
-"packageUrl</p>\n" +
-"<p><strong>Version</strong>: 1.0.0\n" +
-"packageVersionUrl</p>\n" +
-"<p><strong>User:</strong> requestingUser (requestUser@gallery.org)\n" +
-"profileUrl</p>\n" +
-"<p><strong>Reason</strong>:\n" +
-"reason</p>\n" +
-"<p><strong>Has the package owner been contacted?</strong>\n" +
-"No</p>\n" +
-"<p><strong>Message:</strong>\n" +
-"message</p>\n" +
-"<p>Message sent from NuGetGallery</p>\n";
+            "<p><strong>Email:</strong> Sender (sender@gallery.org)</p>\n" +
+"<p><strong>Signature:</strong> signature</p>\n" +
+"<p><strong>Package:</strong> <a href=\"packageUrl\">PackageId</a></p>\n" +
+"<p><strong>Version:</strong> <a href=\"packageVersionUrl\">1.0.0</a></p>\n" +
+"<p><strong>User:</strong> <a href=\"profileUrl\">requestingUser (requestUser@gallery.org)</a></p>\n" +
+"<p><strong>Reason:</strong> reason</p>\n" +
+"<p><strong>Has the package owner been contacted?</strong> No</p>\n" +
+"<p><strong>Message:</strong> message</p>\n" +
+"<p><em>Message sent from NuGetGallery</em></p>\n";
     }
 }

--- a/tests/NuGetGallery.Facts/Infrastructure/Mail/Messages/ReportMyPackageMessageFacts.cs
+++ b/tests/NuGetGallery.Facts/Infrastructure/Mail/Messages/ReportMyPackageMessageFacts.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -131,57 +131,42 @@ namespace NuGetGallery.Infrastructure.Mail.Messages
         }
 
         private const string _expectedMarkdownBody =
-            @"**Email**: Sender (sender@gallery.org)
+            @"**Email:** Sender (sender@gallery\.org)
 
-**Package**: PackageId
-packageUrl
+**Package:** [PackageId](packageUrl)
 
-**Version**: 1.0.0
-packageVersionUrl
+**Version:** [1.0.0](packageVersionUrl)
 
-**User:** requestingUser (requestUser@gallery.org)
-profileUrl
+**User:** [requestingUser (requestUser@gallery\.org)](profileUrl)
 
-**Reason**:
-reason
+**Reason:** reason
 
-**Message**:
-message
+**Message:** message
 
+_Message sent from NuGetGallery_";
 
-Message sent from NuGetGallery";
         private const string _expectedPlainTextBody =
-            @"Email: Sender (sender@gallery.org)
+            @"Email: Sender (sender@gallery\.org)
 
-Package: PackageId
-packageUrl
+Package: PackageId (packageUrl)
 
-Version: 1.0.0
-packageVersionUrl
+Version: 1.0.0 (packageVersionUrl)
 
-User: requestingUser (requestUser@gallery.org)
-profileUrl
+User: requestingUser (requestUser@gallery\.org) (profileUrl)
 
-Reason:
-reason
+Reason: reason
 
-Message:
-message
+Message: message
 
 Message sent from NuGetGallery";
 
         private const string _expectedHtmlBody =
-            "<p><strong>Email</strong>: Sender (sender@gallery.org)</p>\n" +
-"<p><strong>Package</strong>: PackageId\n" +
-"packageUrl</p>\n" +
-"<p><strong>Version</strong>: 1.0.0\n" +
-"packageVersionUrl</p>\n" +
-"<p><strong>User:</strong> requestingUser (requestUser@gallery.org)\n" +
-"profileUrl</p>\n" +
-"<p><strong>Reason</strong>:\n" +
-"reason</p>\n" +
-"<p><strong>Message</strong>:\n" +
-"message</p>\n" +
-"<p>Message sent from NuGetGallery</p>\n";
+            "<p><strong>Email:</strong> Sender (sender@gallery.org)</p>\n" +
+"<p><strong>Package:</strong> <a href=\"packageUrl\">PackageId</a></p>\n" +
+"<p><strong>Version:</strong> <a href=\"packageVersionUrl\">1.0.0</a></p>\n" +
+"<p><strong>User:</strong> <a href=\"profileUrl\">requestingUser (requestUser@gallery.org)</a></p>\n" +
+"<p><strong>Reason:</strong> reason</p>\n" +
+"<p><strong>Message:</strong> message</p>\n" +
+"<p><em>Message sent from NuGetGallery</em></p>\n";
     }
 }


### PR DESCRIPTION
We aren't correctly escaping the markdown in several of the emails we send. This is especially problematic in emails which reference packages that contain underscores in the ID as the URLs we send are invalid (underscore in markdown is for italics). I fixed this issue in a few common emails, but didn't want to do a full pass as there are a lot of emails and that's out of scope for the specific issue being addressed.

## Report Abuse
### Before
![image](https://github.com/user-attachments/assets/a47ec9a0-46cc-4fde-8875-050498a24098)

### After
![image](https://github.com/user-attachments/assets/f0e06ee6-0939-4dcb-9300-2d79809d0cd3)

## Contact Support (own package)
### Before
![image](https://github.com/user-attachments/assets/f619ae71-5bf2-4c70-99cc-7acdddc3c79f)

### After
![image](https://github.com/user-attachments/assets/45714929-7f30-4823-af85-12074b824a80)

## Upload Package
### Before
![image](https://github.com/user-attachments/assets/721adf48-6b37-4ce0-ae9b-d486692709d2)

### After
![image](https://github.com/user-attachments/assets/bf0892f5-cbf1-4eb5-9b58-6bf091a1e3dd)

## Contact Package Owner
### Before
![image](https://github.com/user-attachments/assets/d9d9958d-98d9-4097-908e-c288d3c7438d)

### After
![image](https://github.com/user-attachments/assets/0bc3c8c3-d690-4e20-911e-6a2ffce939e1)

Addresses https://github.com/NuGet/NuGetGallery/issues/1635