### PR TITLE
Initialism support in package manager tabs

### DIFF
--- a/src/NuGetGallery/ViewModels/PackageManagerViewModel.cs
+++ b/src/NuGetGallery/ViewModels/PackageManagerViewModel.cs
@@ -16,12 +16,21 @@ namespace NuGetGallery
         public PackageManagerViewModel(
             string id,
             string name,
-            params InstallPackageCommand[] installPackageCommands
-            )
+            params InstallPackageCommand[] installPackageCommands)
+            : this(id, name, initialismExplanation: null, installPackageCommands)
+        {
+        }
+
+        public PackageManagerViewModel(
+            string id,
+            string name,
+            string initialismExplanation,
+            params InstallPackageCommand[] installPackageCommands)
         {
             Id = id;
             Name = name;
-            CopyLabel = string.Format("Copy the {0} command", name);
+            InitialismExplanation = initialismExplanation;
+            CopyLabel = string.Format(CultureInfo.InvariantCulture, "Copy the {0} command", name);
             int index = 0;
             InstallPackageCommands = installPackageCommands.ToDictionary(
                 _ => string.Format(CultureInfo.InvariantCulture, "{0}-{1:0000}", Id, ++index),
@@ -34,6 +43,12 @@ namespace NuGetGallery
         /// The package manager's name.
         /// </summary>
         public string Name { get; }
+
+        /// <summary>
+        /// If <see cref="Name"/> is an initialism this property contains the explanation for it shown in a tooltip.
+        /// If null or empty string, <see cref="Name"/> is used instead.
+        /// </summary>
+        public string InitialismExplanation { get; } = null;
 
         /// <summary>
         /// A unique identifier that represents this package manager.

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -134,7 +134,8 @@
 
             new PackageManagerViewModel(
                 "package-manager",
-                "Package Manager",
+                "PMC",
+                "Package Manager Console",
                 new PackageManagerViewModel.InstallPackageCommand(
                     string.Format("NuGet\\Install-Package {0} -Version {1}", Model.Id, Model.Version)
                 )
@@ -168,6 +169,7 @@
 
             new PackageManagerViewModel(
                 "package-version",
+                "CPM",
                 "Central Package Management",
                 new PackageManagerViewModel.InstallPackageCommand(
                     "Directory.Packages.props",
@@ -262,7 +264,7 @@
            id="@packageManager.Id-tab" class="package-manager-tab"
            aria-selected="@(active ? "true" : "false")" tabindex="@(active ? "0" : "-1")"
            aria-controls="@packageManager.Id" role="tab" data-toggle="tab"
-           title="Switch to tab panel which contains package installation command for @packageManager.Name">
+           title="Switch to tab panel which contains package installation command for @(string.IsNullOrWhiteSpace(packageManager.InitialismExplanation) ? packageManager.Name : packageManager.InitialismExplanation)">
             @packageManager.Name
         </a>
     </li>


### PR DESCRIPTION
Quick stab at https://github.com/NuGet/NuGetGallery/issues/10481
Related to #10475. Helps with keeping everything on one line at least on wide-enough screens.

Introducing `InitialismExplanation` property for `PackageManagerViewModel` driving package manager tabs on package details page, so we can use shorter tab captions. The "explanation" is then used in the tool tip.

Replaced "Package manager" with "PMC" and "Central Package Management" with CPM.

Before

![image](https://github.com/user-attachments/assets/9942b59b-7a4a-49e5-8037-b994eaedd415)

![image](https://github.com/user-attachments/assets/34a414a6-12e5-4942-8bb9-4d468510a9fd)

After

![image](https://github.com/user-attachments/assets/c2d3d578-a5f9-4a1d-aa08-b63dc126b900)


![image](https://github.com/user-attachments/assets/cc26e935-a8e4-4fed-a43b-a6c212981589)


