### PR TITLE
Revert "[HotFix] Temporary limit to ascii only (#10409)"

### DIFF
--- a/src/AccountDeleter/EmptyFeatureFlagService.cs
+++ b/src/AccountDeleter/EmptyFeatureFlagService.cs
@@ -328,12 +328,7 @@ namespace NuGetGallery.AccountDeleter
         {
             throw new NotImplementedException();
         }
-
-        public bool IsAsciiOnlyPackageIdEnabled()
-        {
-            throw new NotImplementedException();
-        }
-
+        
         public bool IsProfileLoadOptimizationEnabled()
         {
             throw new NotImplementedException();

--- a/src/GitHubVulnerabilities2Db/Fakes/FakeFeatureFlagService.cs
+++ b/src/GitHubVulnerabilities2Db/Fakes/FakeFeatureFlagService.cs
@@ -329,12 +329,7 @@ namespace GitHubVulnerabilities2Db.Fakes
         {
             throw new NotImplementedException();
         }
-
-        public bool IsAsciiOnlyPackageIdEnabled()
-        {
-            throw new NotImplementedException();
-        }
-
+        
         public bool IsProfileLoadOptimizationEnabled()
         {
             throw new NotImplementedException();

--- a/src/NuGetGallery.Core/Packaging/ManifestValidator.cs
+++ b/src/NuGetGallery.Core/Packaging/ManifestValidator.cs
@@ -1,4 +1,4 @@
-// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -7,7 +7,6 @@ using System.ComponentModel.DataAnnotations;
 using System.Globalization;
 using System.IO;
 using System.Linq;
-using System.Net;
 using NuGet.Packaging;
 using NuGet.Versioning;
 
@@ -15,7 +14,7 @@ namespace NuGetGallery.Packaging
 {
     public class ManifestValidator
     {
-        public static IEnumerable<ValidationResult> Validate(Stream nuspecStream, bool asciiOnlyPackageIds, out NuspecReader nuspecReader, out PackageMetadata packageMetadata)
+        public static IEnumerable<ValidationResult> Validate(Stream nuspecStream, out NuspecReader nuspecReader, out PackageMetadata packageMetadata)
         {
             packageMetadata = null;
 
@@ -26,7 +25,7 @@ namespace NuGetGallery.Packaging
                 if (rawMetadata != null && rawMetadata.Any())
                 {
                     packageMetadata = PackageMetadata.FromNuspecReader(nuspecReader, strict: true);
-                    return ValidateCore(packageMetadata, asciiOnlyPackageIds);
+                    return ValidateCore(packageMetadata);
                 }
             }
             catch (Exception ex)
@@ -39,7 +38,7 @@ namespace NuGetGallery.Packaging
             return Enumerable.Empty<ValidationResult>();
         }
 
-        private static IEnumerable<ValidationResult> ValidateCore(PackageMetadata packageMetadata, bool asciiOnlyPackageIds)
+        private static IEnumerable<ValidationResult> ValidateCore(PackageMetadata packageMetadata)
         {
             // Validate the ID
             if (string.IsNullOrEmpty(packageMetadata.Id))
@@ -52,21 +51,12 @@ namespace NuGetGallery.Packaging
                 {
                     yield return new ValidationResult(CoreStrings.Manifest_IdTooLong);
                 }
-                else
+                else if (!PackageIdValidator.IsValidPackageId(packageMetadata.Id))
                 {
-                    if (!PackageIdValidator.IsValidPackageId(packageMetadata.Id))
-                    {
-                        yield return new ValidationResult(string.Format(
-                            CultureInfo.CurrentCulture,
-                            CoreStrings.Manifest_InvalidId,
-                            packageMetadata.Id));
-                    } else if (asciiOnlyPackageIds && !PackageIdValidator.IsAsciiOnlyPackageId(packageMetadata.Id))
-                    {
-                        yield return new ValidationResult(string.Format(
-                            CultureInfo.CurrentCulture,
-                            "Non-ASCII characters in package Id are temporary blocked, please check https://aka.ms/nuget/non-ascii-ids for updates.",
-                            packageMetadata.Id));
-                    }
+                    yield return new ValidationResult(String.Format(
+                        CultureInfo.CurrentCulture,
+                        CoreStrings.Manifest_InvalidId,
+                        packageMetadata.Id));
                 }
             }
 

--- a/src/NuGetGallery.Core/Packaging/PackageIdValidator.cs
+++ b/src/NuGetGallery.Core/Packaging/PackageIdValidator.cs
@@ -14,10 +14,6 @@ namespace NuGetGallery.Packaging
             @"^\w+([.-]\w+)*$",
             RegexOptions.IgnoreCase | RegexOptions.ExplicitCapture);
 
-        private static readonly Regex AllAsciiRegex = RegexEx.CreateWithTimeout(
-            @"^[A-Za-z0-9\-_\.]+$",
-            RegexOptions.IgnoreCase | RegexOptions.ExplicitCapture);
-
         public static bool IsValidPackageId(string packageId)
         {
             if (packageId == null)
@@ -25,27 +21,12 @@ namespace NuGetGallery.Packaging
                 throw new ArgumentNullException(nameof(packageId));
             }
 
-            if (string.Equals(packageId, "$id$", StringComparison.OrdinalIgnoreCase))
+            if (String.Equals(packageId, "$id$", StringComparison.OrdinalIgnoreCase))
             {
                 return false;
             }
 
             return IdRegex.IsMatch(packageId);
-        }
-
-        public static bool IsAsciiOnlyPackageId(string packageId)
-        {
-            if (packageId == null)
-            {
-                throw new ArgumentNullException(nameof(packageId));
-            }
-
-            if (string.Equals(packageId, "$id$", StringComparison.OrdinalIgnoreCase))
-            {
-                return false;
-            }
-
-            return AllAsciiRegex.IsMatch(packageId);
         }
 
         public static void ValidatePackageId(string packageId)
@@ -64,7 +45,7 @@ namespace NuGetGallery.Packaging
             {
                 throw new ArgumentException(string.Format(
                     CultureInfo.CurrentCulture,
-                    "The package ID '{0}' contains invalid characters. Package ID can only contain alphanumeric characters, hyphens, underscores, and periods.",
+                    "The package ID '{0}' contains invalid characters. Examples of valid package IDs include 'MyPackage' and 'MyPackage.Sample'.",
                     packageId));
             }
         }

--- a/src/NuGetGallery.Services/Configuration/FeatureFlagService.cs
+++ b/src/NuGetGallery.Services/Configuration/FeatureFlagService.cs
@@ -64,7 +64,6 @@ namespace NuGetGallery
         private const string DisplayTfmBadgesFeatureName = GalleryPrefix + "DisplayTfmBadges";
         private const string AdvancedFrameworkFilteringFeatureName = GalleryPrefix + "AdvancedFrameworkFiltering";
         private const string FederatedCredentialsFeatureName = GalleryPrefix + "FederatedCredentials";
-        private const string AsciiOnlyPackageIdFeatureName = GalleryPrefix + "AsciiOnlyPackageId";
         private const string ProfileLoadOptimization = GalleryPrefix + "ProfileLoadOptimization";
 
         private const string ODataV1GetAllNonHijackedFeatureName = GalleryPrefix + "ODataV1GetAllNonHijacked";
@@ -429,12 +428,7 @@ namespace NuGetGallery
         {
             return _client.IsEnabled(FederatedCredentialsFeatureName, user, defaultValue: false);
         }
-
-        public bool IsAsciiOnlyPackageIdEnabled()
-        {
-            return _client.IsEnabled(AsciiOnlyPackageIdFeatureName, defaultValue: false);
-        }
-
+        
         public bool IsProfileLoadOptimizationEnabled()
         {
             return _client.IsEnabled(ProfileLoadOptimization, defaultValue: true);

--- a/src/NuGetGallery.Services/Configuration/IFeatureFlagService.cs
+++ b/src/NuGetGallery.Services/Configuration/IFeatureFlagService.cs
@@ -348,13 +348,6 @@ namespace NuGetGallery
         /// </summary>
         bool CanUseFederatedCredentials(User user);
 
-        /// <summary>
-        /// Whether or not only ASCII characters are allowed in PackageId, used for temporary block unicode.
-        /// </summary>
-        bool IsAsciiOnlyPackageIdEnabled();
-
-        /// <summary>
-        /// Whether or not new paging method is used for the profile page.
         bool IsProfileLoadOptimizationEnabled();
     }
 }

--- a/src/NuGetGallery/Controllers/ApiController.cs
+++ b/src/NuGetGallery/Controllers/ApiController.cs
@@ -617,7 +617,7 @@ namespace NuGetGallery
 
                             NuspecReader nuspec;
                             PackageMetadata packageMetadata;
-                            var errors = ManifestValidator.Validate(packageToPush.GetNuspec(), FeatureFlagService.IsAsciiOnlyPackageIdEnabled(), out nuspec, out packageMetadata).ToArray();
+                            var errors = ManifestValidator.Validate(packageToPush.GetNuspec(), out nuspec, out packageMetadata).ToArray();
                             if (errors.Length > 0)
                             {
                                 var errorsString = string.Join("', '", errors.Select(error => error.ErrorMessage));

--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -420,7 +420,7 @@ namespace NuGetGallery
                     PackageArchiveReader packageArchiveReader = CreatePackage(uploadStream);
                     NuspecReader nuspec;
                     PackageMetadata packageMetadata;
-                    var errors = ManifestValidator.Validate(packageArchiveReader.GetNuspec(), _featureFlagService.IsAsciiOnlyPackageIdEnabled(), out nuspec, out packageMetadata).ToArray();
+                    var errors = ManifestValidator.Validate(packageArchiveReader.GetNuspec(), out nuspec, out packageMetadata).ToArray();
                     if (errors.Length > 0)
                     {
                         var errorStrings = new List<JsonValidationMessage>();

--- a/src/NuGetGallery/Services/SymbolPackageService.cs
+++ b/src/NuGetGallery/Services/SymbolPackageService.cs
@@ -1,4 +1,4 @@
-// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -120,7 +120,7 @@ namespace NuGetGallery
             PackageHelper.ValidateNuGetPackageMetadata(metadata);
 
             // Validate nuspec manifest.
-            var errors = ManifestValidator.Validate(symbolPackage.GetNuspec(), false, out var nuspec, out var packageMetadata).ToArray();
+            var errors = ManifestValidator.Validate(symbolPackage.GetNuspec(), out var nuspec, out var packageMetadata).ToArray();
             if (errors.Length > 0)
             {
                 var errorsString = string.Join("', '", errors.Select(error => error.ErrorMessage));

--- a/src/VerifyMicrosoftPackage/Fakes/FakeFeatureFlagService.cs
+++ b/src/VerifyMicrosoftPackage/Fakes/FakeFeatureFlagService.cs
@@ -137,9 +137,7 @@ namespace NuGet.VerifyMicrosoftPackage.Fakes
         public bool IsAdvancedFrameworkFilteringEnabled(User user) => throw new NotImplementedException();
 
         public bool CanUseFederatedCredentials(User user) => throw new NotImplementedException();
-
-        public bool IsAsciiOnlyPackageIdEnabled() => throw new NotImplementedException();
-
+        
         public bool IsProfileLoadOptimizationEnabled() => throw new NotImplementedException();
     }
 }

--- a/tests/NuGetGallery.Core.Facts/Packaging/ManifestValidatorFacts.cs
+++ b/tests/NuGetGallery.Core.Facts/Packaging/ManifestValidatorFacts.cs
@@ -1,4 +1,4 @@
-// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -364,22 +364,6 @@ namespace NuGetGallery.Packaging
                   </metadata>
                 </package>";
 
-        private const string NuSpecNonAsciiId = @"<?xml version=""1.0""?>
-                <package xmlns=""http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd"">
-                    <metadata>
-                    <id>пакет</id>
-                    <version>1.0.1-alpha</version>
-                    <title>Package A</title>
-                    <authors>ownera, ownerb</authors>
-                    <owners>ownera, ownerb</owners>
-                    <requireLicenseAcceptance>false</requireLicenseAcceptance>
-                    <description>package A description.</description>
-                    <language>en-US</language>
-                    <dependencies />
-                    </metadata>
-                </package>";
-
-
         [Fact]
         public void ReturnsErrorIfIdNotPresent()
         {
@@ -577,37 +561,23 @@ namespace NuGetGallery.Packaging
             var nuspecStream = CreateNuspecStream(NuSpecSemVer200);
 
             // Act
-            ManifestValidator.Validate(nuspecStream, false, out var reader, out var packageMetadata);
+            ManifestValidator.Validate(nuspecStream, out var reader, out var packageMetadata);
 
             // Assert
             Assert.NotNull(packageMetadata);
         }
 
-        [Fact]
-        public void BlocksNonAsciiPackageIdsIfEnabled()
-        {
-            // Arrange
-            var nuspecStream = CreateNuspecStream(NuSpecNonAsciiId);
-
-            // Act
-            var errors = ManifestValidator.Validate(nuspecStream, true, out var reader, out var packageMetadata).ToList();
-
-            // Assert
-            Assert.NotEmpty(errors);
-            Assert.Contains(errors, error => error.ErrorMessage.Contains("ASCII"));
-        }
-
         private static string[] GetErrors(Stream nuspecStream)
         {
             return ManifestValidator
-                .Validate(nuspecStream, false, out var reader, out var metadata)
+                .Validate(nuspecStream, out var reader, out var metadata)
                 .Select(r => r.ErrorMessage)
                 .ToArray();
         }
 
         private static Stream CreateNuspecStream(string nuspec)
         {
-            byte[] byteArray = Encoding.UTF8.GetBytes(nuspec);
+            byte[] byteArray = Encoding.ASCII.GetBytes(nuspec);
             return new MemoryStream(byteArray);
         }
     }

--- a/tests/NuGetGallery.Core.Facts/Packaging/PackageIdValidatorTest.cs
+++ b/tests/NuGetGallery.Core.Facts/Packaging/PackageIdValidatorTest.cs
@@ -53,7 +53,7 @@ namespace NuGetGallery.Packaging
             Assert.False(isValid);
         }
 
-        [Theory()]
+        [Theory]
         [InlineData("  Invalid  . Woo   .")]
         [InlineData("(/.__.)/ \\(.__.\\)")]
         public void ValidatePackageIdInvalidIdThrows(string packageId)
@@ -70,7 +70,7 @@ namespace NuGetGallery.Packaging
             }
 
             Assert.NotNull(thrownException);
-            Assert.Equal("The package ID '" + packageId + "' contains invalid characters. Package ID can only contain alphanumeric characters, hyphens, underscores, and periods.", thrownException.Message);
+            Assert.Equal("The package ID '" + packageId + "' contains invalid characters. Examples of valid package IDs include 'MyPackage' and 'MyPackage.Sample'.", thrownException.Message);
         }
 
         [Theory]
@@ -95,61 +95,6 @@ namespace NuGetGallery.Packaging
 
             Assert.NotNull(thrownException);
             Assert.Equal("Id must not exceed " + Constants.MaxPackageIdLength + " characters.", thrownException.Message);
-        }
-
-        [Fact]
-        public void IsAsciiPackageId_WithNull_ThrowsArgumentNullException()
-        {
-            // Arrange & Act & Assert
-            var exception = Assert.Throws<ArgumentNullException>(() => PackageIdValidator.IsAsciiOnlyPackageId(null));
-            Assert.Equal("packageId", exception.ParamName);
-        }
-
-        [Fact]
-        public void IsAsciiPackageId_WithTemplateId_ReturnsFalse()
-        {
-            // Arrange & Act
-            var result = PackageIdValidator.IsAsciiOnlyPackageId("$id$");
-
-            // Assert
-            Assert.False(result);
-        }
-
-        [Theory]
-        [InlineData("package")]
-        [InlineData("package.id")]
-        [InlineData("package-id")]
-        [InlineData("package_id")]
-        [InlineData("package.id-with_various.symbols")]
-        [InlineData("123456789")]
-        public void IsAsciiPackageId_WithAsciiOnlyCharacters_ReturnsTrue(string packageId)
-        {
-            // Arrange & Act
-            var result = PackageIdValidator.IsAsciiOnlyPackageId(packageId);
-
-            // Assert
-            Assert.True(result);
-        }
-
-        [Theory]
-        [InlineData("packageá")]
-        [InlineData("包")]
-        [InlineData("пакет")]
-        [InlineData("패키지")]
-        [InlineData("الحزمة")]
-        [InlineData("package™")]
-        [InlineData("package©")]
-        [InlineData("package£")]
-        [InlineData("elsökning")]
-        [InlineData("件")]
-        [InlineData("valoniα")]
-        public void IsAsciiPackageId_WithUnicodeCharacters_ReturnsFalse(string packageId)
-        {
-            // Arrange & Act
-            var result = PackageIdValidator.IsAsciiOnlyPackageId(packageId);
-
-            // Assert
-            Assert.False(result);
         }
     }
 }


### PR DESCRIPTION
This reverts commit e3638913253056432dc146ef29ba8ed5de785f0e.

We don't need this feature anymore.

Addresses https://github.com/NuGet/Engineering/issues/5857