### PR TITLE
More DevSkim suppressions

### DIFF
--- a/tools/Setup-DevEnvironment.ps1
+++ b/tools/Setup-DevEnvironment.ps1
@@ -97,7 +97,7 @@ if (!(Test-Path $AppCmdPath)) {
 
 # Enable access to the necessary URLs
 # S-1-1-0 is the unlocalized version for: user=Everyone 
-Invoke-Netsh http delete urlacl "url=http://$(Get-SiteHttpHost)/"
+Invoke-Netsh http delete urlacl "url=http://$(Get-SiteHttpHost)/" # DevSkim: ignore DS137138
 Invoke-Netsh http delete urlacl "url=https://$(Get-SiteHttpsHost)/"
 Invoke-Netsh http add urlacl "url=http://$(Get-SiteHttpHost)/" "sddl=D:(A;;GX;;;S-1-1-0)" # DevSkim: ignore DS137138
 Invoke-Netsh http add urlacl "url=https://$(Get-SiteHttpsHost)/" "sddl=D:(A;;GX;;;S-1-1-0)"


### PR DESCRIPTION
DevSkim complains about the edited line that it "uses" plain HTTP.

It sets up URL ACLs for local development. There is no way around it if we want to be able to accept plain HTTP requests while doing local development, so adding suppression.