### PR TITLE
Fix monitoring processor job 

### DIFF
--- a/src/Ng/Jobs/MonitoringProcessorJob.cs
+++ b/src/Ng/Jobs/MonitoringProcessorJob.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -271,7 +271,8 @@ namespace Ng.Jobs
 
             // Decode the package ID in case it was encoded for the queue message.
             string decodedPackageId = Uri.UnescapeDataString(packageId);
-            var packageIdentity = new FeedPackageIdentity(decodedPackageId, packageVersion);
+            string decodedPackageVersion = Uri.UnescapeDataString(packageVersion);
+            var packageIdentity = new FeedPackageIdentity(decodedPackageId, decodedPackageVersion);
             PackageValidatorContext queuedContext =
                 new PackageValidatorContext(packageIdentity, queueMessage.Contents.CatalogEntries);
 


### PR DESCRIPTION
Addresses: https://github.com/NuGet/Engineering/issues/5889

We have proper unicode blob storage
![image](https://github.com/user-attachments/assets/0a36b51b-aa33-435a-8f9e-993619223140)

But queue encode it as uri, for example `e2e.semver1stableunicodeid.250602.175918.6260110пакет包elsökning123/`, it's causing issues with [v3 metadata monitoring](https://portal.microsofticm.com/imp/v5/incidents/details/635972493/summary) , we need to escape it before use for logic.
![image](https://github.com/user-attachments/assets/e8c3401f-52d0-4f9f-b56a-ef4bb87b9018)

When monitoring processor job check [`search index result` vs `database entry`,](https://github.com/NuGet/NuGetGallery/blob/77cba4f2ac7b0d9e669c999d0ca3aff4cae5dfd2/src/NuGet.Services.Metadata.Catalog.Monitoring/Validation/Test/Search/SearchHasVersionValidator.cs#L25)  .
It finds the search index entry but fails to locate the corresponding database entry. This causes the comparison to fail and triggers a requeue, even though the entry is already encoded, leading to double encoding everytime it requeues. Eventually, the package ID reaches the 100-character limit due to repeated double encoding, which leads to a version parsing exception.

**Before fix**:
Blob storage:
![image](https://github.com/user-attachments/assets/14609fbe-3bb1-4b24-ab9e-4a6444ada28b)

Storage queue
![image](https://github.com/user-attachments/assets/313380f9-22a8-42a9-82c8-4f27c94b3b42)

**After fix**:
Blob moved moved to `valid`
![image](https://github.com/user-attachments/assets/9843e783-eb1a-425c-919a-d0e9fa53762d)

---------------
Another major contributor for package without Unicode id was encoding of versions, package was already successfully published: https://dev.nugettest.org/packages/e2e.semver2stablemetadataunlisted.250604.234541.8297363
![image](https://github.com/user-attachments/assets/58d54b16-1f37-45a4-9a22-dc524bd0f94c)

Above code is already deployed to DEV env, mitigated 3 IcMs.
