### PR TITLE
Added UI for .NET10 TFM

### DIFF
--- a/src/NuGetGallery.Core/Frameworks/SupportedFrameworks.cs
+++ b/src/NuGetGallery.Core/Frameworks/SupportedFrameworks.cs
@@ -116,6 +116,7 @@ namespace NuGetGallery.Frameworks
         public static class TfmFilters {
             public static readonly List<NuGetFramework> NetTfms = new List<NuGetFramework>
             {
+                Net100,
                 Net90,
                 Net80,
                 Net70,


### PR DESCRIPTION
Azure search index has been rebuilt, and I added the UI .NET10 checkbox to our search filters.

![image](https://github.com/user-attachments/assets/ce880850-86c9-48b5-8c64-f098ee4d3ec3)

Addresses https://github.com/orgs/NuGet/projects/21/views/1?pane=issue&itemId=99610317&issue=NuGet%7CEngineering%7C5792