### PR TITLE
Fixed TFM tooltip instability when checked/unchecked

### DIFF
--- a/src/NuGetGallery/Views/Shared/ListPackages.cshtml
+++ b/src/NuGetGallery/Views/Shared/ListPackages.cshtml
@@ -30,13 +30,13 @@
                     aria-label="shows and hides TFM filters for @(frameworkDisplayName)" aria-expanded="false" aria-controls="@(frameworkShortName)tab">
                 <i class="ms-Icon ms-Icon--ChevronRight" id="@(frameworkShortName)button"></i>
             </button>
-            <label class="brand-checkbox" style="display: flex; align-items: baseline;">
+            <label class="brand-checkbox">
                 <input type="checkbox" id="@(frameworkShortName)" class="framework">
                 <span>@(frameworkDisplayName)</span>
                 @if (frameworkDisplayName == ".NET")
                 {
-                    <a class="tooltip-target" href="javascript:void(0)" role="button" aria-labelledby="dotnetframework-tooltip">
-                        <i class="ms-Icon ms-Icon--Info" style="margin-left: 4px;"></i>
+                    <a class="tooltip-target" href="javascript:void(0)" role="button" aria-labelledby="dotnetframework-tooltip" style="margin-left: 4px; margin-top: 8px;">
+                        <i class="ms-Icon ms-Icon--Info"></i>
                         <span class="tooltip-block" role="tooltip" id="dotnetframework-tooltip">
                             <span class="tooltip-wrapper tooltip-with-icon popover right">
                                 <span class="arrow"></span>


### PR DESCRIPTION
Tooltip in TFM search moves slightly when checked or unchecked

* Made changes in the cshtml file to fix the the tooltip movement

Addresses https://github.com/NuGet/NuGetGallery/issues/9812

Deployed changes on dev and verified them
![Tooltip_Fix](https://github.com/user-attachments/assets/7e380851-9902-4e09-a3dc-78296410ee2c)
 