### PR TITLE
Only use DefaultAzureCredential for local debug

### DIFF
--- a/src/NuGet.Jobs.Common/StorageAccountExtensions.cs
+++ b/src/NuGet.Jobs.Common/StorageAccountExtensions.cs
@@ -175,25 +175,18 @@ namespace NuGet.Jobs
         {
             if (msiConfiguration.UseManagedIdentity)
             {
-                if (string.IsNullOrWhiteSpace(msiConfiguration.ManagedIdentityClientId))
-                {
 #if DEBUG
-                    return CloudBlobClientWrapper.UsingDefaultAzureCredential(
-                        storageConnectionString,
-                        readAccessGeoRedundant: readAccessGeoRedundant,
-                        requestTimeout: requestTimeout);
+                return CloudBlobClientWrapper.UsingDefaultAzureCredential(
+                    storageConnectionString,
+                    readAccessGeoRedundant: readAccessGeoRedundant,
+                    requestTimeout: requestTimeout);
 #else
-                    throw new InvalidOperationException("Managed identity client ID is not set.");
+                return CloudBlobClientWrapper.UsingMsi(
+                    storageConnectionString,
+                    msiConfiguration.ManagedIdentityClientId,
+                    readAccessGeoRedundant,
+                    requestTimeout);
 #endif
-                }
-                else
-                {
-                    return CloudBlobClientWrapper.UsingMsi(
-                        storageConnectionString,
-                        msiConfiguration.ManagedIdentityClientId,
-                        readAccessGeoRedundant,
-                        requestTimeout);
-                }
             }
 
             return new CloudBlobClientWrapper(

--- a/src/NuGet.Jobs.Common/StorageAccountExtensions.cs
+++ b/src/NuGet.Jobs.Common/StorageAccountExtensions.cs
@@ -177,10 +177,14 @@ namespace NuGet.Jobs
             {
                 if (string.IsNullOrWhiteSpace(msiConfiguration.ManagedIdentityClientId))
                 {
+#if DEBUG
                     return CloudBlobClientWrapper.UsingDefaultAzureCredential(
                         storageConnectionString,
                         readAccessGeoRedundant: readAccessGeoRedundant,
                         requestTimeout: requestTimeout);
+#else
+                    throw new InvalidOperationException("Managed identity client ID is not set.");
+#endif
                 }
                 else
                 {

--- a/src/NuGet.Services.Configuration/ConfigurationExtensions.cs
+++ b/src/NuGet.Services.Configuration/ConfigurationExtensions.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved. 
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information. 
 
-using System;
 using Azure.Core;
 using Azure.Identity;
 using Microsoft.Extensions.Configuration;
@@ -14,15 +13,10 @@ namespace NuGet.Services.Configuration
         {
             string clientId = configuration[Constants.ManagedIdentityClientIdKey];
 
-            if (!string.IsNullOrWhiteSpace(clientId))
-            {
-                return new ManagedIdentityCredential(clientId);
-            }
-
 #if DEBUG
             return new DefaultAzureCredential();
 #else
-            throw new InvalidOperationException("Managed identity client ID is not set.");
+            return new ManagedIdentityCredential(clientId);
 #endif
         }
     }

--- a/src/NuGet.Services.Configuration/ConfigurationExtensions.cs
+++ b/src/NuGet.Services.Configuration/ConfigurationExtensions.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved. 
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information. 
 
+using System;
 using Azure.Core;
 using Azure.Identity;
 using Microsoft.Extensions.Configuration;

--- a/src/NuGet.Services.Configuration/ConfigurationExtensions.cs
+++ b/src/NuGet.Services.Configuration/ConfigurationExtensions.cs
@@ -18,7 +18,11 @@ namespace NuGet.Services.Configuration
                 return new ManagedIdentityCredential(clientId);
             }
 
+#if DEBUG
             return new DefaultAzureCredential();
+#else
+            throw new InvalidOperationException("Managed identity client ID is not set.");
+#endif
         }
     }
 }

--- a/src/NuGet.Services.KeyVault/KeyVaultReader.cs
+++ b/src/NuGet.Services.KeyVault/KeyVaultReader.cs
@@ -99,7 +99,11 @@ namespace NuGet.Services.KeyVault
             {
                 if (string.IsNullOrEmpty(_configuration.ClientId) || _configuration.LocalDevelopment)
                 {
+#if DEBUG
                     credential = new DefaultAzureCredential();
+#else
+                    throw new InvalidOperationException("Managed identity client ID is not set.");
+#endif
                 }
                 else
                 {

--- a/src/NuGet.Services.KeyVault/KeyVaultReader.cs
+++ b/src/NuGet.Services.KeyVault/KeyVaultReader.cs
@@ -97,18 +97,11 @@ namespace NuGet.Services.KeyVault
 
             if (_configuration.UseManagedIdentity)
             {
-                if (string.IsNullOrEmpty(_configuration.ClientId) || _configuration.LocalDevelopment)
-                {
 #if DEBUG
-                    credential = new DefaultAzureCredential();
+                credential = new DefaultAzureCredential();
 #else
-                    throw new InvalidOperationException("Managed identity client ID is not set.");
+                credential = new ManagedIdentityCredential(_configuration.ClientId);
 #endif
-                }
-                else
-                {
-                    credential = new ManagedIdentityCredential(_configuration.ClientId);
-                }
             }
             else if (_configuration.SendX5c)
             {

--- a/src/NuGet.Services.ServiceBus/ServiceBusClientHelper.cs
+++ b/src/NuGet.Services.ServiceBus/ServiceBusClientHelper.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Azure.Core;
@@ -27,9 +27,19 @@ namespace NuGet.Services.ServiceBus
                 return new ServiceBusClient(connectionString);
             }
 
-            var credential = string.IsNullOrEmpty(managedIdentityClientId) 
-                ? (TokenCredential)new DefaultAzureCredential()
-                : new ManagedIdentityCredential(managedIdentityClientId);
+            TokenCredential credential;
+            if (string.IsNullOrWhiteSpace(managedIdentityClientId))
+            {
+#if DEBUG
+                credential = new DefaultAzureCredential();
+#else
+                throw new InvalidOperationException("Managed identity client ID is not set.");
+#endif
+            }
+            else
+            {
+                credential = new ManagedIdentityCredential(managedIdentityClientId);
+            }
 
             if (Uri.TryCreate(connectionString, UriKind.Absolute, out var uri) && uri.Scheme == "sb")
             {

--- a/src/NuGet.Services.ServiceBus/ServiceBusClientHelper.cs
+++ b/src/NuGet.Services.ServiceBus/ServiceBusClientHelper.cs
@@ -27,19 +27,11 @@ namespace NuGet.Services.ServiceBus
                 return new ServiceBusClient(connectionString);
             }
 
-            TokenCredential credential;
-            if (string.IsNullOrWhiteSpace(managedIdentityClientId))
-            {
 #if DEBUG
-                credential = new DefaultAzureCredential();
+            TokenCredential credential = new DefaultAzureCredential();
 #else
-                throw new InvalidOperationException("Managed identity client ID is not set.");
+            TokenCredential credential = new ManagedIdentityCredential(managedIdentityClientId);
 #endif
-            }
-            else
-            {
-                credential = new ManagedIdentityCredential(managedIdentityClientId);
-            }
 
             if (Uri.TryCreate(connectionString, UriKind.Absolute, out var uri) && uri.Scheme == "sb")
             {

--- a/src/NuGetGallery.Core/Services/CloudBlobClientWrapper.cs
+++ b/src/NuGetGallery.Core/Services/CloudBlobClientWrapper.cs
@@ -79,11 +79,7 @@ namespace NuGetGallery
             TimeSpan? requestTimeout = null)
         {
 #if DEBUG
-            var options = new DefaultAzureCredentialOptions
-            {
-                ManagedIdentityClientId = clientId,
-            };
-            var tokenCredential = new DefaultAzureCredential(options);
+            var tokenCredential = new DefaultAzureCredential();
             return new CloudBlobClientWrapper(storageConnectionString, tokenCredential, readAccessGeoRedundant, requestTimeout);
 #else
             throw new InvalidOperationException("DefaultAzureCredential is only supported in DEBUG builds.");

--- a/src/NuGetGallery.Core/Services/CloudBlobClientWrapper.cs
+++ b/src/NuGetGallery.Core/Services/CloudBlobClientWrapper.cs
@@ -78,12 +78,16 @@ namespace NuGetGallery
             bool readAccessGeoRedundant = false,
             TimeSpan? requestTimeout = null)
         {
+#if DEBUG
             var options = new DefaultAzureCredentialOptions
             {
                 ManagedIdentityClientId = clientId,
             };
             var tokenCredential = new DefaultAzureCredential(options);
             return new CloudBlobClientWrapper(storageConnectionString, tokenCredential, readAccessGeoRedundant, requestTimeout);
+#else
+            throw new InvalidOperationException("DefaultAzureCredential is only supported in DEBUG builds.");
+#endif
         }
 
         public ISimpleCloudBlob GetBlobFromUri(Uri uri)

--- a/src/NuGetGallery/App_Start/DefaultDependenciesModule.cs
+++ b/src/NuGetGallery/App_Start/DefaultDependenciesModule.cs
@@ -1593,7 +1593,9 @@ namespace NuGetGallery
                         connectionString,
                         readAccessGeoRedundant: useStorageReadAccessGeoRedundant);
 #else
-                    throw new InvalidOperationException("Managed identity client ID is not set.");
+                    return CloudBlobClientWrapper.UsingMsi(
+                        connectionString,
+                        readAccessGeoRedundant: useStorageReadAccessGeoRedundant);
 #endif
                 }
                 else

--- a/src/NuGetGallery/App_Start/DefaultDependenciesModule.cs
+++ b/src/NuGetGallery/App_Start/DefaultDependenciesModule.cs
@@ -1593,9 +1593,7 @@ namespace NuGetGallery
                         connectionString,
                         readAccessGeoRedundant: useStorageReadAccessGeoRedundant);
 #else
-                    return CloudBlobClientWrapper.UsingMsi(
-                        connectionString,
-                        readAccessGeoRedundant: useStorageReadAccessGeoRedundant);
+                    throw new InvalidOperationException("Managed identity client ID is not set.");
 #endif
                 }
                 else

--- a/tests/NuGet.Services.ServiceBus.Tests/ServiceBusClientHelperFacts.cs
+++ b/tests/NuGet.Services.ServiceBus.Tests/ServiceBusClientHelperFacts.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Xunit;
@@ -14,7 +14,7 @@ namespace NuGet.Services.ServiceBus.Tests
             {
                 var connectionString = "sb://mytestnamespace.servicebus.windows.net/";
 
-                var client = ServiceBusClientHelper.GetServiceBusClient(connectionString, managedIdentityClientId: null);
+                var client = ServiceBusClientHelper.GetServiceBusClient(connectionString, managedIdentityClientId: "clientId");
 
                 Assert.Equal("mytestnamespace.servicebus.windows.net", client.FullyQualifiedNamespace);
             }


### PR DESCRIPTION
> DefaultAzureCredential offers a balanced approach to retries, response wait times, and multiple authentication mechanisms. However, production workloads require resilience to latencies, robust retries, and deterministic behavior. Using DefaultAzureCredential() in Azure production services can lead to additional IcMs during managed identity service (IMDS) outages. During such outages, DefaultAzureCredential continues to probe additional credentials after ManagedIdentityCredential times out, including development-time credentials such as AzureCliCredential, AzureDeveloperCliCredential, and AzurePowerShellCredential. This behavior causes your service to be flagged by AzSecPack for suspicious activity.

We should avoid using `DefaultAzureCredential` in any context except for debug builds which can be used to more easily authenticate when developing locally.

Addresses https://github.com/NuGet/Engineering/issues/5869