### PR TITLE
Audit failures to create federated credential policies

### DIFF
--- a/src/NuGetGallery.Core/Auditing/FederatedCredentialPolicyAuditRecord.cs
+++ b/src/NuGetGallery.Core/Auditing/FederatedCredentialPolicyAuditRecord.cs
@@ -50,6 +50,11 @@ namespace NuGetGallery.Auditing
         /// A federated credential policy was modified.
         /// </summary>
         Update,
+
+        /// <summary>
+        /// Failure to create a federated credential policy.
+        /// </summary>
+        FailedToCreate,
     }
 
     public class FederatedCredentialPolicyAuditRecord : AuditRecord<AuditedFederatedCredentialPolicyAction>
@@ -64,18 +69,45 @@ namespace NuGetGallery.Auditing
             bool success,
             FederatedCredential? federatedCredential,
             IReadOnlyList<CredentialAuditRecord> apiKeyCredentials,
-            ExternalSecurityTokenAuditRecord? externalCredential) : base(action)
+            ExternalSecurityTokenAuditRecord? externalCredential) : this(
+                action,
+                policy.Key,
+                policy.Type,
+                policy.CreatedBy,
+                policy.PackageOwner,
+                policy.Criteria,
+                success,
+                federatedCredential,
+                apiKeyCredentials,
+                externalCredential,
+                null)
         {
-            Key = policy.Key;
-            Type = policy.Type.ToString();
-            Criteria = policy.Criteria;
-            CreatedByUsername = policy.CreatedBy.Username;
-            PackageOwnerUsername = policy.PackageOwner.Username;
+        }
+
+        private FederatedCredentialPolicyAuditRecord(
+            AuditedFederatedCredentialPolicyAction action,
+            int key,
+            FederatedCredentialType type,
+            User createdBy,
+            User packageOwner,
+            string criteria,
+            bool success,
+            FederatedCredential? federatedCredential,
+            IReadOnlyList<CredentialAuditRecord> apiKeyCredentials,
+            ExternalSecurityTokenAuditRecord? externalCredential,
+            string? errorMessage) : base(action)
+        {
+            Key = key;
+            Type = type.ToString();
+            Criteria = criteria;
+            CreatedByUsername = createdBy.Username;
+            PackageOwnerUsername = packageOwner.Username;
 
             Success = success;
             FederatedCredential = federatedCredential is null ? null : new FederatedCredentialAuditRecord(AuditedFederatedCredentialAction.Create, federatedCredential);
             ApiKeyCredentials = apiKeyCredentials;
             ExternalCredential = externalCredential;
+            ErrorMessage = errorMessage;
         }
 
         public int Key { get; }
@@ -87,6 +119,7 @@ namespace NuGetGallery.Auditing
         public IReadOnlyList<CredentialAuditRecord> ApiKeyCredentials { get; }
         public bool Success { get; }
         public ExternalSecurityTokenAuditRecord? ExternalCredential { get; }
+        public string? ErrorMessage { get; }
 
         public static FederatedCredentialPolicyAuditRecord Compare(
             FederatedCredentialPolicy policy,
@@ -183,6 +216,27 @@ namespace NuGetGallery.Auditing
                 federatedCredential: null,
                 apiKeyCredentials: [],
                 externalCredential: null);
+        }
+
+        public static FederatedCredentialPolicyAuditRecord FailedToCreate(
+            FederatedCredentialType type,
+            User createdBy,
+            User packageOwner,
+            string criteria,
+            string errorMessage)
+        {
+            return new FederatedCredentialPolicyAuditRecord(
+                AuditedFederatedCredentialPolicyAction.FailedToCreate,
+                0,
+                type,
+                createdBy,
+                packageOwner,
+                criteria,
+                success: false,
+                federatedCredential: null,
+                apiKeyCredentials: [],
+                externalCredential: null,
+                errorMessage: errorMessage);
         }
 
         public override string GetPath()

--- a/src/NuGetGallery.Core/Auditing/FederatedCredentialPolicyAuditRecord.cs
+++ b/src/NuGetGallery.Core/Auditing/FederatedCredentialPolicyAuditRecord.cs
@@ -91,7 +91,7 @@ namespace NuGetGallery.Auditing
 
         private FederatedCredentialPolicyAuditRecord(
             AuditedFederatedCredentialPolicyAction action,
-            int key,
+            int? key,
             FederatedCredentialType type,
             User createdBy,
             User packageOwner,
@@ -115,7 +115,7 @@ namespace NuGetGallery.Auditing
             ErrorMessage = errorMessage;
         }
 
-        public int Key { get; }
+        public int? Key { get; }
         public string Type { get; }
         public string Criteria { get; }
         public string CreatedByUsername { get; }
@@ -232,7 +232,7 @@ namespace NuGetGallery.Auditing
         {
             return new FederatedCredentialPolicyAuditRecord(
                 AuditedFederatedCredentialPolicyAction.BadRequest,
-                0, // no DB policy key
+                null, // no DB policy key
                 type,
                 createdBy,
                 packageOwner,
@@ -253,7 +253,7 @@ namespace NuGetGallery.Auditing
         {
             return new FederatedCredentialPolicyAuditRecord(
                 AuditedFederatedCredentialPolicyAction.Unauthorized,
-                0, // no DB policy key
+                null, // no DB policy key
                 type,
                 createdBy,
                 packageOwner,
@@ -267,7 +267,7 @@ namespace NuGetGallery.Auditing
 
         public override string GetPath()
         {
-            return $"{Type}/{Key}";
+            return $"{Type}/{Key?.ToString() ?? "no-key"}";
         }
     }
 }

--- a/src/NuGetGallery.Core/Auditing/FederatedCredentialPolicyAuditRecord.cs
+++ b/src/NuGetGallery.Core/Auditing/FederatedCredentialPolicyAuditRecord.cs
@@ -227,7 +227,7 @@ namespace NuGetGallery.Auditing
         {
             return new FederatedCredentialPolicyAuditRecord(
                 AuditedFederatedCredentialPolicyAction.FailedToCreate,
-                0,
+                0, // no DB keys for failed-to-create policies
                 type,
                 createdBy,
                 packageOwner,

--- a/src/NuGetGallery.Core/Auditing/FederatedCredentialPolicyAuditRecord.cs
+++ b/src/NuGetGallery.Core/Auditing/FederatedCredentialPolicyAuditRecord.cs
@@ -52,9 +52,14 @@ namespace NuGetGallery.Auditing
         Update,
 
         /// <summary>
-        /// Failure to create a federated credential policy.
+        /// Bad request occurred while creating a <see cref="FederatedCredentialPolicy"/>.
         /// </summary>
-        FailedToCreate,
+        BadRequest,
+
+        /// <summary>
+        /// Unauthorized request while creating a <see cref="FederatedCredentialPolicy"/>.
+        /// </summary>
+        Unauthorized,
     }
 
     public class FederatedCredentialPolicyAuditRecord : AuditRecord<AuditedFederatedCredentialPolicyAction>
@@ -218,7 +223,7 @@ namespace NuGetGallery.Auditing
                 externalCredential: null);
         }
 
-        public static FederatedCredentialPolicyAuditRecord FailedToCreate(
+        public static FederatedCredentialPolicyAuditRecord BadRequest(
             FederatedCredentialType type,
             User createdBy,
             User packageOwner,
@@ -226,8 +231,29 @@ namespace NuGetGallery.Auditing
             string errorMessage)
         {
             return new FederatedCredentialPolicyAuditRecord(
-                AuditedFederatedCredentialPolicyAction.FailedToCreate,
-                0, // no DB keys for failed-to-create policies
+                AuditedFederatedCredentialPolicyAction.BadRequest,
+                0, // no DB policy key
+                type,
+                createdBy,
+                packageOwner,
+                criteria,
+                success: false,
+                federatedCredential: null,
+                apiKeyCredentials: [],
+                externalCredential: null,
+                errorMessage: errorMessage);
+        }
+
+        public static FederatedCredentialPolicyAuditRecord Unauthorized(
+            FederatedCredentialType type,
+            User createdBy,
+            User packageOwner,
+            string criteria,
+            string errorMessage)
+        {
+            return new FederatedCredentialPolicyAuditRecord(
+                AuditedFederatedCredentialPolicyAction.Unauthorized,
+                0, // no DB policy key
                 type,
                 createdBy,
                 packageOwner,

--- a/src/NuGetGallery.Services/Authentication/Federated/AddFederatedCredentialPolicyResult.cs
+++ b/src/NuGetGallery.Services/Authentication/Federated/AddFederatedCredentialPolicyResult.cs
@@ -12,6 +12,7 @@ namespace NuGetGallery.Services.Authentication
     {
         Created,
         BadRequest,
+        Unauthorized,
     }
 
     public class AddFederatedCredentialPolicyResult
@@ -38,5 +39,8 @@ namespace NuGetGallery.Services.Authentication
 
         public static AddFederatedCredentialPolicyResult BadRequest(string userMessage)
             => new AddFederatedCredentialPolicyResult(AddFederatedCredentialPolicyResultType.BadRequest, userMessage);
+
+        public static AddFederatedCredentialPolicyResult Unauthorized(string userMessage)
+            => new AddFederatedCredentialPolicyResult(AddFederatedCredentialPolicyResultType.Unauthorized, userMessage);
     }
 }

--- a/src/NuGetGallery.Services/Authentication/Federated/FederatedCredentialService.cs
+++ b/src/NuGetGallery.Services/Authentication/Federated/FederatedCredentialService.cs
@@ -160,6 +160,7 @@ namespace NuGetGallery.Services.Authentication
                     break;
 
                 case AddFederatedCredentialPolicyResultType.Created:
+                    // For successful policy creation audit is logged in AddPolicyAsync.
                     break;
 
                 default:
@@ -210,6 +211,7 @@ namespace NuGetGallery.Services.Authentication
                     break;
 
                 case AddFederatedCredentialPolicyResultType.Created:
+                    // For successful policy creation audit is logged in AddPolicyAsync.
                     break;
 
                 default:
@@ -230,6 +232,14 @@ namespace NuGetGallery.Services.Authentication
             return await AddPolicyAsync(createdBy, packageOwner, policyName, policyType, criteria);
         }
 
+        /// <summary>
+        /// Adds a new federated credential policy for the specified user and package owner. 
+        /// The policy defines the trust relationship and scoping for federated credential authentication.
+        /// </summary>
+        /// <remarks>
+        /// An audit record is generated and saved if the policy is successfully created.
+        /// No audit record is created for unsuccessful attempts.
+        /// </remarks>
         private async Task<AddFederatedCredentialPolicyResult> AddPolicyAsync(User createdBy, User packageOwner, string? policyName, FederatedCredentialType policyType, string criteria)
         {
             if (createdBy is Organization)

--- a/tests/NuGetGallery.Facts/Authentication/Federated/FederatedCredentialServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Authentication/Federated/FederatedCredentialServiceFacts.cs
@@ -38,7 +38,12 @@ namespace NuGetGallery.Services.Authentication
                 Assert.Equal(AddFederatedCredentialPolicyResultType.BadRequest, result.Type);
                 Assert.StartsWith($"Policy user '{CurrentUser.Username}' is an organization.", result.UserMessage);
 
-                AssertNoAudits();
+                AssertFailedCreateAudit(
+                    CurrentUser,
+                    PackageOwner,
+                    FederatedCredentialType.EntraIdServicePrincipal,
+                    """{"tid":"58fa0116-d469-4fc9-83c8-9b1a8706d9cc","oid":"4ab4b916-b6de-4412-aee0-808ef692b270"}""",
+                    result.UserMessage);
             }
 
             [Fact]
@@ -54,7 +59,12 @@ namespace NuGetGallery.Services.Authentication
                 Assert.Equal(AddFederatedCredentialPolicyResultType.BadRequest, result.Type);
                 Assert.StartsWith($"The user '{CurrentUser.Username}' does not have the required permissions", result.UserMessage);
 
-                AssertNoAudits();
+                AssertFailedCreateAudit(
+                    CurrentUser,
+                    PackageOwner,
+                    FederatedCredentialType.EntraIdServicePrincipal,
+                    """{"tid":"58fa0116-d469-4fc9-83c8-9b1a8706d9cc","oid":"4ab4b916-b6de-4412-aee0-808ef692b270"}""",
+                    result.UserMessage);
             }
 
             [Fact]
@@ -70,7 +80,12 @@ namespace NuGetGallery.Services.Authentication
                 Assert.Equal(AddFederatedCredentialPolicyResultType.BadRequest, result.Type);
                 Assert.StartsWith($"The package owner '{PackageOwner.Username}' is not enabled to use federated credentials.", result.UserMessage);
 
-                AssertNoAudits();
+                AssertFailedCreateAudit(
+                    CurrentUser,
+                    PackageOwner,
+                    FederatedCredentialType.EntraIdServicePrincipal,
+                    """{"tid":"58fa0116-d469-4fc9-83c8-9b1a8706d9cc","oid":"4ab4b916-b6de-4412-aee0-808ef692b270"}""",
+                    result.UserMessage);
             }
 
             [Fact]
@@ -88,7 +103,12 @@ namespace NuGetGallery.Services.Authentication
 
                 Assert.Empty(FederatedCredentialRepository.Invocations);
 
-                AssertNoAudits();
+                AssertFailedCreateAudit(
+                    CurrentUser,
+                    PackageOwner,
+                    FederatedCredentialType.EntraIdServicePrincipal,
+                    """{"tid":"58fa0116-d469-4fc9-83c8-9b1a8706d9cc","oid":"4ab4b916-b6de-4412-aee0-808ef692b270"}""",
+                    result.UserMessage);
             }
 
             [Fact]
@@ -104,9 +124,8 @@ namespace NuGetGallery.Services.Authentication
                 Assert.Same(PackageOwner, result.Policy.PackageOwner);
                 Assert.Equal(FederatedCredentialType.EntraIdServicePrincipal, result.Policy.Type);
                 Assert.Equal(
-                    """
-                    {"tid":"58fa0116-d469-4fc9-83c8-9b1a8706d9cc","oid":"4ab4b916-b6de-4412-aee0-808ef692b270"}
-                    """, result.Policy.Criteria);
+                    """{"tid":"58fa0116-d469-4fc9-83c8-9b1a8706d9cc","oid":"4ab4b916-b6de-4412-aee0-808ef692b270"}""",
+                    result.Policy.Criteria);
                 Assert.Null(result.Policy.LastMatched);
 
                 FeatureFlagService.Verify(x => x.CanUseFederatedCredentials(PackageOwner), Times.Once);
@@ -152,7 +171,12 @@ namespace NuGetGallery.Services.Authentication
                 Assert.Equal(AddFederatedCredentialPolicyResultType.BadRequest, result.Type);
                 Assert.StartsWith($"The user '{CurrentUser.Username}' does not have the required permissions", result.UserMessage);
 
-                AssertNoAudits();
+                AssertFailedCreateAudit(
+                    CurrentUser,
+                    PackageOwner,
+                    PolicyType,
+                    PolicyCriteria,
+                    result.UserMessage);
             }
 
             [Fact]
@@ -168,7 +192,12 @@ namespace NuGetGallery.Services.Authentication
                 Assert.Equal(AddFederatedCredentialPolicyResultType.BadRequest, result.Type);
                 Assert.StartsWith("Trusted Publishing is not enabled", result.UserMessage);
 
-                AssertNoAudits();
+                AssertFailedCreateAudit(
+                    CurrentUser,
+                    PackageOwner,
+                    PolicyType,
+                    PolicyCriteria,
+                    result.UserMessage);
             }
 
             [Fact]
@@ -718,6 +747,22 @@ namespace NuGetGallery.Services.Authentication
         protected void AssertNoAudits()
         {
             AuditingService.Verify(x => x.SaveAuditRecordAsync(It.IsAny<AuditRecord>()), Times.Never);
+        }
+
+        protected void AssertFailedCreateAudit(User createdBy, User packageOwner, FederatedCredentialType policyType, string criteria, string failureReason)
+        {
+            var audits = AssertAuditResourceTypes(FederatedCredentialPolicyAuditRecord.ResourceType);
+            var policyAudit = Assert.IsType<FederatedCredentialPolicyAuditRecord>(audits[0]);
+            Assert.Equal(AuditedFederatedCredentialPolicyAction.FailedToCreate, policyAudit.Action);
+
+            // Verify the audit record was created with the expected parameters
+            AuditingService.Verify(x => x.SaveAuditRecordAsync(
+                It.Is<FederatedCredentialPolicyAuditRecord>(audit =>
+                    audit.Action == AuditedFederatedCredentialPolicyAction.FailedToCreate &&
+                    audit.Type == policyType.ToString() &&
+                    audit.Criteria == criteria &&
+                    audit.ErrorMessage == failureReason
+                )), Times.Once);
         }
 
         private void AssertRejectReplayAudit()


### PR DESCRIPTION
Currently we audit following `FederatedCredentialPolicy` activities, with **failed policy creation** added by this change

**Data Modification Auditing**
* Policy Creation - New policy successfully created
* Policy Deletion - Policy deleted with associated API keys
* Policy Update - Policy modified with API key cleanup
* 🆕 **Failed Policy Creation** - Creation attempt failed with reason

**Data Access/Usage Auditing**
* Policy Comparison - OIDC token evaluated against policy
* API Key Exchange - Successful token-to-API-key conversion
* Token Replay Rejection - Duplicate token usage blocked
* First Use Policy Update - Auto-update on initial use


https://github.com/NuGet/Engineering/issues/5934