### PR TITLE
Pack sdk style projects using nuspec file for internal projects

### DIFF
--- a/build/common.ps1
+++ b/build/common.ps1
@@ -687,7 +687,7 @@ Function New-Package {
         }
         else {
             # Throw exception if .nuspec file doesn't exist for SDK-style project
-            Error-Log "SDK-style project detected but required .nuspec file not found at: $nuspecPath" -Fatal
+            throw "SDK-style project '$projectName' detected but required .nuspec file for packing not found at: $nuspecPath"
         }
     }
     else {


### PR DESCRIPTION
The `build/common.ps1` file in the Gallery repository is used for packing project into .nupkg files in internal repositories.

I added nuget.exe packing support for SDK-style .csproj files in the internal repository, since we’re already doing it for this Gallery repository. For example, [Auxiliary2AzureSearch.csproj](https://github.com/NuGet/NuGetGallery/blob/main/src/NuGet.Jobs.Auxiliary2AzureSearch/NuGet.Jobs.Auxiliary2AzureSearch.csproj) which SDK type, use [this NuGet.Jobs.Auxiliary2AzureSearch.nuspec file](https://github.com/NuGet/NuGetGallery/blob/ed98da6f9aa60d40e7b5c918440c6ee3c8e2aa95/build.ps1#L139C6-L139C90) for packing , actual nuspec [is here](https://github.com/NuGet/NuGetGallery/blob/main/src/NuGet.Jobs.Auxiliary2AzureSearch/NuGet.Jobs.Auxiliary2AzureSearch.nuspec). 

An alternative solution would be to use msbuild or dotnet pack, but that would require packaging it as a dotnet tool. It also doesn’t account for the include `scripting files + nssm.exe file`, which feels like overkill and complicated setup  compared to the simpler approach above already exist.