### PR TITLE
Fix registration scope for OIDC related objects

### DIFF
--- a/src/NuGetGallery/App_Start/DefaultDependenciesModule.cs
+++ b/src/NuGetGallery/App_Start/DefaultDependenciesModule.cs
@@ -583,7 +583,7 @@ namespace NuGetGallery
 
             builder
                 .RegisterType<JsonWebTokenHandler>()
-                .InstancePerDependency();
+                .InstancePerLifetimeScope();
 
             builder
                 .Register(c =>
@@ -595,7 +595,7 @@ namespace NuGetGallery
                     }).ToList();
                 })
                 .As<IReadOnlyList<IFederatedCredentialValidator>>() // a singleton, materialized list
-                .SingleInstance();
+                .InstancePerLifetimeScope();
 
             // Register individual validators
             builder
@@ -605,7 +605,7 @@ namespace NuGetGallery
                     c.Resolve<JsonWebTokenHandler>()))
                 .As<IEntraIdTokenValidator>()
                 .As<ITokenPolicyValidator>()
-                .SingleInstance();
+                .InstancePerLifetimeScope();
 
             builder
                 .Register(c => new GitHubTokenPolicyValidator(
@@ -616,12 +616,12 @@ namespace NuGetGallery
                     c.Resolve<JsonWebTokenHandler>()
                     ))
                 .As<ITokenPolicyValidator>()
-                .SingleInstance();
+                .InstancePerLifetimeScope();
 
             builder
                 .RegisterType<FederatedCredentialPolicyEvaluator>()
                 .As<IFederatedCredentialPolicyEvaluator>()
-                .InstancePerDependency();
+                .InstancePerLifetimeScope();
 
             builder
                 .RegisterType<FederatedCredentialService>()


### PR DESCRIPTION
### 🐞 Root Cause

The issue stemmed from the `GitHubTokenPolicyValidator` being registered as a singleton. This caused it to retain a reference to the `IFederatedCredentialRepository`, which is instantiated per HTTP request. As a result, when attempting a "first use" update on an incoming policy, the validator operated with an outdated or incorrect DB context—leading to a no-op.

### ✅ Fix

The solution is to register the OIDC service and validator objects using `InstancePerLifetimeScope` (i.e., once per HTTP request). This ensures that each request gets a fresh and valid instance of the DB access object.
