### PR TITLE
Do not apply 1P OIDC feature flag to 3P scenarios

### DIFF
--- a/src/NuGetGallery.Services/Authentication/Federated/FederatedCredentialService.cs
+++ b/src/NuGetGallery.Services/Authentication/Federated/FederatedCredentialService.cs
@@ -458,11 +458,6 @@ namespace NuGetGallery.Services.Authentication
                 return error;
             }
 
-            if (!_featureFlagService.CanUseFederatedCredentials(packageOwner))
-            {
-                return GenerateApiKeyResult.BadRequest(NotInFlightMessage(packageOwner));
-            }
-
             return null;
         }
 

--- a/src/NuGetGallery.Services/Configuration/IFeatureFlagService.cs
+++ b/src/NuGetGallery.Services/Configuration/IFeatureFlagService.cs
@@ -350,12 +350,16 @@ namespace NuGetGallery
         bool IsAdvancedFrameworkFilteringEnabled(User user);
 
         /// <summary>
-        /// Whether or not the user specified in a package owner scope can use federated credentials.
+        /// Whether or not the user specified in a package owner scope can use federated credentials,
+        /// a.k.a. Entra ID. When enabled, this controls both the ability to create federated credential
+        /// policies and the ability to exchange external tokens for NuGet API keys during package operations.
         /// </summary>
         bool CanUseFederatedCredentials(User user);
 
         /// <summary>
-        /// Whether or not the user can access trusted publishing functionality.
+        /// Whether or not the user can access trusted publishing functionality, e.g. GitHub Actions workflows.
+        /// When enabled, this controls both the ability to create Trusted Publishing policies and the ability
+        /// to exchange external tokens for NuGet API keys during package operations.
         /// </summary>
         bool IsTrustedPublishingEnabled(User user);
 

--- a/src/NuGetGallery/App_Start/DefaultDependenciesModule.cs
+++ b/src/NuGetGallery/App_Start/DefaultDependenciesModule.cs
@@ -602,6 +602,7 @@ namespace NuGetGallery
                 .Register(c => new EntraIdTokenPolicyValidator(
                     c.ResolveKeyed<ConfigurationManager<OpenIdConnectConfiguration>>(EntraIdKey),
                     c.Resolve<IFederatedCredentialConfiguration>(),
+                    c.Resolve<IFeatureFlagService>(),
                     c.Resolve<JsonWebTokenHandler>()))
                 .As<IEntraIdTokenValidator>()
                 .As<ITokenPolicyValidator>()
@@ -613,6 +614,7 @@ namespace NuGetGallery
                     c.ResolveKeyed<ConfigurationManager<OpenIdConnectConfiguration>>(GitHubActionsKey),
                     c.Resolve<IFederatedCredentialConfiguration>(),
                     c.Resolve<IAuditingService>(),
+                    c.Resolve<IFeatureFlagService>(),
                     c.Resolve<JsonWebTokenHandler>()
                     ))
                 .As<ITokenPolicyValidator>()

--- a/tests/NuGetGallery.Facts/Authentication/Federated/EntraIdTokenValidatorFacts.cs
+++ b/tests/NuGetGallery.Facts/Authentication/Federated/EntraIdTokenValidatorFacts.cs
@@ -237,6 +237,7 @@ namespace NuGetGallery.Services.Authentication
             public async Task RejectsMissingClaim(string claim)
             {
                 // Arrange
+                FeatureFlagService.Setup(x => x.CanUseFederatedCredentials(PackageOwner)).Returns(true);
                 var policy = new FederatedCredentialPolicy
                 {
                     Type = FederatedCredentialType.EntraIdServicePrincipal,
@@ -270,6 +271,7 @@ namespace NuGetGallery.Services.Authentication
             public async Task RejectsInvalidCredentialType()
             {
                 // Arrange
+                FeatureFlagService.Setup(x => x.CanUseFederatedCredentials(PackageOwner)).Returns(true);
                 var policy = new FederatedCredentialPolicy
                 {
                     Type = FederatedCredentialType.EntraIdServicePrincipal,
@@ -302,6 +304,7 @@ namespace NuGetGallery.Services.Authentication
             public async Task RejectsInvalidIdentityType()
             {
                 // Arrange
+                FeatureFlagService.Setup(x => x.CanUseFederatedCredentials(PackageOwner)).Returns(true);
                 var policy = new FederatedCredentialPolicy
                 {
                     Type = FederatedCredentialType.EntraIdServicePrincipal,
@@ -334,6 +337,7 @@ namespace NuGetGallery.Services.Authentication
             public async Task RejectsInvalidVersion()
             {
                 // Arrange
+                FeatureFlagService.Setup(x => x.CanUseFederatedCredentials(PackageOwner)).Returns(true);
                 var policy = new FederatedCredentialPolicy
                 {
                     Type = FederatedCredentialType.EntraIdServicePrincipal,
@@ -366,6 +370,7 @@ namespace NuGetGallery.Services.Authentication
             public async Task RejectsOidNotMatchingSub()
             {
                 // Arrange
+                FeatureFlagService.Setup(x => x.CanUseFederatedCredentials(PackageOwner)).Returns(true);
                 var policy = new FederatedCredentialPolicy
                 {
                     Type = FederatedCredentialType.EntraIdServicePrincipal,
@@ -398,6 +403,7 @@ namespace NuGetGallery.Services.Authentication
             public async Task RejectsWrongTenantId()
             {
                 // Arrange
+                FeatureFlagService.Setup(x => x.CanUseFederatedCredentials(PackageOwner)).Returns(true);
                 var policy = new FederatedCredentialPolicy
                 {
                     Type = FederatedCredentialType.EntraIdServicePrincipal,
@@ -430,6 +436,7 @@ namespace NuGetGallery.Services.Authentication
             public async Task RejectsNotAllowedTenantId()
             {
                 // Arrange
+                FeatureFlagService.Setup(x => x.CanUseFederatedCredentials(PackageOwner)).Returns(true);
                 AllowedTenantIds = ["different-tenant-id"];
 
                 var policy = new FederatedCredentialPolicy
@@ -464,6 +471,7 @@ namespace NuGetGallery.Services.Authentication
             public async Task RejectsWrongObjectId()
             {
                 // Arrange
+                FeatureFlagService.Setup(x => x.CanUseFederatedCredentials(PackageOwner)).Returns(true);
                 var differentObjectId = new Guid("d8f0bfc3-5def-4079-b08c-618832b6ae16");
                 var policy = new FederatedCredentialPolicy
                 {
@@ -562,6 +570,7 @@ namespace NuGetGallery.Services.Authentication
             public async Task RejectsInvalidCriteriaJson()
             {
                 // Arrange
+                FeatureFlagService.Setup(x => x.CanUseFederatedCredentials(PackageOwner)).Returns(true);
                 var policy = new FederatedCredentialPolicy
                 {
                     Type = FederatedCredentialType.EntraIdServicePrincipal,

--- a/tests/NuGetGallery.Facts/Authentication/Federated/FederatedCredentialServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Authentication/Federated/FederatedCredentialServiceFacts.cs
@@ -529,22 +529,6 @@ namespace NuGetGallery.Services.Authentication
             }
 
             [Fact]
-            public async Task RejectsPackageOwnerNotInFlight()
-            {
-                // Arrange
-                FeatureFlagService.Setup(x => x.CanUseFederatedCredentials(PackageOwner)).Returns(false);
-
-                // Act
-                var result = await Target.GenerateApiKeyAsync(CurrentUser.Username, BearerToken, RequestHeaders);
-
-                // Assert
-                Assert.Equal(GenerateApiKeyResultType.BadRequest, result.Type);
-                Assert.Equal("The package owner 'jim-org' is not enabled to use federated credentials.", result.UserMessage);
-
-                AssertNoAudits();
-            }
-
-            [Fact]
             public async Task RejectsCredentialWithInvalidScopes()
             {
                 // Arrange


### PR DESCRIPTION
Currently we check 1P feature flag `CanUseFederatedCredentials` when validating policies for which apply to 3P, a.k.a. GitHub Actions. We should use `IsTrustedPublishingEnabled` instead. 