### PR TITLE
[OIDC] API Key v5 - 3: Hide the key.

### DIFF
--- a/src/NuGetGallery.Core/CredentialTypes.cs
+++ b/src/NuGetGallery.Core/CredentialTypes.cs
@@ -55,8 +55,8 @@ namespace NuGetGallery
         {
             return c?.Type?.Equals(type, StringComparison.OrdinalIgnoreCase) ?? false;
         }
-      
-        internal static IReadOnlyList<string> SupportedCredentialTypes = new List<string>
+
+        private static IReadOnlyList<string> ViewSupportedPasswordAndApiKeyTypes = new List<string>
         {
             Password.Sha1,
             Password.Pbkdf2,
@@ -75,7 +75,9 @@ namespace NuGetGallery
         /// <returns></returns>
         public static bool IsSupportedCredential(this Credential credential)
         {
-            return credential.IsViewSupportedCredential() || IsPackageVerificationApiKey(credential.Type);
+            return credential.IsViewSupportedCredential() ||
+                   credential.IsType(ApiKey.V5) ||
+                   credential.IsType(ApiKey.VerifyV1);
         }
 
         /// <summary>
@@ -86,9 +88,8 @@ namespace NuGetGallery
         /// <returns></returns>
         public static bool IsViewSupportedCredential(this Credential credential)
         {
-            return
-                SupportedCredentialTypes.Any(credType => credential.IsType(credType)) ||
-                credential.IsExternal();
+            return ViewSupportedPasswordAndApiKeyTypes.Any(credType => credential.IsType(credType)) ||
+                   credential.IsExternal();
         }
 
         public static bool IsScopedApiKey(this Credential credential)

--- a/src/NuGetGallery.Services/Authentication/Federated/FederatedCredentialRepository.cs
+++ b/src/NuGetGallery.Services/Authentication/Federated/FederatedCredentialRepository.cs
@@ -60,13 +60,10 @@ namespace NuGetGallery.Services.Authentication
 
         public IReadOnlyList<Credential> GetShortLivedApiKeysForPolicy(int policyKey)
         {
-            // TODO: introduce a new API key type for short-lived API keys
-            // Tracking: https://github.com/NuGet/NuGetGallery/issues/10212
-
             return _credentialRepository
                 .GetAll()
                 .Where(c => c.FederatedCredentialPolicyKey == policyKey)
-                .Where(c => c.Type == CredentialTypes.ApiKey.V4)
+                .Where(c => c.Type == CredentialTypes.ApiKey.V4 || c.Type == CredentialTypes.ApiKey.V5)
                 .ToList();
         }
 

--- a/src/NuGetGallery/Filters/ApiAuthorizeAttribute.cs
+++ b/src/NuGetGallery/Filters/ApiAuthorizeAttribute.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -39,7 +39,8 @@ namespace NuGetGallery.Filters
                             GalleryConstants.WarningHeaderName,
                             string.Format(CultureInfo.InvariantCulture, Strings.WarningApiKeyExpired, accountUrl));
                     }
-                    else if (expirationPeriod.TotalDays <= controller.NuGetContext.Config.Current.WarnAboutExpirationInDaysForApiKeyV1)
+                    else if (expirationPeriod.TotalDays <= controller.NuGetContext.Config.Current.WarnAboutExpirationInDaysForApiKeyV1 &&
+                        !apiKeyCredential.IsType(CredentialTypes.ApiKey.V5))
                     {
                         // about to expire warning
                         var expirationDays = Math.Round(expirationPeriod.TotalDays, 0);

--- a/tests/NuGetGallery.Core.Facts/CredentialTypesFacts.cs
+++ b/tests/NuGetGallery.Core.Facts/CredentialTypesFacts.cs
@@ -1,0 +1,47 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using NuGet.Services.Entities;
+using Xunit;
+
+namespace NuGetGallery
+{
+    public class CredentialTypesFacts
+    {
+        [Theory]
+        [InlineData(CredentialTypes.Password.Sha1, true)]
+        [InlineData(CredentialTypes.Password.Pbkdf2, true)]
+        [InlineData(CredentialTypes.Password.V3, true)]
+        [InlineData(CredentialTypes.ApiKey.V1, true)]
+        [InlineData(CredentialTypes.ApiKey.V2, true)]
+        [InlineData(CredentialTypes.ApiKey.V3, true)]
+        [InlineData(CredentialTypes.ApiKey.V4, true)]
+        [InlineData(CredentialTypes.External.MicrosoftAccount, true)]
+        [InlineData(CredentialTypes.External.AzureActiveDirectoryAccount, true)]
+        [InlineData(CredentialTypes.ApiKey.V5, false)]
+        [InlineData(CredentialTypes.ApiKey.VerifyV1, false)]
+        public void IsViewSupportedCredential(string credentialType, bool isViewSupported)
+        {
+            var credential = new Credential(credentialType, "testcredential");
+            Assert.Equal(isViewSupported, credential.IsViewSupportedCredential());
+        }
+
+        [Theory]
+        [InlineData(CredentialTypes.Password.Sha1)]
+        [InlineData(CredentialTypes.Password.Pbkdf2)]
+        [InlineData(CredentialTypes.Password.V3)]
+        [InlineData(CredentialTypes.ApiKey.V1)]
+        [InlineData(CredentialTypes.ApiKey.V2)]
+        [InlineData(CredentialTypes.ApiKey.V3)]
+        [InlineData(CredentialTypes.ApiKey.V4)]
+        [InlineData(CredentialTypes.ApiKey.V5)]
+        [InlineData(CredentialTypes.ApiKey.VerifyV1)]
+        [InlineData(CredentialTypes.External.MicrosoftAccount)]
+        [InlineData(CredentialTypes.External.AzureActiveDirectoryAccount)]
+        public void IsSupportedCredential(string credentialType)
+        {
+            var credential = new Credential(credentialType, "testcredential");
+            Assert.True(credential.IsSupportedCredential());
+        }
+    }
+}

--- a/tests/NuGetGallery.Facts/Authentication/Federated/FederatedCredentialRepositoryFacts.cs
+++ b/tests/NuGetGallery.Facts/Authentication/Federated/FederatedCredentialRepositoryFacts.cs
@@ -202,8 +202,8 @@ namespace NuGetGallery.Services.Authentication
 
             Credentials = new List<Credential>
             {
-                new() { Key = 6, Type = CredentialTypes.ApiKey.V4, FederatedCredentialPolicyKey = 1 },
-                new() { Key = 7, Type = CredentialTypes.ApiKey.V4, FederatedCredentialPolicyKey = 3 },
+                new() { Key = 6, Type = CredentialTypes.ApiKey.V5, FederatedCredentialPolicyKey = 1 },
+                new() { Key = 7, Type = CredentialTypes.ApiKey.V5, FederatedCredentialPolicyKey = 3 },
             };
             CredentialRepository.Setup(x => x.GetAll()).Returns(() => Credentials.AsQueryable());
 

--- a/tests/NuGetGallery.Facts/Filters/ApiAuthorizeAttributeFacts.cs
+++ b/tests/NuGetGallery.Facts/Filters/ApiAuthorizeAttributeFacts.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -64,6 +64,25 @@ namespace NuGetGallery.Filters
                 Assert.Equal(200, owinContext.Response.StatusCode);
                 Assert.Contains("X-NuGet-Warning", context.HttpContext.Response.Headers.AllKeys);
                 Assert.Equal(expectedWarning, context.HttpContext.Response.Headers["X-NuGet-Warning"]);
+            }
+
+            [Fact]
+            public void AddsNoExpirationInDaysWarningForApiKeyV5()
+            {
+                var apiKey = TestCredentialHelper.CreateV5ApiKey(galleryEnvironment: ServicesConstants.DevelopmentEnvironment,
+                    userKey: 1,
+                    expiration: TimeSpan.FromHours(1),
+                    out _);
+
+                var context = BuildAuthorizationContext(authenticated: true, credential: apiKey).Object;
+                var attribute = new ApiAuthorizeAttribute();
+
+                // Act
+                attribute.OnAuthorization(context);
+                var owinContext = context.HttpContext.GetOwinContext();
+
+                // Assert
+                Assert.DoesNotContain("X-NuGet-Warning", context.HttpContext.Response.Headers.AllKeys);
             }
 
             [Fact]


### PR DESCRIPTION
1. Hide the short-lived API Key v5 in the API Keys page.
2. No warn about expiration in days as the key is short-lived and expires in a day.