### PR TITLE
[OIDC] API Key v5 - 4: Remove the feature flag.

### DIFF
--- a/src/AccountDeleter/EmptyFeatureFlagService.cs
+++ b/src/AccountDeleter/EmptyFeatureFlagService.cs
@@ -358,10 +358,5 @@ namespace NuGetGallery.AccountDeleter
         {
             throw new NotImplementedException();
         }
-
-        public bool IsApiKeyV5EnabledForOIDC(User user)
-        {
-            throw new NotImplementedException();
-        }
     }
 }

--- a/src/GitHubVulnerabilities2Db/Fakes/FakeFeatureFlagService.cs
+++ b/src/GitHubVulnerabilities2Db/Fakes/FakeFeatureFlagService.cs
@@ -359,10 +359,5 @@ namespace GitHubVulnerabilities2Db.Fakes
         {
             throw new NotImplementedException();
         }
-
-        public bool IsApiKeyV5EnabledForOIDC(User user)
-        {
-            throw new NotImplementedException();
-        }
     }
 }

--- a/src/NuGetGallery.Services/Authentication/CredentialBuilder.cs
+++ b/src/NuGetGallery.Services/Authentication/CredentialBuilder.cs
@@ -29,7 +29,7 @@ namespace NuGetGallery.Infrastructure.Authentication
                 V3Hasher.GenerateHash(plaintextPassword));
         }
 
-        public Credential CreateShortLivedApiKey(TimeSpan expiration, FederatedCredentialPolicy policy, string galleryEnvironment, bool isApiKeyV5Enabled, out string plaintextApiKey)
+        public Credential CreateShortLivedApiKey(TimeSpan expiration, FederatedCredentialPolicy policy, string galleryEnvironment, out string plaintextApiKey)
         {
             if (policy.PackageOwner is null)
             {
@@ -41,21 +41,13 @@ namespace NuGetGallery.Infrastructure.Authentication
                 throw new ArgumentOutOfRangeException(nameof(expiration));
             }
 
-            Credential credential;
-            if (isApiKeyV5Enabled)
-            {
-                var allocationTime = DateTime.UtcNow;
-                allocationTime = allocationTime.AddSeconds(-allocationTime.Second).AddMilliseconds(-allocationTime.Millisecond);
+            var allocationTime = DateTime.UtcNow;
+            allocationTime = allocationTime.AddSeconds(-allocationTime.Second).AddMilliseconds(-allocationTime.Millisecond);
 
-                var apiKey = ApiKeyV5.Create(allocationTime, ApiKeyV5.GetEnvironment(galleryEnvironment), policy.PackageOwnerUserKey, ApiKeyV5.KnownApiKeyTypes.ShortLived, expiration);
-                plaintextApiKey = apiKey.PlaintextApiKey;
+            var apiKey = ApiKeyV5.Create(allocationTime, ApiKeyV5.GetEnvironment(galleryEnvironment), policy.PackageOwnerUserKey, ApiKeyV5.KnownApiKeyTypes.ShortLived, expiration);
+            plaintextApiKey = apiKey.PlaintextApiKey;
 
-                credential = new Credential(CredentialTypes.ApiKey.V5, apiKey.HashedApiKey, expiration: expiration);
-            }
-            else
-            {
-                credential = CreateApiKey(expiration, out plaintextApiKey);
-            }
+            var credential = new Credential(CredentialTypes.ApiKey.V5, apiKey.HashedApiKey, expiration: expiration);
 
             credential.FederatedCredentialPolicy = policy;
             credential.Description = "Short-lived API key generated via a federated credential";

--- a/src/NuGetGallery.Services/Authentication/Federated/FederatedCredentialService.cs
+++ b/src/NuGetGallery.Services/Authentication/Federated/FederatedCredentialService.cs
@@ -94,7 +94,6 @@ namespace NuGetGallery.Services.Authentication
         private readonly IAuthenticationService _authenticationService;
         private readonly IAuditingService _auditingService;
         private readonly IDateTimeProvider _dateTimeProvider;
-        private readonly IFeatureFlagService _featureFlagService;
         private readonly IFederatedCredentialConfiguration _configuration;
         private readonly IGalleryConfigurationService _galleryConfigurationService;
 
@@ -106,7 +105,6 @@ namespace NuGetGallery.Services.Authentication
             IAuthenticationService authenticationService,
             IAuditingService auditingService,
             IDateTimeProvider dateTimeProvider,
-            IFeatureFlagService featureFlagService,
             IFederatedCredentialConfiguration configuration,
             IGalleryConfigurationService galleryConfigurationService)
         {
@@ -117,7 +115,6 @@ namespace NuGetGallery.Services.Authentication
             _authenticationService = authenticationService ?? throw new ArgumentNullException(nameof(authenticationService));
             _auditingService = auditingService ?? throw new ArgumentNullException(nameof(auditingService));
             _dateTimeProvider = dateTimeProvider ?? throw new ArgumentNullException(nameof(dateTimeProvider));
-            _featureFlagService = featureFlagService ?? throw new ArgumentNullException(nameof(featureFlagService));
             _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
             _galleryConfigurationService = galleryConfigurationService ?? throw new ArgumentNullException(nameof(configuration));
         }
@@ -332,7 +329,6 @@ namespace NuGetGallery.Services.Authentication
                 _configuration.ShortLivedApiKeyDuration,
                 policyEvaluation.MatchedPolicy,
                 _galleryConfigurationService.Current.Environment,
-                _featureFlagService.IsApiKeyV5EnabledForOIDC(packageOwner),
                 out var plaintextApiKey);
 
             if (!_credentialBuilder.VerifyScopes(currentUser, apiKeyCredential.Scopes))

--- a/src/NuGetGallery.Services/Authentication/ICredentialBuilder.cs
+++ b/src/NuGetGallery.Services/Authentication/ICredentialBuilder.cs
@@ -21,6 +21,6 @@ namespace NuGetGallery.Infrastructure.Authentication
 
         bool VerifyScopes(User currentUser, IEnumerable<Scope> scopes);
 
-        Credential CreateShortLivedApiKey(TimeSpan expiration, FederatedCredentialPolicy policy, string galleryEnvironment, bool isApiKeyV5Enabled, out string plaintextApiKey);
+        Credential CreateShortLivedApiKey(TimeSpan expiration, FederatedCredentialPolicy policy, string galleryEnvironment, out string plaintextApiKey);
     }
 }

--- a/src/NuGetGallery.Services/Configuration/FeatureFlagService.cs
+++ b/src/NuGetGallery.Services/Configuration/FeatureFlagService.cs
@@ -464,10 +464,5 @@ namespace NuGetGallery
         {
             return _client.IsEnabled(McpServerPackageDisplayFeatureName, defaultValue: false);
         }
-
-        public bool IsApiKeyV5EnabledForOIDC(User user)
-        {
-            return _client.IsEnabled(EnableApiKeyV5ForOIDCFeatureName, user, defaultValue: false);
-        }
     }
 }

--- a/src/NuGetGallery.Services/Configuration/IFeatureFlagService.cs
+++ b/src/NuGetGallery.Services/Configuration/IFeatureFlagService.cs
@@ -376,10 +376,5 @@ namespace NuGetGallery
         bool IsMcpServerPackageFilteringEnabled();
 
         bool IsMcpServerPackageDisplayEnabled();
-
-        /// <summary>
-        /// Whether or not Api Key V5 is enabled for OIDC.
-        /// </summary>
-        bool IsApiKeyV5EnabledForOIDC(User user);
     }
 }

--- a/src/VerifyMicrosoftPackage/Fakes/FakeFeatureFlagService.cs
+++ b/src/VerifyMicrosoftPackage/Fakes/FakeFeatureFlagService.cs
@@ -149,7 +149,5 @@ namespace NuGet.VerifyMicrosoftPackage.Fakes
         public bool IsMcpServerPackageFilteringEnabled() => throw new NotImplementedException();
 
         public bool IsMcpServerPackageDisplayEnabled() => throw new NotImplementedException();
-
-        public bool IsApiKeyV5EnabledForOIDC(User user) => throw new NotImplementedException();
     }
 }

--- a/tests/NuGetGallery.Facts/Authentication/CredentialBuilderFacts.cs
+++ b/tests/NuGetGallery.Facts/Authentication/CredentialBuilderFacts.cs
@@ -14,30 +14,10 @@ namespace NuGetGallery.Infrastructure.Authentication
         public class TheCreateShortLivedApiKeyMethod : CredentialBuilderFacts
         {
             [Fact]
-            public void CreatesShortLivedApiKeyWithV4()
-            {
-                // Act
-                var credential = Target.CreateShortLivedApiKey(Expiration, Policy, galleryEnvironment: It.IsAny<string>(), isApiKeyV5Enabled: false, out var plaintextApiKey);
-
-                // Assert
-                Assert.Null(credential.User);
-                Assert.Equal(default, credential.UserKey);
-                Assert.StartsWith("oy2", plaintextApiKey, StringComparison.Ordinal);
-                Assert.Equal(CredentialTypes.ApiKey.V4, credential.Type);
-                Assert.Equal("Short-lived API key generated via a federated credential", credential.Description);
-                Assert.Equal(Expiration.Ticks, credential.ExpirationTicks);
-
-                var scope = Assert.Single(credential.Scopes);
-                Assert.Equal(NuGetScopes.All, scope.AllowedAction);
-                Assert.Equal(NuGetPackagePattern.AllInclusivePattern, scope.Subject);
-                Assert.Same(Policy.PackageOwner, scope.Owner);
-            }
-
-            [Fact]
             public void CreatesShortLivedApiKeyWithV5()
             {
                 // Act
-                var credential = Target.CreateShortLivedApiKey(Expiration, Policy, galleryEnvironment: ServicesConstants.DevelopmentEnvironment, isApiKeyV5Enabled: true, out var plaintextApiKey);
+                var credential = Target.CreateShortLivedApiKey(Expiration, Policy, galleryEnvironment: ServicesConstants.DevelopmentEnvironment, out var plaintextApiKey);
 
                 // Assert
                 Assert.Null(credential.User);
@@ -59,7 +39,7 @@ namespace NuGetGallery.Infrastructure.Authentication
                 Policy.PackageOwner = null;
 
                 // Act
-                Assert.Throws<ArgumentException>(() => Target.CreateShortLivedApiKey(Expiration, Policy, It.IsAny<string>(), It.IsAny<bool>(), out var plaintextApiKey));
+                Assert.Throws<ArgumentException>(() => Target.CreateShortLivedApiKey(Expiration, Policy, It.IsAny<string>(), out var plaintextApiKey));
             }
 
             [Theory]
@@ -72,7 +52,7 @@ namespace NuGetGallery.Infrastructure.Authentication
                 Expiration = TimeSpan.FromMinutes(expirationMinutes);
 
                 // Act
-                Assert.Throws<ArgumentOutOfRangeException>(() => Target.CreateShortLivedApiKey(Expiration, Policy, It.IsAny<string>(), It.IsAny<bool>(), out var plaintextApiKey));
+                Assert.Throws<ArgumentOutOfRangeException>(() => Target.CreateShortLivedApiKey(Expiration, Policy, It.IsAny<string>(), out var plaintextApiKey));
             }
 
             public FederatedCredentialPolicy Policy { get; }


### PR DESCRIPTION
Remove the feature flag so OIDC always uses API Key v5.