### PR TITLE
Always validate email for new registrations

### DIFF
--- a/src/NuGetGallery.Services/Authentication/AuthenticationService.cs
+++ b/src/NuGetGallery.Services/Authentication/AuthenticationService.cs
@@ -379,7 +379,7 @@ namespace NuGetGallery.Authentication
             return claims.ToArray();
         }
 
-        public virtual async Task<AuthenticatedUser> Register(string username, string emailAddress, Credential credential, bool autoConfirm = false, bool enableMultiFactorAuthentication = false)
+        public virtual async Task<AuthenticatedUser> Register(string username, string emailAddress, Credential credential, bool enableMultiFactorAuthentication = false)
         {
             if (_config.FeedOnlyMode)
             {
@@ -413,7 +413,7 @@ namespace NuGetGallery.Authentication
             // Add a credential for the password
             newUser.Credentials.Add(credential);
 
-            if (!_config.ConfirmEmailAddresses || autoConfirm)
+            if (!_config.ConfirmEmailAddresses)
             {
                 newUser.ConfirmEmailAddress();
             }

--- a/src/NuGetGallery/Controllers/AuthenticationController.cs
+++ b/src/NuGetGallery/Controllers/AuthenticationController.cs
@@ -312,7 +312,6 @@ namespace NuGetGallery
                         model.Register.Username,
                         model.Register.EmailAddress,
                         result.Credential,
-                        autoConfirm: (result.Credential.IsExternal() && string.Equals(result.UserInfo?.Email, model.Register.EmailAddress)),
                         enableMultiFactorAuthentication: enableMultiFactorAuthentication);
                 }
                 else if (_featureFlagService.IsNewAccount2FAEnforcementEnabled())

--- a/tests/NuGetGallery.Facts/Authentication/AuthenticationServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Authentication/AuthenticationServiceFacts.cs
@@ -1188,7 +1188,6 @@ namespace NuGetGallery.Authentication
                             c.Value,
                             CredentialBuilder.LatestPasswordType,
                             password)),
-                        It.IsAny<bool>(),
                         It.IsAny<bool>()))
                     .CompletesWithNull()
                     .Verifiable();
@@ -1277,31 +1276,6 @@ namespace NuGetGallery.Authentication
             [Theory]
             [InlineData("MicrosoftAccount")]
             [InlineData("AzureActiveDirectory")]
-            public async Task WillSaveTheNewUserWithExternalCredentialAndMatchEmailAsConfirmed(string credType)
-            {
-                // Arrange
-                var configurationService = GetConfigurationService();
-                configurationService.Current.ConfirmEmailAddresses = true;
-
-                var auth = Get<AuthenticationService>();
-
-                // Act
-                var authUser = await auth.Register(
-                    "newUser",
-                    "theEmailAddress",
-                    new CredentialBuilder().CreateExternalCredential(credType, "blorg", "Bloog"),
-                    true);
-
-                // Assert
-                Assert.True(auth.Entities.Users.Contains(authUser.User));
-                Assert.True(authUser.User.Confirmed);
-                Assert.Equal("theEmailAddress", authUser.User.EmailAddress);
-                auth.Entities.VerifyCommitChanges();
-            }
-
-            [Theory]
-            [InlineData("MicrosoftAccount")]
-            [InlineData("AzureActiveDirectory")]
             public async Task WillSaveTheNewUserWithExternalCredentialAndNotMatchEmailAsNotConfirmed(string credType)
             {
                 // Arrange
@@ -1314,8 +1288,7 @@ namespace NuGetGallery.Authentication
                 var authUser = await auth.Register(
                     "newUser",
                     "theEmailAddress",
-                    new CredentialBuilder().CreateExternalCredential(credType, "blorg", "Bloog"),
-                    false);
+                    new CredentialBuilder().CreateExternalCredential(credType, "blorg", "Bloog"));
 
                 // Assert
                 Assert.True(auth.Entities.Users.Contains(authUser.User));

--- a/tests/NuGetGallery.Facts/Controllers/AuthenticationControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/AuthenticationControllerFacts.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -857,7 +857,7 @@ namespace NuGetGallery.Controllers
             public async Task WillInvalidateModelStateAndShowTheViewWhenAnEntityExceptionIsThrow()
             {
                 GetMock<AuthenticationService>()
-                    .Setup(x => x.Register(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Credential>(), It.IsAny<bool>(), It.IsAny<bool>()))
+                    .Setup(x => x.Register(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Credential>(), It.IsAny<bool>()))
                     .Throws(new EntityException("aMessage"));
 
                 var controller = GetController<AuthenticationController>();
@@ -929,7 +929,7 @@ namespace NuGetGallery.Controllers
                 var authenticationService = GetMock<AuthenticationService>();
                 var controller = GetController<AuthenticationController>();
 
-                authenticationService.Setup(x => x.Register(authUser.User.Username, authUser.User.UnconfirmedEmailAddress, It.IsAny<Credential>(), It.IsAny<bool>(), It.IsAny<bool>()))
+                authenticationService.Setup(x => x.Register(authUser.User.Username, authUser.User.UnconfirmedEmailAddress, It.IsAny<Credential>(), It.IsAny<bool>()))
                     .CompletesWith(authUser);
 
                 authenticationService
@@ -980,7 +980,7 @@ namespace NuGetGallery.Controllers
                 configurationService.Current.ConfirmEmailAddresses = false;
 
                 GetMock<AuthenticationService>()
-                    .Setup(x => x.Register("theUsername", "unconfirmed@example.com", It.IsAny<Credential>(), It.IsAny<bool>(), It.IsAny<bool>()))
+                    .Setup(x => x.Register("theUsername", "unconfirmed@example.com", It.IsAny<Credential>(), It.IsAny<bool>()))
                     .CompletesWith(authUser);
 
                 var controller = GetController<AuthenticationController>();
@@ -1004,7 +1004,7 @@ namespace NuGetGallery.Controllers
 
                 // Assert
                 GetMock<AuthenticationService>()
-                    .Verify(x => x.Register("theUsername", "unconfirmed@example.com", It.IsAny<Credential>(), false, It.IsAny<bool>()));
+                    .Verify(x => x.Register("theUsername", "unconfirmed@example.com", It.IsAny<Credential>(), It.IsAny<bool>()));
 
                 GetMock<IMessageService>()
                     .Verify(
@@ -1030,7 +1030,7 @@ namespace NuGetGallery.Controllers
                 var authenticationServiceMock = GetMock<AuthenticationService>();
                 var controller = GetController<AuthenticationController>();
                 authenticationServiceMock
-                    .Setup(x => x.Register(authUser.User.Username, authUser.User.UnconfirmedEmailAddress, It.IsAny<Credential>(), It.IsAny<bool>(), It.IsAny<bool>()))
+                    .Setup(x => x.Register(authUser.User.Username, authUser.User.UnconfirmedEmailAddress, It.IsAny<Credential>(), It.IsAny<bool>()))
                     .CompletesWith(authUser);
                 authenticationServiceMock
                     .Setup(x => x.CreateSessionAsync(controller.OwinContext, authUser, false))
@@ -1074,7 +1074,7 @@ namespace NuGetGallery.Controllers
                 authenticationServiceMock.VerifyAll();
 
                 GetMock<AuthenticationService>()
-                    .Verify(x => x.Register(authUser.User.Username, authUser.User.UnconfirmedEmailAddress, It.IsAny<Credential>(), false, It.IsAny<bool>()));
+                    .Verify(x => x.Register(authUser.User.Username, authUser.User.UnconfirmedEmailAddress, It.IsAny<Credential>(), It.IsAny<bool>()));
 
                 messageService.Verify();
 
@@ -1098,7 +1098,7 @@ namespace NuGetGallery.Controllers
                 var authenticationServiceMock = GetMock<AuthenticationService>();
                 var controller = GetController<AuthenticationController>();
                 authenticationServiceMock
-                    .Setup(x => x.Register(authUser.User.Username, "anotherunconfirmed@example.com", externalCred, It.IsAny<bool>(), It.IsAny<bool>()))
+                    .Setup(x => x.Register(authUser.User.Username, "anotherunconfirmed@example.com", externalCred, It.IsAny<bool>()))
                     .CompletesWith(authUser);
                 authenticationServiceMock
                     .Setup(x => x.CreateSessionAsync(controller.OwinContext, authUser, false))
@@ -1142,7 +1142,7 @@ namespace NuGetGallery.Controllers
                 authenticationServiceMock.VerifyAll();
 
                 GetMock<AuthenticationService>()
-                    .Verify(x => x.Register(authUser.User.Username, "anotherunconfirmed@example.com", externalCred, false, It.IsAny<bool>()));
+                    .Verify(x => x.Register(authUser.User.Username, "anotherunconfirmed@example.com", externalCred, It.IsAny<bool>()));
 
                 messageService.Verify();
 
@@ -1150,7 +1150,7 @@ namespace NuGetGallery.Controllers
             }
 
             [Fact]
-            public async Task WillAutoConfirmAndWillNotSendConfirmationEmailWhenIsExternalCredentialAndModelRegisterEmailAndExternalCredentialEmailMatch()
+            public async Task WillAutoConfirmAndWillNotSendConfirmationEmailWhenIsMicrosoftAccountAndModelRegisterEmailAndExternalCredentialEmailMatch()
             {
                 // Arrange
                 var authUser = new AuthenticatedUser(
@@ -1166,7 +1166,7 @@ namespace NuGetGallery.Controllers
                 var authenticationServiceMock = GetMock<AuthenticationService>();
                 var controller = GetController<AuthenticationController>();
                 authenticationServiceMock
-                    .Setup(x => x.Register(authUser.User.Username, authUser.User.UnconfirmedEmailAddress, externalCred, It.IsAny<bool>(), It.IsAny<bool>()))
+                    .Setup(x => x.Register(authUser.User.Username, authUser.User.UnconfirmedEmailAddress, externalCred, It.IsAny<bool>()))
                     .CompletesWith(authUser)
                     .Callback(() =>
                      {
@@ -1202,7 +1202,7 @@ namespace NuGetGallery.Controllers
                 authenticationServiceMock.VerifyAll();
 
                 GetMock<AuthenticationService>()
-                    .Verify(x => x.Register(authUser.User.Username, authUser.User.EmailAddress, externalCred, true, It.IsAny<bool>()));
+                    .Verify(x => x.Register(authUser.User.Username, authUser.User.EmailAddress, externalCred, It.IsAny<bool>()));
 
                 GetMock<IMessageService>()
                     .Verify(x => x.SendMessageAsync(
@@ -1242,7 +1242,7 @@ namespace NuGetGallery.Controllers
                 GetMock<AuthenticationService>()
                     .Verify(x => x.CreateSessionAsync(It.IsAny<IOwinContext>(), It.IsAny<AuthenticatedUser>(), false), Times.Never());
                 GetMock<AuthenticationService>()
-                    .Verify(x => x.Register("theUsername", "theEmailAddress", It.IsAny<Credential>(), It.IsAny<bool>(), It.IsAny<bool>()), Times.Never());
+                    .Verify(x => x.Register("theUsername", "theEmailAddress", It.IsAny<Credential>(), It.IsAny<bool>()), Times.Never());
             }
 
             [Fact]
@@ -1262,7 +1262,7 @@ namespace NuGetGallery.Controllers
                 var authenticationServiceMock = GetMock<AuthenticationService>();
                 var controller = GetController<AuthenticationController>();
                 authenticationServiceMock
-                    .Setup(x => x.Register(authUser.User.Username, authUser.User.UnconfirmedEmailAddress, externalCred, It.IsAny<bool>(), It.IsAny<bool>()))
+                    .Setup(x => x.Register(authUser.User.Username, authUser.User.UnconfirmedEmailAddress, externalCred, It.IsAny<bool>()))
                     .CompletesWith(authUser);
                 authenticationServiceMock
                     .Setup(x => x.CreateSessionAsync(controller.OwinContext, authUser, false))
@@ -1329,7 +1329,7 @@ namespace NuGetGallery.Controllers
                 var featureFlagServiceMock = GetMock<IFeatureFlagService>();
                 var controller = GetController<AuthenticationController>();
                 authenticationServiceMock
-                    .Setup(x => x.Register(authUser.User.Username, authUser.User.UnconfirmedEmailAddress, externalCred, It.IsAny<bool>(), enableMultiFactorAuthentication))
+                    .Setup(x => x.Register(authUser.User.Username, authUser.User.UnconfirmedEmailAddress, externalCred, enableMultiFactorAuthentication))
                     .CompletesWith(authUser);
                 authenticationServiceMock
                     .Setup(x => x.CreateSessionAsync(controller.OwinContext, authUser, usedMultiFactorAuthentication))
@@ -1390,7 +1390,7 @@ namespace NuGetGallery.Controllers
                     externalCred);
 
                 GetMock<AuthenticationService>()
-                    .Setup(x => x.Register("theUsername", "theEmailAddress", externalCred, It.IsAny<bool>(), It.IsAny<bool>()))
+                    .Setup(x => x.Register("theUsername", "theEmailAddress", externalCred, It.IsAny<bool>()))
                     .CompletesWith(authUser);
 
                 EnableAllAuthenticators(Get<AuthenticationService>());


### PR DESCRIPTION
Reverted part of https://github.com/NuGet/NuGetGallery/issues/6389.

Email addresses always need validation, even if they come from Azure AD tenants, which can be created by any user who can provide any email address.

Addresses https://github.com/NuGet/Engineering/issues/5929