### PR TITLE
Add #:sdk directive support for .NET 10 file-based apps

### DIFF
--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -179,7 +179,18 @@
                 AlertLevel = AlertLevel.Info,
                 AlertMessage = string.Format("For projects that support Sdk, copy this XML node into the project file to reference the package."),
                 CopyLabel = "Copy the SDK XML node",
-            }
+            },
+            new PackageManagerViewModel(
+                "dotnet-run-file-sdk",
+                "File-based Apps (SDK)",
+                new PackageManagerViewModel.InstallPackageCommand(
+                    string.Format("#:sdk {0}@{1}", Model.Id, Model.Version)
+                )
+            )
+            {
+                AlertLevel = AlertLevel.Info,
+                AlertMessage = "#:sdk directive can be used in C# file-based apps starting in .NET 10 preview 6. Copy this into a .cs file before any lines of code to reference the SDK."
+            },
         };
     }
     else


### PR DESCRIPTION
## Overview
This PR adds support for the new `#:sdk` directive introduced in .NET 10 preview 6, allowing developers to reference SDKs directly in C# files without needing a project file.

## Changes
- **Added new package manager option**: `dotnet-run-file-sdk` for file-based apps
- **Format**: `#:sdk {package}@{version}` (e.g., `#:sdk Microsoft.Extensions.Hosting@8.0.0`)
- **UI Label**: "File-based Apps (SDK)" 
- **Alert Message**: Explains the feature and usage requirements for .NET 10 preview 6+

## Context
This follows up on the work started in #10475 by @DamianEdwards, which initially added the package snippet functionality.

## Screenshot today
<img width="902" height="285" alt="image" src="https://github.com/user-attachments/assets/ca46ed07-5912-4a07-baf2-718761043f0b" />

From: https://www.nuget.org/packages/Cake.Sdk/5.0.25225.53-beta

## Screenshot  after change

<img width="890" height="305" alt="image" src="https://github.com/user-attachments/assets/06e167ed-33d4-49c3-8928-0196c61cdac8" />

