### PR TITLE
Synchronously wait for directory cleanup

### DIFF
--- a/src/Validation.Symbols/ITelemetryService.cs
+++ b/src/Validation.Symbols/ITelemetryService.cs
@@ -52,6 +52,9 @@ namespace Validation.Symbols
         /// <summary>
         /// Tracks that a temporary working directory was not deleted.
         /// </summary>
+        /// <param name="packageId">The package ID.</param>
+        /// <param name="packageNormalizedVersion">The package normalized version.</param>
+        /// <param name="workingDirectory">The temporary working directory that could not be deleted.</param>
         void TrackSymbolsWorkingDirectoryNotDeletedEvent(string packageId, string packageNormalizedVersion, string workingDirectory);
     }
 }

--- a/src/Validation.Symbols/ITelemetryService.cs
+++ b/src/Validation.Symbols/ITelemetryService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -48,5 +48,10 @@ namespace Validation.Symbols
         /// <param name="packageNormalizedVersion">The package normalized version.</param>
         /// <param name="validationStatus">The validation result.</param>
         void TrackSymbolsValidationResultEvent(string packageId, string packageNormalizedVersion, ValidationStatus validationStatus);
+
+        /// <summary>
+        /// Tracks that a temporary working directory was not deleted.
+        /// </summary>
+        void TrackSymbolsWorkingDirectoryNotDeletedEvent(string packageId, string packageNormalizedVersion, string workingDirectory);
     }
 }

--- a/src/Validation.Symbols/SymbolsValidatorService.cs
+++ b/src/Validation.Symbols/SymbolsValidatorService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -15,12 +15,14 @@ using NuGet.Jobs.Validation;
 using NuGet.Jobs.Validation.Symbols.Core;
 using NuGet.Services.Validation;
 using NuGet.Services.Validation.Issues;
+using System.Diagnostics;
 
 namespace Validation.Symbols
 {
     public class SymbolsValidatorService : ISymbolsValidatorService
     {
-        private static TimeSpan _cleanWorkingDirectoryTimeSpan = TimeSpan.FromSeconds(20);
+        private static TimeSpan CleanWorkingDirectoryTimeSpan = TimeSpan.FromSeconds(20);
+
         private static readonly string[] PEExtensionsPatterns = new string[] { "*.dll", "*.exe" };
         private static readonly string[] PEExtensions = new string[] { ".dll", ".exe" };
         private static readonly string[] SymbolExtension = new string[] { ".pdb" };
@@ -96,7 +98,11 @@ namespace Validation.Symbols
                                 }
                                 finally
                                 {
-                                    TryCleanWorkingDirectoryForSeconds(targetDirectory, message.PackageId, message.PackageNormalizedVersion, _cleanWorkingDirectoryTimeSpan);
+                                    await TryDeleteWorkingDirectoryForSecondsAsync(
+                                        targetDirectory,
+                                        message.PackageId,
+                                        message.PackageNormalizedVersion,
+                                        CleanWorkingDirectoryTimeSpan);
                                 }
                             }
                         }
@@ -115,40 +121,34 @@ namespace Validation.Symbols
             }
         }
 
-        private void TryCleanWorkingDirectoryForSeconds(string workingDirectory, string packageId, string packageNormalizedVersion, TimeSpan seconds)
+        private async Task TryDeleteWorkingDirectoryForSecondsAsync(string workingDirectory, string packageId, string packageNormalizedVersion, TimeSpan seconds)
         {
-            CancellationTokenSource cts = new CancellationTokenSource(seconds);
-            _logger.LogInformation("{ValidatorName} :Start cleaning working directory {WorkingDirectory}. PackageId: {packageId} PackageNormalizedVersion: {packageNormalizedVersion}",
-                ValidatorName.SymbolsValidator,
-                workingDirectory,
-                packageId,
-                packageNormalizedVersion);
-            Task cleanTask = new Task(() =>
-            {
-                IOException lastException = new IOException("NoStarted");
-                bool directoryExists = Directory.Exists(workingDirectory);
-                while (!cts.Token.IsCancellationRequested && directoryExists)
-                {
-                    directoryExists = Directory.Exists(workingDirectory);
-                    try
-                    {
-                        if (directoryExists)
-                        {
-                            Directory.Delete(workingDirectory, true);
-                        }
-                    }
-                    catch (IOException e)
-                    {
-                        lastException = e;
-                    }
-                }
-                if (Directory.Exists(workingDirectory))
-                {
-                    _logger.LogWarning(0, lastException, "{ValidatorName} :TryCleanWorkingDirectory failed. WorkingDirectory:{WorkingDirectory}", ValidatorName.SymbolsValidator, workingDirectory);
-                }
-            }, TaskCreationOptions.LongRunning);
+            using CancellationTokenSource cts = new CancellationTokenSource(seconds);
+            var sw = Stopwatch.StartNew();
 
-            cleanTask.Start();
+            var attempt = 0;
+            do
+            {
+                try
+                {
+                    attempt++;
+                    _logger.LogInformation("Attempting to delete working directory {WorkingDirectory} (attempt {Attempt})", workingDirectory, attempt);
+                    Directory.Delete(workingDirectory, recursive: true);
+                }
+                catch (Exception ex)
+                {
+                    var sleep = TimeSpan.FromSeconds(1);
+                    _logger.LogWarning(ex, "Failed to delete working directory {WorkingDirectory} (attempt {Attempt}). Sleeping for {SleepSeconds}s.", workingDirectory, attempt, sleep.TotalSeconds);
+                    await Task.Delay(sleep);
+                }
+            }
+            while (!cts.Token.IsCancellationRequested && Directory.Exists(workingDirectory));
+
+            if (Directory.Exists(workingDirectory))
+            {
+                _logger.LogWarning("Failed to delete working directory {WorkingDirectory} within {Seconds}.", workingDirectory, sw.Elapsed.TotalSeconds);
+                _telemetryService.TrackSymbolsWorkingDirectoryNotDeletedEvent(packageId, packageNormalizedVersion, workingDirectory);
+            }
         }
 
         /// <summary>

--- a/src/Validation.Symbols/SymbolsValidatorService.cs
+++ b/src/Validation.Symbols/SymbolsValidatorService.cs
@@ -21,7 +21,7 @@ namespace Validation.Symbols
 {
     public class SymbolsValidatorService : ISymbolsValidatorService
     {
-        private static TimeSpan CleanWorkingDirectoryTimeSpan = TimeSpan.FromSeconds(20);
+        private static TimeSpan CleanWorkingDirectoryTimeout = TimeSpan.FromSeconds(20);
 
         private static readonly string[] PEExtensionsPatterns = new string[] { "*.dll", "*.exe" };
         private static readonly string[] PEExtensions = new string[] { ".dll", ".exe" };
@@ -102,7 +102,7 @@ namespace Validation.Symbols
                                         targetDirectory,
                                         message.PackageId,
                                         message.PackageNormalizedVersion,
-                                        CleanWorkingDirectoryTimeSpan);
+                                        CleanWorkingDirectoryTimeout);
                                 }
                             }
                         }

--- a/src/Validation.Symbols/SymbolsValidatorService.cs
+++ b/src/Validation.Symbols/SymbolsValidatorService.cs
@@ -149,6 +149,14 @@ namespace Validation.Symbols
                 _logger.LogWarning("Failed to delete working directory {WorkingDirectory} within {Seconds}.", workingDirectory, sw.Elapsed.TotalSeconds);
                 _telemetryService.TrackSymbolsWorkingDirectoryNotDeletedEvent(packageId, packageNormalizedVersion, workingDirectory);
             }
+            else
+            {
+                _logger.LogInformation(
+                    "Successfully deleted working directory {WorkingDirectory} in {Seconds} and {Attempts} attempts.",
+                    workingDirectory,
+                    sw.Elapsed.TotalSeconds,
+                    attempt);
+            }
         }
 
         /// <summary>

--- a/src/Validation.Symbols/TelemetryService.cs
+++ b/src/Validation.Symbols/TelemetryService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -20,6 +20,7 @@ namespace Validation.Symbols
         private const string MessageLockLost = Prefix + "MessageLockLost";
         private const string SymbolValidationResult = Prefix + "SymbolValidationResult";
         private const string SymbolAssemblyValidationResult = Prefix + "SymbolAssemblyValidationResult";
+        private const string SymbolsWorkingDirectoryNotDeleted = Prefix + "SymbolsWorkingDirectoryNotDeleted";
 
         private const string PackageId = "PackageId";
         private const string PackageNormalizedVersion = "PackageNormalizedVersion";
@@ -30,6 +31,7 @@ namespace Validation.Symbols
         private const string AssemblyName = "AssemblyName";
         private const string CallGuid = "CallGuid";
         private const string Handled = "Handled";
+        private const string WorkingDirectory = "WorkingDirectory";
 
         private readonly ITelemetryClient _telemetryClient;
 
@@ -142,6 +144,19 @@ namespace Validation.Symbols
                 {
                     { MessageType, typeof(TMessage).Name },
                     { CallGuid, callGuid.ToString() }
+                });
+        }
+
+        public void TrackSymbolsWorkingDirectoryNotDeletedEvent(string packageId, string packageNormalizedVersion, string workingDirectory)
+        {
+            _telemetryClient.TrackMetric(
+                SymbolsWorkingDirectoryNotDeleted,
+                1,
+                new Dictionary<string, string>
+                {
+                    { PackageId, packageId },
+                    { PackageNormalizedVersion, packageNormalizedVersion },
+                    { WorkingDirectory, workingDirectory },
                 });
         }
     }

--- a/tests/StatusAggregator.Tests/Messages/MessageContentBuilderTests.cs
+++ b/tests/StatusAggregator.Tests/Messages/MessageContentBuilderTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -108,7 +108,7 @@ namespace StatusAggregator.Tests.Messages
         {
             IComponent bottom = null;
             IComponent root = null;
-            foreach (var name in names.Reverse())
+            foreach (var name in Enumerable.Reverse(names))
             {
                 if (bottom == null)
                 {


### PR DESCRIPTION
Currently the task to clean-up the temporary directory is not awaited. From telemetry and the disk on our compute nodes, it looks like we silently fail to clean up. This moves the clean-up step to be inside the validation flow, but leave the max time limit.

