### PR TITLE
Use version from filtered package rather than URL for MCP server json

### DIFF
--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -1023,7 +1023,7 @@ namespace NuGetGallery
                 if (mcpServerPackageType != null)
                 {
                     model.IsMcpServerPackageType = true;
-                    model.VsCodeMcpServerEntryTemplate = McpHelper.CreateVsCodeMcpServerEntryTemplate(mcpServerPackageType.CustomData, id, version);
+                    model.VsCodeMcpServerEntryTemplate = McpHelper.CreateVsCodeMcpServerEntryTemplate(mcpServerPackageType.CustomData, id, package.Version);
                 }
             }
 


### PR DESCRIPTION
## Problem
> go to this URL
> [nuget.org/packages/ErikEJ.DacFX.TSQLAnalyzer.Cli](https://www.nuget.org/packages/ErikEJ.DacFX.TSQLAnalyzer.Cli)
(no version in URL)
> Note the generate JSON has no version but has the @ -- bad arg format
<img width="416" height="25" alt="image" src="https://github.com/user-attachments/assets/ece0b687-cca6-4970-beaf-c1518a3faf90" />

## Solution
> we need to use the version from the fetched Package not the URL (MVC action inputs)
<img width="518" height="29" alt="image" src="https://github.com/user-attachments/assets/209b3097-8799-42e5-9332-42e14a2ece0f" />


Addresses https://github.com/NuGet/Engineering/issues/6104