### PR TITLE
Fix framework badge appearance for McpServer packages

### DIFF
--- a/src/NuGetGallery.Core/Services/AssetFrameworkHelper.cs
+++ b/src/NuGetGallery.Core/Services/AssetFrameworkHelper.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -38,12 +38,19 @@ namespace NuGetGallery
                 var runtimeGraph = new RuntimeGraph();
                 var conventions = new ManagedCodeConventions(runtimeGraph);
 
+                var isToolOnly = packageTypes.Count == 1 &&
+                                (packageTypes[0] == PackageType.DotnetTool ||
+                                 packageTypes[0] == PackageType.DotnetCliTool);
+
+                var isToolWithMcpServer = packageTypes.Count == 2 &&
+                                          packageTypes.Contains(PackageType.DotnetTool) &&
+                                          packageTypes.Any(pt => pt.Name == "McpServer");
+
                 // Let's test for tools packages first--they're a special case
                 var groups = new List<ContentItemGroup>();
-                if (packageTypes.Count == 1 && (packageTypes[0] == PackageType.DotnetTool ||
-                                                packageTypes[0] == PackageType.DotnetCliTool))
+                if (isToolOnly || isToolWithMcpServer)
                 {
-                    // Only a package that is a tool package (and nothing else) will be matched against tools pattern set
+                    // Only a package that is a tool package (or MCP server package) will be matched against tools pattern set
                     items.PopulateItemGroups(conventions.Patterns.ToolsAssemblies, groups);
                 }
                 else


### PR DESCRIPTION
## Before
<img width="772" height="167" alt="image" src="https://github.com/user-attachments/assets/8a3f46c9-3a0c-40ef-ab4d-f3a36b7ef731" />

## After
<img width="782" height="214" alt="image" src="https://github.com/user-attachments/assets/8bf2e63e-703e-4414-9dde-8f1c5f2c022c" />

## Before
<img width="898" height="183" alt="image" src="https://github.com/user-attachments/assets/36028f06-b247-4aa5-b92a-5a01a8051782" />

## After
<img width="1084" height="473" alt="image" src="https://github.com/user-attachments/assets/826f8fae-ff85-4f3c-b3cb-e6990ad9ced8" />

Addresses https://github.com/NuGet/Engineering/issues/6106