### PR TITLE
Remove use of prod DefaultAzureCredential in jobs sln

### DIFF
--- a/src/CopyAzureContainer/CopyAzureContainerJob.cs
+++ b/src/CopyAzureContainer/CopyAzureContainerJob.cs
@@ -243,8 +243,11 @@ namespace CopyAzureContainer
                 var sasCredential = new AzureSasCredential(storageSasToken);
                 return new BlobServiceClient(serviceUri, sasCredential);
             }
-
+#if DEBUG
             var credential = new DefaultAzureCredential();
+#else
+            var credential = new ManagedIdentityCredential();
+#endif
             return new BlobServiceClient(serviceUri, credential);
         }
 

--- a/src/Ng/CommandHelpers.cs
+++ b/src/Ng/CommandHelpers.cs
@@ -336,8 +336,13 @@ namespace Ng
                         TokenCredential credential;
                         if (string.IsNullOrEmpty(clientId))
                         {
+#if DEBUG
                             credential = new DefaultAzureCredential();
                             credentialType = SearchCursorCredentialType.DefaultAzureCredential;
+#else
+                            credential = new ManagedIdentityCredential();
+                            credentialType = SearchCursorCredentialType.ManagedIdentityCredential;
+#endif
                         }
                         else
                         {

--- a/src/NuGet.Jobs.Common/StorageAccountExtensions.cs
+++ b/src/NuGet.Jobs.Common/StorageAccountExtensions.cs
@@ -60,7 +60,11 @@ namespace NuGet.Jobs
 
             if (setupLocalDevelopment)
             {
+#if DEBUG
                 serviceCollection.AddSingleton<TokenCredential>(new DefaultAzureCredential());
+#else
+                serviceCollection.AddSingleton<TokenCredential>(new ManagedIdentityCredential());
+#endif
             }
             else
             {
@@ -212,11 +216,19 @@ namespace NuGet.Jobs
 
                 if (string.IsNullOrWhiteSpace(storageMsiConfiguration.ManagedIdentityClientId))
                 {
+#if DEBUG
                     // 1. Using MSI with DefaultAzureCredential (local debugging)
                     return new BlobServiceClient(
                         blobEndpointUri,
                         new DefaultAzureCredential(),
                         blobClientOptions);
+#else
+                    // 1. Using MSI with no ClientId (system assigned)
+                    return new BlobServiceClient(
+                        blobEndpointUri,
+                        new ManagedIdentityCredential(),
+                        blobClientOptions);
+#endif
                 }
                 else
                 {
@@ -247,10 +259,17 @@ namespace NuGet.Jobs
 
                 if (string.IsNullOrWhiteSpace(storageMsiConfiguration.ManagedIdentityClientId))
                 {
+#if DEBUG
                     // 1. Using MSI with DefaultAzureCredential (local debugging)
                     return new BlobServiceClientFactory(
                         blobEndpointUri,
                         new DefaultAzureCredential());
+#else
+                    // 1. Using MSI with no ClientId (system assigned)
+                    return new BlobServiceClientFactory(
+                        blobEndpointUri,
+                        new ManagedIdentityCredential());
+#endif
                 }
                 else
                 {
@@ -280,7 +299,11 @@ namespace NuGet.Jobs
 
                 if (string.IsNullOrWhiteSpace(msiConfiguration.ManagedIdentityClientId))
                 {
+#if DEBUG
                     return new TableServiceClient(tableEndpointUri, new DefaultAzureCredential());
+#else
+                    return new TableServiceClient(tableEndpointUri, new ManagedIdentityCredential());
+#endif
                 }
                 else
                 {

--- a/src/NuGet.Services.AzureSearch/DependencyInjectionExtensions.cs
+++ b/src/NuGet.Services.AzureSearch/DependencyInjectionExtensions.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Net.Http;
 using Autofac;
 using Azure;
+using Azure.Core;
 using Azure.Core.Pipeline;
 using Azure.Identity;
 using Azure.Search.Documents;
@@ -302,10 +303,17 @@ namespace NuGet.Services.AzureSearch
                     }
                     else if (options.Value.SearchServiceUseDefaultCredential)
                     {
+#if DEBUG
                         return new SearchIndexClient(
                             endpoint,
                             new DefaultAzureCredential(),
                             searchOptions);
+#else
+                        return new SearchIndexClient(
+                            endpoint,
+                            new ManagedIdentityCredential(),
+                            searchOptions);
+#endif
                     }
                     else
                     {

--- a/src/Stats.CollectAzureChinaCDNLogs/Job.cs
+++ b/src/Stats.CollectAzureChinaCDNLogs/Job.cs
@@ -152,10 +152,17 @@ namespace Stats.CollectAzureChinaCDNLogs
 
                     if (string.IsNullOrWhiteSpace(msiConfiguration.ManagedIdentityClientId))
                     {
+#if DEBUG
                         // 1. Using MSI with DefaultAzureCredential (local debugging)
                         return new BlobServiceClient(
                             blobEndpointUri,
                             new DefaultAzureCredential());
+#else
+                        // 1. Using MSI with no ClientId (system assigned)
+                        return new BlobServiceClient(
+                            blobEndpointUri,
+                            new ManagedIdentityCredential());
+#endif
                     }
                     else
                     {

--- a/src/Stats.PostProcessReports/Job.cs
+++ b/src/Stats.PostProcessReports/Job.cs
@@ -51,8 +51,13 @@ namespace Stats.PostProcessReports
 
                             if (string.IsNullOrWhiteSpace(storageMsiConfiguration.ManagedIdentityClientId))
                             {
+#if DEBUG
                                 // 1. Using MSI with DefaultAzureCredential (local debugging)
                                 return new BlobServiceClientFactory(blobEndpointUri, new DefaultAzureCredential());
+#else
+                                // 1. Using MSI with no ClientId (system assigned)
+                                return new BlobServiceClientFactory(blobEndpointUri, new ManagedIdentityCredential());
+#endif
                             }
                             else
                             {

--- a/tests/NgTests/CommandHelpersTests.cs
+++ b/tests/NgTests/CommandHelpersTests.cs
@@ -105,7 +105,11 @@ namespace NgTests
 
                 Assert.Equal("https://example/v3/search-a/cursor.json", configA.Cursors[0].CursorUri.AbsoluteUri);
                 Assert.NotNull(configA.Cursors[0].BlobClient);
+#if DEBUG
                 Assert.Equal(SearchCursorCredentialType.DefaultAzureCredential, configA.Cursors[0].CredentialType);
+#else
+                Assert.Equal(SearchCursorCredentialType.ManagedIdentityCredential, configA.Cursors[0].CredentialType);
+#endif
             }
 
             [Fact]
@@ -161,7 +165,11 @@ namespace NgTests
 
                 Assert.Equal("https://example/v3/search-a/cursor.json", configA.Cursors[0].CursorUri.AbsoluteUri);
                 Assert.NotNull(configA.Cursors[0].BlobClient);
+#if DEBUG
                 Assert.Equal(SearchCursorCredentialType.DefaultAzureCredential, configA.Cursors[0].CredentialType);
+#else
+                Assert.Equal(SearchCursorCredentialType.ManagedIdentityCredential, configA.Cursors[0].CredentialType);
+#endif
             }
         }
 


### PR DESCRIPTION
We were previously using `DefaultAzureCredential` when `ManagedIdentityCredential` was lacking a client ID. However, it’s valid for `ManagedIdentityCredential` to be constructed without a client ID. In this case it uses a system assigned managed identity (vs. user assigned when a client ID is provided). [More info here](https://learn.microsoft.com/en-us/entra/identity/managed-identities-azure-resources/managed-identity-best-practice-recommendations#choosing-system-or-user-assigned-managed-identities).

To maintain consistent authentication behavior, I’m defaulting to `DefaultAzureCredential` for debug builds (to support local development scenarios), and to `ManagedIdentityCredential` (no client ID = system assigned) in release builds. This mirrors what `DefaultAzureCredential` does in its [token acquisition chain](https://learn.microsoft.com/en-us/dotnet/api/azure.identity.defaultazurecredential?view=azure-dotnet) in production, it will attempt to use a system assigned managed identity if available.

I’m not 100% certain whether all our production environments use system assigned managed identities, so this approach preserves our current support for both system and user assigned identities.

Addresses https://github.com/NuGet/Engineering/issues/6023