### PR TITLE
Copy button not working fix for Package Details page

### DIFF
--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -1621,9 +1621,10 @@
     </style>
 
     <script type="text/javascript" nonce="@Html.GetCSPNonce()">
-        var packageId = @Html.ToJson(Model.Id);
-        var packageVersion = @Html.ToJson(Model.Version);
-        var packageManagers = @Html.ToJson(
+        window.nuget = window.nuget || {};
+        window.nuget.packageId = @Html.ToJson(Model.Id);
+        window.nuget.packageVersion = @Html.ToJson(Model.Version);
+        window.nuget.packageManagers = @Html.ToJson(
                                  (
                                     from pm in packageManagers
                                     from ipc in pm.InstallPackageCommands
@@ -1631,7 +1632,7 @@
                                  )
                                  .ToList()
                              );
-        var sponsorshipUrlCount = @sponsorshipUrlCount;
+        window.nuget.sponsorshipUrlCount = @sponsorshipUrlCount;
     </script>
 
     @if (Model.IsMarkdigMdSyntaxHighlightEnabled) 


### PR DESCRIPTION
Summary of the changes:

* page-display-package.js uses **var packageManagers = window.nuget && window.nuget.packageManagers || [];** which is then used to configure the copy button. 

* These properties were declared as variables in DisplayPackage.cshtml. Changed them to window.nuget properties that are accessible to page-display-package.js file so that copy button is initialized properly.

Addresses: https://github.com/NuGet/NuGetGallery/issues/10610

<img width="999" height="674" alt="image" src="https://github.com/user-attachments/assets/50ad35e6-9cdc-4ab2-acad-e1187429a533" />
