### PR TITLE
Remove TrustedPublishing feature flag

### DIFF
--- a/src/AccountDeleter/EmptyFeatureFlagService.cs
+++ b/src/AccountDeleter/EmptyFeatureFlagService.cs
@@ -333,11 +333,6 @@ namespace NuGetGallery.AccountDeleter
         {
             throw new NotImplementedException();
         }
-        
-        public bool IsTrustedPublishingEnabled(User user)
-        {
-            throw new NotImplementedException();
-        }
 
         public bool IsProfileLoadOptimizationEnabled()
         {

--- a/src/GitHubVulnerabilities2Db/Fakes/FakeFeatureFlagService.cs
+++ b/src/GitHubVulnerabilities2Db/Fakes/FakeFeatureFlagService.cs
@@ -335,11 +335,6 @@ namespace GitHubVulnerabilities2Db.Fakes
             throw new NotImplementedException();
         }
 
-        public bool IsTrustedPublishingEnabled(User user)
-        {
-            throw new NotImplementedException();
-        }
-
         public bool IsProfileLoadOptimizationEnabled()
         {
             throw new NotImplementedException();

--- a/src/NuGetGallery.Services/Authentication/Federated/GitHubTokenPolicyValidator.cs
+++ b/src/NuGetGallery.Services/Authentication/Federated/GitHubTokenPolicyValidator.cs
@@ -70,13 +70,6 @@ namespace NuGetGallery.Services.Authentication
                     policyPropertyName: null);
             }
 
-            if (!_featureFlagService.IsTrustedPublishingEnabled(policy.CreatedBy))
-            {
-                return FederatedCredentialPolicyValidationResult.BadRequest(
-                    $"Trusted Publishing is not enabled for '{policy.CreatedBy.Username}'.",
-                    nameof(FederatedCredentialPolicy.CreatedBy));
-            }
-
             GitHubCriteria gitHubCriteria = GitHubCriteria.FromDatabaseJson(policy.Criteria);
             NormalizeRepositoryName(gitHubCriteria);
             NormalizeWorkflowFileName(gitHubCriteria);
@@ -182,11 +175,6 @@ namespace NuGetGallery.Services.Authentication
             if (policy.Type != FederatedCredentialType.GitHubActions)
             {
                 return FederatedCredentialPolicyResult.NotApplicable;
-            }
-
-            if (!_featureFlagService.IsTrustedPublishingEnabled(policy.CreatedBy))
-            {
-                return FederatedCredentialPolicyResult.Unauthorized($"Trusted publishing is not enabled for {policy.CreatedBy.Username}");
             }
 
             var criteria = GitHubCriteria.FromDatabaseJson(policy.Criteria);

--- a/src/NuGetGallery.Services/Configuration/FeatureFlagService.cs
+++ b/src/NuGetGallery.Services/Configuration/FeatureFlagService.cs
@@ -440,11 +440,6 @@ namespace NuGetGallery
             return _client.IsEnabled(FederatedCredentialsFeatureName, user, defaultValue: false);
         }
 
-        public bool IsTrustedPublishingEnabled(User user)
-        {
-            return _client.IsEnabled(TrustedPublishingFeatureName, user, defaultValue: false);
-        }
-
         public bool IsProfileLoadOptimizationEnabled()
         {
             return _client.IsEnabled(ProfileLoadOptimization, defaultValue: true);

--- a/src/NuGetGallery.Services/Configuration/IFeatureFlagService.cs
+++ b/src/NuGetGallery.Services/Configuration/IFeatureFlagService.cs
@@ -357,13 +357,6 @@ namespace NuGetGallery
         bool CanUseFederatedCredentials(User user);
 
         /// <summary>
-        /// Whether or not the user can access trusted publishing functionality, e.g. GitHub Actions workflows.
-        /// When enabled, this controls both the ability to create Trusted Publishing policies and the ability
-        /// to exchange external tokens for NuGet API keys during package operations.
-        /// </summary>
-        bool IsTrustedPublishingEnabled(User user);
-
-        /// <summary>
         /// Whether or not the first iteration of the profile load optimization is enabled.
         /// </summary>
         bool IsProfileLoadOptimizationEnabled();

--- a/src/NuGetGallery/Controllers/UsersController.cs
+++ b/src/NuGetGallery/Controllers/UsersController.cs
@@ -1039,11 +1039,6 @@ namespace NuGetGallery
         public virtual ActionResult TrustedPublishing()
         {
             User currentUser = GetCurrentUser();
-            if (!_featureFlagService.IsTrustedPublishingEnabled(currentUser))
-            {
-                return new HttpStatusCodeResult(HttpStatusCode.NotFound);
-            }
-
             var userPolicies = _federatedCredentialService.GetPoliciesCreatedByUser(currentUser.Key);
 
             // Show newest policies on the top.
@@ -1208,11 +1203,6 @@ namespace NuGetGallery
         public virtual async Task<ActionResult> RemoveTrustedPublisherPolicy(int? federatedCredentialKey)
         {
             User currentUser = GetCurrentUser();
-            if (!_featureFlagService.IsTrustedPublishingEnabled(currentUser))
-            {
-                Response.StatusCode = (int)HttpStatusCode.BadRequest;
-                return Json(Strings.DefaultUserSafeExceptionMessage);
-            }
 
             var result = GetFederatedCredentialPolicy(federatedCredentialKey);
             if (result.policy == null)

--- a/src/NuGetGallery/Views/Shared/Gallery/Header.cshtml
+++ b/src/NuGetGallery/Views/Shared/Gallery/Header.cshtml
@@ -6,8 +6,6 @@
         && Config.Current.DeprecateNuGetPasswordLogins
         && User.HasPasswordLogin();
     var rawErrorMessage = TempData.ContainsKey("RawErrorMessage") ? TempData["RawErrorMessage"].ToString() : null;
-    var featureFlagService = DependencyResolver.Current.GetService<IFeatureFlagService>();
-    ViewBag.IsTrustedPublishingEnabled = featureFlagService != null && featureFlagService.IsTrustedPublishingEnabled(CurrentUser);
 }
 
 <div id="cookie-banner"></div>
@@ -143,10 +141,7 @@
                                             </a>
                                         </li>
 
-                                        @if (ViewBag.IsTrustedPublishingEnabled)
-                                        {
-                                            <li role="presentation"><a href="@Url.ManageMyTrustedPublishing()" role="menuitem">Trusted Publishing</a></li>
-                                        }
+                                        <li role="presentation"><a href="@Url.ManageMyTrustedPublishing()" role="menuitem">Trusted Publishing</a></li>
                                         <li role="presentation"><a href="@Url.ManageMyApiKeys()" role="menuitem">API Keys</a></li>
 
                                         <li class="divider"></li>

--- a/src/NuGetGallery/Views/Users/ApiKeys.cshtml
+++ b/src/NuGetGallery/Views/Users/ApiKeys.cshtml
@@ -4,8 +4,6 @@
 @{
     ViewBag.Title = "API Keys";
     ViewBag.MdPageColumns = GalleryConstants.ColumnsFormMd;
-    var featureFlagService = DependencyResolver.Current.GetService<IFeatureFlagService>();
-    ViewBag.IsTrustedPublishingEnabled = featureFlagService != null && featureFlagService.IsTrustedPublishingEnabled(CurrentUser);
 }
 
 <section role="main" class="container main-container page-api-keys">
@@ -14,16 +12,13 @@
         <div class="@ViewHelpers.GetColumnClasses(ViewBag)">
             @ViewHelpers.BreadcrumbWithProfile(Url, CurrentUser, true, @<text>API keys</text>)
 
-            @if (ViewBag.IsTrustedPublishingEnabled)
-            {
-                @ViewHelpers.Alert(
+            @ViewHelpers.Alert(
                     @<text>
                         <strong>Looking for a more secure and streamlined way to publish packages?</strong>
                         If you're using GitHub Actions, we recommend switching to
                         <a href="@Url.ManageMyTrustedPublishing()">Trusted Publishing</a> since it eliminates the need to manage API keys.
                     </text>,
-                    "info", icon: null)
-            }
+           "info", icon: null)
 
             <p>
                 An API key is a token that can identify you to @(Config.Current.Brand). The
@@ -33,10 +28,10 @@
             @if (!CurrentUser.Confirmed)
             {
                 @ViewHelpers.AlertWarning(
-                    @<text>
-                        To get an API Key you will need to
-                        <a href="@Url.ConfirmationRequired()">confirm your account</a>.
-                    </text>)
+                        @<text>
+                            To get an API Key you will need to
+                            <a href="@Url.ConfirmationRequired()">confirm your account</a>.
+                        </text>)
             }
             else
             {
@@ -49,21 +44,21 @@
                 @ViewHelpers.Section(this,
                     "create",
                     "Create",
-                    @<text>
-                        <div class="upsert-api-key">
-                            <div class="panel-body" data-bind="template: { name: 'upsert-api-key', data: NewApiKey }"></div>
-                        </div>
-                    </text>,
-        expanded: false,
-        expandedIcon: "Subtraction",
-        collapsedIcon: "Add")
+                        @<text>
+                            <div class="upsert-api-key">
+                                <div class="panel-body" data-bind="template: { name: 'upsert-api-key', data: NewApiKey }"></div>
+                            </div>
+                        </text>,
+     expanded: false,
+     expandedIcon: "Subtraction",
+     collapsedIcon: "Add")
 
                 @ViewHelpers.Section(this,
                     "manage",
                     "Manage",
-                    @<text>
-                        <div data-bind="template: 'manage-api-keys'"></div>
-                    </text>)
+                        @<text>
+                            <div data-bind="template: 'manage-api-keys'"></div>
+                        </text>)
             }
         </div>
     </div>

--- a/src/VerifyMicrosoftPackage/Fakes/FakeFeatureFlagService.cs
+++ b/src/VerifyMicrosoftPackage/Fakes/FakeFeatureFlagService.cs
@@ -140,8 +140,6 @@ namespace NuGet.VerifyMicrosoftPackage.Fakes
 
         public bool CanUseFederatedCredentials(User user) => throw new NotImplementedException();
 
-        public bool IsTrustedPublishingEnabled(User user) => throw new NotImplementedException();
-
         public bool IsProfileLoadOptimizationEnabled() => throw new NotImplementedException();
 
         public bool IsProfileLoadOptimizationV2Enabled() => throw new NotImplementedException();

--- a/tests/NuGetGallery.Facts/Authentication/Federated/GitHubTokenPolicyValidatorFacts.cs
+++ b/tests/NuGetGallery.Facts/Authentication/Federated/GitHubTokenPolicyValidatorFacts.cs
@@ -151,29 +151,6 @@ namespace NuGetGallery.Services.Authentication
             Assert.Null(result.PolicyPropertyName);
         }
 
-        [Fact]
-        public void RejectsWhenTrustedPublishingDisabled()
-        {
-            // Arrange
-            var user = new User("test-user");
-            var policy = new FederatedCredentialPolicy
-            {
-                Type = FederatedCredentialType.GitHubActions,
-                CreatedBy = user,
-                Criteria = TokenTestHelper.PermanentPolicyCriteria
-            };
-
-            FeatureFlagService.Setup(x => x.IsTrustedPublishingEnabled(user)).Returns(false);
-
-            // Act
-            var result = Target.ValidatePolicy(policy);
-
-            // Assert
-            Assert.Equal(FederatedCredentialPolicyValidationResultType.BadRequest, result.Type);
-            Assert.Equal("Trusted Publishing is not enabled for 'test-user'.", result.UserMessage);
-            Assert.Equal(nameof(FederatedCredentialPolicy.CreatedBy), result.PolicyPropertyName);
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("")]
@@ -189,8 +166,6 @@ namespace NuGetGallery.Services.Authentication
                 PolicyName = policyName,
                 Criteria = TokenTestHelper.PermanentPolicyCriteria
             };
-
-            FeatureFlagService.Setup(x => x.IsTrustedPublishingEnabled(user)).Returns(true);
 
             // Act
             var result = Target.ValidatePolicy(policy);
@@ -212,8 +187,6 @@ namespace NuGetGallery.Services.Authentication
                 PolicyName = "Test Policy",
                 Criteria = "invalid json"
             };
-
-            FeatureFlagService.Setup(x => x.IsTrustedPublishingEnabled(user)).Returns(true);
 
             // Act & Assert
             Assert.ThrowsAny<Exception>(() => Target.ValidatePolicy(policy));
@@ -238,8 +211,6 @@ namespace NuGetGallery.Services.Authentication
                 Criteria = invalidCriteria
             };
 
-            FeatureFlagService.Setup(x => x.IsTrustedPublishingEnabled(user)).Returns(true);
-
             // Act
             var result = Target.ValidatePolicy(policy);
 
@@ -261,8 +232,6 @@ namespace NuGetGallery.Services.Authentication
                 PolicyName = "Test Policy",
                 Criteria = TokenTestHelper.PermanentPolicyCriteria
             };
-
-            FeatureFlagService.Setup(x => x.IsTrustedPublishingEnabled(user)).Returns(true);
 
             // Act
             var result = Target.ValidatePolicy(policy);
@@ -286,8 +255,6 @@ namespace NuGetGallery.Services.Authentication
                 PolicyName = "Test Policy",
                 Criteria = """{"owner":"test-owner","repository":"test-repo","workflow":"test.yml"}"""
             };
-
-            FeatureFlagService.Setup(x => x.IsTrustedPublishingEnabled(user)).Returns(true);
 
             // Act
             var result = Target.ValidatePolicy(policy);
@@ -318,8 +285,6 @@ namespace NuGetGallery.Services.Authentication
                 Criteria = originalCriteria
             };
 
-            FeatureFlagService.Setup(x => x.IsTrustedPublishingEnabled(user)).Returns(true);
-
             // Act
             var result = Target.ValidatePolicy(policy);
 
@@ -346,8 +311,6 @@ namespace NuGetGallery.Services.Authentication
                 PolicyName = "Test Policy",
                 Criteria = originalCriteria
             };
-
-            FeatureFlagService.Setup(x => x.IsTrustedPublishingEnabled(user)).Returns(true);
 
             // Act
             var result = Target.ValidatePolicy(policy);
@@ -376,8 +339,6 @@ namespace NuGetGallery.Services.Authentication
                 Criteria = expiredCriteria
             };
 
-            FeatureFlagService.Setup(x => x.IsTrustedPublishingEnabled(user)).Returns(true);
-
             // Act
             var result = Target.ValidatePolicy(policy);
 
@@ -403,8 +364,6 @@ namespace NuGetGallery.Services.Authentication
                 Criteria = """{"owner":"test-owner","repository":"test-repo","workflow":"test.yml","environment":"production"}"""
             };
 
-            FeatureFlagService.Setup(x => x.IsTrustedPublishingEnabled(user)).Returns(true);
-
             // Act
             var result = Target.ValidatePolicy(policy);
 
@@ -424,8 +383,6 @@ namespace NuGetGallery.Services.Authentication
                 PolicyName = "Test Policy",
                 Criteria = TokenTestHelper.PermanentPolicyCriteria
             };
-
-            FeatureFlagService.Setup(x => x.IsTrustedPublishingEnabled(user)).Returns(true);
 
             // Act
             var result = Target.ValidatePolicy(policy);
@@ -461,8 +418,6 @@ namespace NuGetGallery.Services.Authentication
                 PolicyName = "Test Policy",
                 Criteria = System.Text.Json.JsonSerializer.Serialize(criteria)
             };
-
-            FeatureFlagService.Setup(x => x.IsTrustedPublishingEnabled(user)).Returns(true);
 
             // Act
             var result = Target.ValidatePolicy(policy);
@@ -500,8 +455,6 @@ namespace NuGetGallery.Services.Authentication
                 PolicyName = "Test Policy",
                 Criteria = System.Text.Json.JsonSerializer.Serialize(criteria)
             };
-
-            FeatureFlagService.Setup(x => x.IsTrustedPublishingEnabled(user)).Returns(true);
 
             // Act
             var result = Target.ValidatePolicy(policy);
@@ -589,30 +542,6 @@ namespace NuGetGallery.Services.Authentication
             }
 
             [Fact]
-            public async Task RejectsWhenTrustedPublishingDisabled()
-            {
-                // Arrange
-                var createdBy = new User("test-user");
-                var policy = new FederatedCredentialPolicy
-                {
-                    Type = FederatedCredentialType.GitHubActions,
-                    Criteria = TokenTestHelper.PermanentPolicyCriteria,
-                    CreatedBy = createdBy
-                };
-
-                FeatureFlagService.Setup(x => x.IsTrustedPublishingEnabled(createdBy)).Returns(false);
-
-                var token = TokenTestHelper.CreateTestJwt();
-
-                // Act
-                var result = await Target.EvaluatePolicyAsync(policy, token);
-
-                // Assert
-                Assert.Equal(FederatedCredentialPolicyResultType.Unauthorized, result.Type);
-                Assert.Equal("Trusted publishing is not enabled for test-user", result.Error);
-            }
-
-            [Fact]
             public async Task ThrowsInvalidCriteriaJson()
             {
                 // Arrange
@@ -623,8 +552,6 @@ namespace NuGetGallery.Services.Authentication
                     Criteria = "invalid",
                     CreatedBy = createdBy
                 };
-
-                FeatureFlagService.Setup(x => x.IsTrustedPublishingEnabled(createdBy)).Returns(true);
 
                 var token = TokenTestHelper.CreateTestJwt();
 
@@ -644,8 +571,6 @@ namespace NuGetGallery.Services.Authentication
                     Criteria = TokenTestHelper.ExpiredPolicyCriteria,
                     CreatedBy = createdBy
                 };
-
-                FeatureFlagService.Setup(x => x.IsTrustedPublishingEnabled(createdBy)).Returns(true);
 
                 var token = TokenTestHelper.CreateTestJwt();
 
@@ -674,8 +599,6 @@ namespace NuGetGallery.Services.Authentication
                     Criteria = TokenTestHelper.PermanentPolicyCriteria,
                     CreatedBy = createdBy
                 };
-
-                FeatureFlagService.Setup(x => x.IsTrustedPublishingEnabled(createdBy)).Returns(true);
 
                 var tokenWithEmptyValue = TokenTestHelper.CreateTestJwtWithCustomClaimValue(claim, null);
                 var tokenWithMissingValue = TokenTestHelper.CreateTestJwtWithCustomClaimValue(claim, "");
@@ -726,8 +649,6 @@ namespace NuGetGallery.Services.Authentication
                     CreatedBy = createdBy
                 };
 
-                FeatureFlagService.Setup(x => x.IsTrustedPublishingEnabled(createdBy)).Returns(true);
-
                 var token = TokenTestHelper.CreateTestJwtWithCustomClaimValue(claim, claimValue);
 
                 // Act
@@ -769,8 +690,6 @@ namespace NuGetGallery.Services.Authentication
                     CreatedBy = createdBy
                 };
 
-                FeatureFlagService.Setup(x => x.IsTrustedPublishingEnabled(createdBy)).Returns(true);
-
                 string value = TokenTestHelper.ValidClaims[claim].ToString().ToUpperInvariant();
                 var token = TokenTestHelper.CreateTestJwtWithCustomClaimValue(claim, value);
 
@@ -798,8 +717,6 @@ namespace NuGetGallery.Services.Authentication
                     CreatedBy = createdBy
                 };
 
-                FeatureFlagService.Setup(x => x.IsTrustedPublishingEnabled(createdBy)).Returns(true);
-
                 var token = TokenTestHelper.CreateTestJwt();
 
                 // Act
@@ -822,8 +739,6 @@ namespace NuGetGallery.Services.Authentication
                     CreatedBy = createdBy,
                     PackageOwner = new User("test-owner")
                 };
-
-                FeatureFlagService.Setup(x => x.IsTrustedPublishingEnabled(createdBy)).Returns(true);
 
                 var token = TokenTestHelper.CreateTestJwt();
 
@@ -859,8 +774,6 @@ namespace NuGetGallery.Services.Authentication
                     Type = policy.Type,
                     Criteria = TokenTestHelper.PermanentPolicyCriteria
                 };
-
-                FeatureFlagService.Setup(x => x.IsTrustedPublishingEnabled(createdBy)).Returns(true);
 
                 var token = TokenTestHelper.CreateTestJwt();
 
@@ -911,8 +824,6 @@ namespace NuGetGallery.Services.Authentication
                     Criteria = updatedCriteria.ToDatabaseJson()
                 };
 
-                FeatureFlagService.Setup(x => x.IsTrustedPublishingEnabled(createdBy)).Returns(true);
-
                 var token = TokenTestHelper.CreateTestJwt();
 
                 // Setup SavePoliciesAsync to throw DbUpdateConcurrencyException
@@ -946,8 +857,6 @@ namespace NuGetGallery.Services.Authentication
                     Criteria = TokenTestHelper.TemporaryPolicyCriteria,
                     CreatedBy = createdBy
                 };
-
-                FeatureFlagService.Setup(x => x.IsTrustedPublishingEnabled(createdBy)).Returns(true);
 
                 var token = TokenTestHelper.CreateTestJwt();
 

--- a/tests/NuGetGallery.Facts/Controllers/UsersControllerFacts.TrustedPublishing.cs
+++ b/tests/NuGetGallery.Facts/Controllers/UsersControllerFacts.TrustedPublishing.cs
@@ -31,10 +31,6 @@ public class TheTrustedPublishingAction : TestContainer
     public void WhenTrustedPublishingEnabled_ReturnsTrustedPublishingView(User currentUser)
     {
         // Arrange
-        GetMock<IFeatureFlagService>()
-            .Setup(f => f.IsTrustedPublishingEnabled(currentUser))
-            .Returns(true);
-
         GetMock<IFederatedCredentialService>()
             .Setup(r => r.GetPoliciesCreatedByUser(It.IsAny<int>()))
             .Returns([]);
@@ -57,30 +53,9 @@ public class TheTrustedPublishingAction : TestContainer
     }
 
     [Fact]
-    public void WhenTrustedPublishingDisabled_ReturnsBadRequest()
-    {
-        // Arrange
-        GetMock<IFeatureFlagService>()
-            .Setup(f => f.IsTrustedPublishingEnabled(It.IsAny<User>()))
-            .Returns(false);
-
-        var controller = GetController<UsersController>();
-
-        // Act
-        var result = controller.TrustedPublishing();
-
-        // Assert
-        Assert.Equal((int)HttpStatusCode.NotFound, ((HttpStatusCodeResult)result).StatusCode);
-    }
-
-    [Fact]
     public void FiltersOnlyTrustedPublisherPolicies()
     {
         // Arrange
-        GetMock<IFeatureFlagService>()
-            .Setup(f => f.IsTrustedPublishingEnabled(It.IsAny<User>()))
-            .Returns(true);
-
         var currentUser = TestUtility.FakeUser;
         var policies = new List<FederatedCredentialPolicy>
                 {
@@ -117,10 +92,6 @@ public class TheTrustedPublishingAction : TestContainer
     public void WhenPolicyHasUserNotInOrganizationInvalidReason_CorrectlyPopulatesModel()
     {
         // Arrange
-        GetMock<IFeatureFlagService>()
-            .Setup(f => f.IsTrustedPublishingEnabled(It.IsAny<User>()))
-            .Returns(true);
-
         var currentUser = TestUtility.FakeUser;
         var organization = TestUtility.FakeOrganization;
 
@@ -157,10 +128,6 @@ public class TheTrustedPublishingAction : TestContainer
     public void WhenPolicyHasOrganizationLockedOrDeletedInvalidReason_CorrectlyPopulatesModel(bool isLocked, bool isDeleted)
     {
         // Arrange
-        GetMock<IFeatureFlagService>()
-            .Setup(f => f.IsTrustedPublishingEnabled(It.IsAny<User>()))
-            .Returns(true);
-
         // Create a new organization and user for this test
         var organization = new Organization { Username = "TestOrganization", Key = 5 };
         var currentUser = Get<Fakes>().CreateUser("TestOrganizationAdmin");
@@ -200,10 +167,6 @@ public class TheTrustedPublishingAction : TestContainer
     public void WhenUserOwnsPolicy_OwnerIsValid()
     {
         // Arrange
-        GetMock<IFeatureFlagService>()
-            .Setup(f => f.IsTrustedPublishingEnabled(It.IsAny<User>()))
-            .Returns(true);
-
         var currentUser = TestUtility.FakeOrganizationAdmin;
 
         var policy = new FederatedCredentialPolicy
@@ -242,10 +205,6 @@ public class TheTrustedPublishingAction : TestContainer
     public void WhenOrganizationMemberOwnsPolicy_OwnerIsValid()
     {
         // Arrange
-        GetMock<IFeatureFlagService>()
-            .Setup(f => f.IsTrustedPublishingEnabled(It.IsAny<User>()))
-            .Returns(true);
-
         var currentUser = TestUtility.FakeOrganizationAdmin;
         var organization = TestUtility.FakeOrganization;
 
@@ -289,10 +248,6 @@ public class TheTrustedPublishingAction : TestContainer
     public void WhenPolicyIsPermanent_IsPermanentlyEnabled()
     {
         // Arrange
-        GetMock<IFeatureFlagService>()
-            .Setup(f => f.IsTrustedPublishingEnabled(It.IsAny<User>()))
-            .Returns(true);
-
         var currentUser = TestUtility.FakeUser;
         var policy = new FederatedCredentialPolicy
         {
@@ -327,10 +282,6 @@ public class TheTrustedPublishingAction : TestContainer
     public void WhenPolicyWithValidateByDate_IsTemporaryAndEnabledDaysLeft(int daysLeft)
     {
         // Arrange
-        GetMock<IFeatureFlagService>()
-            .Setup(f => f.IsTrustedPublishingEnabled(It.IsAny<User>()))
-            .Returns(true);
-
         var currentUser = TestUtility.FakeUser;
         DateTimeOffset validateBy = DateTimeOffset.UtcNow + TimeSpan.FromHours(24 * daysLeft - 1);
         string dbJson = """{"owner":"nuget","repository":"Engineering","workflow":"2.yam","environment":"what","validateBy":"%DATE%"}""";
@@ -366,10 +317,6 @@ public class TheTrustedPublishingAction : TestContainer
     public void WhenMultiplePoliciesWithDifferentTypes_CorrectlyClassifiesEach()
     {
         // Arrange
-        GetMock<IFeatureFlagService>()
-            .Setup(f => f.IsTrustedPublishingEnabled(It.IsAny<User>()))
-            .Returns(true);
-
         var currentUser = TestUtility.FakeUser;
         var temporaryPolicy = new FederatedCredentialPolicy
         {
@@ -434,10 +381,6 @@ public class TheGenerateTrustedPublisherPolicyAction : TestContainer
     public async Task WhenValidRequestWithIds_CreatesPermanentlyEnabledPolicy()
     {
         // Arrange
-        GetMock<IFeatureFlagService>()
-            .Setup(f => f.IsTrustedPublishingEnabled(It.IsAny<User>()))
-            .Returns(true);
-
         var user = TestUtility.FakeUser;
         var controller = GetController<UsersController>();
         controller.SetCurrentUser(user);
@@ -480,10 +423,6 @@ public class TheGenerateTrustedPublisherPolicyAction : TestContainer
     public async Task WhenFederatedCredentialServiceReturnsBadRequest_ReturnsBadRequestWithUserMessage()
     {
         // Arrange
-        GetMock<IFeatureFlagService>()
-            .Setup(f => f.IsTrustedPublishingEnabled(It.IsAny<User>()))
-            .Returns(true);
-
         var user = TestUtility.FakeUser;
         var controller = GetController<UsersController>();
         controller.SetCurrentUser(user);
@@ -513,10 +452,6 @@ public class TheGenerateTrustedPublisherPolicyAction : TestContainer
     public async Task WhenFederatedCredentialServiceReturnsUnauthorizes_ReturnsUnauthorizedWithUserMessage()
     {
         // Arrange
-        GetMock<IFeatureFlagService>()
-            .Setup(f => f.IsTrustedPublishingEnabled(It.IsAny<User>()))
-            .Returns(true);
-
         var user = TestUtility.FakeUser;
         var controller = GetController<UsersController>();
         controller.SetCurrentUser(user);
@@ -549,10 +484,6 @@ public class TheEditTrustedPublisherPolicyAction : TestContainer
     public async Task WhenEditingPolicy_CallsUpdatePolicyAsyncWithCorrectParameters()
     {
         // Arrange
-        GetMock<IFeatureFlagService>()
-            .Setup(f => f.IsTrustedPublishingEnabled(It.IsAny<User>()))
-            .Returns(true);
-
         var user = TestUtility.FakeUser;
         string newJSCriteria = """{"RepositoryOwner":"someOwner","Repository":"repo","WorkflowFile":"new.yml","Environment":"", "validateBy":"2025-01-01T00:00:00Z"}""";
 
@@ -597,10 +528,6 @@ public class TheEditTrustedPublisherPolicyAction : TestContainer
     public async Task WhenEditingPolicy_ReturnsJsonResultFromService()
     {
         // Arrange
-        GetMock<IFeatureFlagService>()
-            .Setup(f => f.IsTrustedPublishingEnabled(It.IsAny<User>()))
-            .Returns(true);
-
         var user = TestUtility.FakeUser;
         string newJSCriteria = """{"RepositoryOwner":"someOwner","Repository":"repo","WorkflowFile":"new.yml", "validateBy":"2025-01-01T00:00:00Z"}""";
 
@@ -644,10 +571,6 @@ public class TheEditTrustedPublisherPolicyAction : TestContainer
     public async Task WhenFederatedCredentialServiceReturnsError_ReturnsBadRequestWithUserMessage()
     {
         // Arrange
-        GetMock<IFeatureFlagService>()
-            .Setup(f => f.IsTrustedPublishingEnabled(It.IsAny<User>()))
-            .Returns(true);
-
         var user = TestUtility.FakeUser;
         var policy = new FederatedCredentialPolicy
         {
@@ -687,10 +610,6 @@ public class TheEditTrustedPublisherPolicyAction : TestContainer
     public async Task WhenPolicyNotFound_ReturnsBadRequest()
     {
         // Arrange
-        GetMock<IFeatureFlagService>()
-            .Setup(f => f.IsTrustedPublishingEnabled(It.IsAny<User>()))
-            .Returns(true);
-
         GetMock<IFederatedCredentialService>()
             .Setup(r => r.GetPolicyByKey(1))
             .Returns((FederatedCredentialPolicy)null);
@@ -711,10 +630,6 @@ public class TheEditTrustedPublisherPolicyAction : TestContainer
     public async Task WhenUserNotOwnerOfPolicy_ReturnsBadRequest()
     {
         // Arrange
-        GetMock<IFeatureFlagService>()
-            .Setup(f => f.IsTrustedPublishingEnabled(It.IsAny<User>()))
-            .Returns(true);
-
         var user = TestUtility.FakeUser;
         var otherUser = TestUtility.FakeAdminUser;
         var policy = new FederatedCredentialPolicy
@@ -750,10 +665,6 @@ public class TheEnableTrustedPublisherPolicyAction : TestContainer
     public async Task WhenPolicyNotFound_ReturnsBadRequest()
     {
         // Arrange
-        GetMock<IFeatureFlagService>()
-            .Setup(f => f.IsTrustedPublishingEnabled(It.IsAny<User>()))
-            .Returns(true);
-
         GetMock<IFederatedCredentialService>()
             .Setup(r => r.GetPolicyByKey(1))
             .Returns((FederatedCredentialPolicy)null);
@@ -776,10 +687,6 @@ public class TheEnableTrustedPublisherPolicyAction : TestContainer
     public async Task WhenFederatedCredentialKeyIsInvalid_ReturnsBadRequest(int? federatedCredentialKey)
     {
         // Arrange
-        GetMock<IFeatureFlagService>()
-            .Setup(f => f.IsTrustedPublishingEnabled(It.IsAny<User>()))
-            .Returns(true);
-
         GetMock<IFederatedCredentialService>()
             .Setup(r => r.GetPolicyByKey(It.IsAny<int>()))
             .Returns((FederatedCredentialPolicy)null);
@@ -800,10 +707,6 @@ public class TheEnableTrustedPublisherPolicyAction : TestContainer
     public async Task WhenValidPolicy_CallsUpdatePolicyAsyncAndReturnsJsonResult()
     {
         // Arrange
-        GetMock<IFeatureFlagService>()
-            .Setup(f => f.IsTrustedPublishingEnabled(It.IsAny<User>()))
-            .Returns(true);
-
         var user = TestUtility.FakeUser;
         var policy = new FederatedCredentialPolicy
         {
@@ -845,33 +748,9 @@ public class TheEnableTrustedPublisherPolicyAction : TestContainer
 public class TheRemoveTrustedPublisherPolicyAction : TestContainer
 {
     [Fact]
-    public async Task WhenTrustedPublishingDisabled_ReturnsBadRequest()
-    {
-        // Arrange
-        GetMock<IFeatureFlagService>()
-            .Setup(f => f.IsTrustedPublishingEnabled(It.IsAny<User>()))
-            .Returns(false);
-
-        var user = TestUtility.FakeUser;
-        var controller = GetController<UsersController>();
-        controller.SetCurrentUser(user);
-
-        // Act
-        var result = await controller.RemoveTrustedPublisherPolicy(federatedCredentialKey: 1);
-
-        // Assert
-        Assert.Equal((int)HttpStatusCode.BadRequest, controller.Response.StatusCode);
-        Assert.Equal(Strings.DefaultUserSafeExceptionMessage, ((JsonResult)result).Data);
-    }
-
-    [Fact]
     public async Task WhenPolicyNotFound_ReturnsBadRequest()
     {
         // Arrange
-        GetMock<IFeatureFlagService>()
-            .Setup(f => f.IsTrustedPublishingEnabled(It.IsAny<User>()))
-            .Returns(true);
-
         GetMock<IFederatedCredentialService>()
             .Setup(r => r.GetPolicyByKey(1))
             .Returns((FederatedCredentialPolicy)null);
@@ -892,10 +771,6 @@ public class TheRemoveTrustedPublisherPolicyAction : TestContainer
     public async Task WhenUserNotOwnerOfPolicy_ReturnsForbidden()
     {
         // Arrange
-        GetMock<IFeatureFlagService>()
-            .Setup(f => f.IsTrustedPublishingEnabled(It.IsAny<User>()))
-            .Returns(true);
-
         var user = TestUtility.FakeUser;
         var otherUser = TestUtility.FakeAdminUser;
         var policy = new FederatedCredentialPolicy
@@ -925,10 +800,6 @@ public class TheRemoveTrustedPublisherPolicyAction : TestContainer
     public async Task WhenValidRequest_DeletesPolicy()
     {
         // Arrange
-        GetMock<IFeatureFlagService>()
-            .Setup(f => f.IsTrustedPublishingEnabled(It.IsAny<User>()))
-            .Returns(true);
-
         var user = TestUtility.FakeUser;
         var policy = new FederatedCredentialPolicy
         {


### PR DESCRIPTION
Use of `IFeatureFlagService` in the shared `Header.cshtml` file is causing issues in NuGet.Status when I try to bump the NuGetGallery submodule. This is because the Status project doesn't compile that type and doing so causes a chain reaction causing hundreds of new types to be compiled as well. It's best to just remove it.