### PR TITLE
Move search filter constants to GalleryConstants

### DIFF
--- a/src/NuGetGallery/GalleryConstants.cs
+++ b/src/NuGetGallery/GalleryConstants.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using NuGet.Versioning;
@@ -108,6 +108,19 @@ namespace NuGetGallery
             public const string CreatedDesc = "created-desc";
             public const string TotalDownloadsAsc = "totalDownloads-asc";
             public const string TotalDownloadsDesc = "totalDownloads-desc";
+        }
+
+        public static class SearchFilterIds
+        {
+            /// <summary>
+            /// MUST MATCH common.js. Used to add localy stored search params to a element.
+            /// </summary>
+            public const string PackagesLinkClass = "link-to-add-local-search-filters";
+
+            /// <summary>
+            /// MUST MATCH common.js. Used to add localy stored search params to form element.
+            /// </summary>
+            public const string SimpleSearchFormId = "form-to-add-local-search-filters";
         }
     }
 }

--- a/src/NuGetGallery/UrlHelperExtensions.cs
+++ b/src/NuGetGallery/UrlHelperExtensions.cs
@@ -19,16 +19,6 @@ namespace NuGetGallery
         private const string Area = "area";
         private static IGalleryConfigurationService _configuration;
 
-        /// <summary>
-        /// MUST MATCH common.js. Used to add localy stored search params to a element.
-        /// </summary>
-        public const string PackagesLinkClass = "link-to-add-local-search-filters";
-
-        /// <summary>
-        /// MUST MATCH common.js. Used to add localy stored search params to form element.
-        /// </summary>
-        public const string SimpleSearchFormId = "form-to-add-local-search-filters";
-
         public static class Fragments
         {
             public static class ManagePage

--- a/src/NuGetGallery/Views/Experiments/SearchSideBySide.cshtml
+++ b/src/NuGetGallery/Views/Experiments/SearchSideBySide.cshtml
@@ -17,7 +17,7 @@
                             The side-by-side search page is now <b>closed</b>.
                             <br /><br />
                             Thank you for trying out the side-by-side preview. The new and improved NuGet search
-                            is now <a href="@Url.PackageList()" class="@UrlHelperExtensions.PackagesLinkClass">live</a>! For details about the initial release, check out the
+                            is now <a href="@Url.PackageList()" class="@GalleryConstants.SearchFilterIds.PackagesLinkClass">live</a>! For details about the initial release, check out the
                             <a href="https://devblogs.microsoft.com/nuget/new-and-improved-nuget-search/">blog post</a>.
                             The old search results are no longer available.
                             <br /><br />

--- a/src/NuGetGallery/Views/Pages/Home.cshtml
+++ b/src/NuGetGallery/Views/Pages/Home.cshtml
@@ -96,7 +96,7 @@ else if (AskUserToEnable2FA)
                 </p>
             </div>
             <div class="col-sm-4">
-                <a href="@Url.PackageList()" class="@UrlHelperExtensions.PackagesLinkClass"
+                <a href="@Url.PackageList()" class="@GalleryConstants.SearchFilterIds.PackagesLinkClass"
                    title="Explore packages available on NuGet.org">
                     <div class="home-icons">
                         <img src="@Url.Absolute("~/Content/gallery/img/search-icon.svg")" alt="Find packages" width="96" height="96" />

--- a/src/NuGetGallery/Views/Pages/Home.cshtml
+++ b/src/NuGetGallery/Views/Pages/Home.cshtml
@@ -48,7 +48,7 @@ else if (AskUserToEnable2FA)
             </div>
             <div class="row">
                 <div class="col-sm-8 col-sm-offset-2">
-                    <form id="@UrlHelperExtensions.SimpleSearchFormId" action="@Url.PackageList()" method="get">
+                    <form id="@GalleryConstants.SearchFilterIds.SimpleSearchFormId" action="@Url.PackageList()" method="get">
                         @Html.Partial("_SearchBar")
                         @Html.Partial("_AutocompleteTemplate")
                     </form>

--- a/src/NuGetGallery/Views/Shared/Gallery/Header.cshtml
+++ b/src/NuGetGallery/Views/Shared/Gallery/Header.cshtml
@@ -74,7 +74,7 @@
                 </div>
                 <div id="navbar" class="navbar-collapse collapse">
                     <ul class="nav navbar-nav" role="tablist">
-                        @DisplayNavigationItem("Packages", Url.PackageList(), className: UrlHelperExtensions.PackagesLinkClass)
+                        @DisplayNavigationItem("Packages", Url.PackageList(), className: GalleryConstants.SearchFilterIds.PackagesLinkClass)
                         @DisplayNavigationItem("Upload", Url.UploadPackage())
                         @if (StatisticsHelper.IsStatisticsPageAvailable)
                         {
@@ -176,7 +176,7 @@
     {
         <div id="search-bar-header" class="container search-container">
             <div class="row">
-                <form aria-label="Package search bar" class="col-sm-12" id="@UrlHelperExtensions.SimpleSearchFormId" action="@Url.PackageList()" method="get">
+                <form aria-label="Package search bar" class="col-sm-12" id="@GalleryConstants.SearchFilterIds.SimpleSearchFormId" action="@Url.PackageList()" method="get">
                     @Html.Partial("_SearchBar")
                     @Html.Partial("_AutocompleteTemplate")
                 </form>

--- a/src/NuGetGallery/Views/Shared/SiteMenu.cshtml
+++ b/src/NuGetGallery/Views/Shared/SiteMenu.cshtml
@@ -8,7 +8,7 @@
         }
     }
     <li class="@classes["Home"]"><a href="@Url.Home()">Home</a></li>
-    <li class="@classes["Packages"]"><a href="@Url.PackageList()" class="@UrlHelperExtensions.PackagesLinkClass">Packages</a></li>
+    <li class="@classes["Packages"]"><a href="@Url.PackageList()" class="@GalleryConstants.SearchFilterIds.PackagesLinkClass">Packages</a></li>
     <li class="@classes["Upload"]"><a href="@Url.UploadPackage()" class="upload">Upload Package</a></li>
     @if (StatisticsHelper.IsStatisticsPageAvailable)
     {


### PR DESCRIPTION
Use of `URLHelperExtensions.cs` in the shared Header.cshtml file is causing issues in NuGet.Status when I try to bump the NuGetGallery submodule. This is because the Status project doesn't compile that type and doing so causes a chain reaction causing hundreds of new types to be compiled as well. It's best to move these cosntants in the dependency-less `GalleryConstants.cs` which NuGet.Status already compiles.