### PR TITLE
Add permissive network isolation policy to CI pipeline

### DIFF
--- a/.pipelines/NuGetGallery-CI.yml
+++ b/.pipelines/NuGetGallery-CI.yml
@@ -49,6 +49,8 @@ resources:
 extends:
   template: v1/1ES.Unofficial.PipelineTemplate.yml@1ESPipelineTemplates
   parameters:
+    settings:
+      networkIsolationPolicy: Permissive
     pool:
       name: NuGet-1ES-Hosted-Pool
       image: NuGet-1ESPT-Win2022


### PR DESCRIPTION
Not sure why this became necessary overnight, but it appears to unblock the build.