### PR TITLE
Fix indentation in NuGetGallery-CI.yml

### DIFF
--- a/.pipelines/NuGetGallery-CI.yml
+++ b/.pipelines/NuGetGallery-CI.yml
@@ -50,7 +50,7 @@ extends:
   template: v1/1ES.Unofficial.PipelineTemplate.yml@1ESPipelineTemplates
   parameters:
     settings:
-        networkIsolationPolicy: Permissive
+      networkIsolationPolicy: Permissive
     pool:
       name: NuGet-1ES-Hosted-Pool
       image: NuGet-1ESPT-Win2022


### PR DESCRIPTION
The indentation difference here is creating a merge conflict between dev and main. Normalizing it.

https://github.com/NuGet/NuGetGallery/pull/10639