### PR TITLE
Don't return an empty user message string in OIDC flow

### DIFF
--- a/src/NuGetGallery.Services/Authentication/Federated/FederatedCredentialPolicyEvaluator.cs
+++ b/src/NuGetGallery.Services/Authentication/Federated/FederatedCredentialPolicyEvaluator.cs
@@ -144,7 +144,8 @@ namespace NuGetGallery.Services.Authentication
                 }
             }
 
-            return OidcTokenEvaluationResult.NoMatchingPolicy(disclosableErrors.ToString());
+            string? userError = disclosableErrors.Length > 0 ? disclosableErrors.ToString() : null;
+            return OidcTokenEvaluationResult.NoMatchingPolicy(userError);
         }
 
         private async Task ExecuteAdditionalValidatorsAsync(NameValueCollection requestHeaders, TokenContext context)

--- a/src/NuGetGallery.Services/Telemetry/QuietLog.cs
+++ b/src/NuGetGallery.Services/Telemetry/QuietLog.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -47,7 +47,7 @@ namespace NuGetGallery
             try
             {
                 // send exception to AppInsights
-                Telemetry.TrackException(e, new Dictionary<string, string>
+                Telemetry?.TrackException(e, new Dictionary<string, string>
                 {
                     { "aggregateExceptionId", aggregateExceptionId }
                 });

--- a/src/NuGetGallery/App_Start/DefaultDependenciesModule.cs
+++ b/src/NuGetGallery/App_Start/DefaultDependenciesModule.cs
@@ -557,7 +557,8 @@ namespace NuGetGallery
         {
             builder
                 .RegisterType<FederatedCredentialRepository>()
-                .As<IFederatedCredentialRepository>();
+                .As<IFederatedCredentialRepository>()
+                .InstancePerLifetimeScope();
 
             builder
                 .Register(c => configuration.FederatedCredential)
@@ -608,7 +609,8 @@ namespace NuGetGallery
                     c.Resolve<IFederatedCredentialConfiguration>(),
                     c.Resolve<IFeatureFlagService>(),
                     c.Resolve<JsonWebTokenHandler>()))
-                .As<ITokenPolicyValidator>();
+                .As<ITokenPolicyValidator>()
+                .InstancePerLifetimeScope();
 
             builder
                 .Register(c => new GitHubTokenPolicyValidator(
@@ -619,15 +621,18 @@ namespace NuGetGallery
                     c.Resolve<IFeatureFlagService>(),
                     c.Resolve<JsonWebTokenHandler>()
                     ))
-                .As<ITokenPolicyValidator>();
+                .As<ITokenPolicyValidator>()
+                .InstancePerLifetimeScope();
 
             builder
                 .RegisterType<FederatedCredentialPolicyEvaluator>()
-                .As<IFederatedCredentialPolicyEvaluator>();
+                .As<IFederatedCredentialPolicyEvaluator>()
+                .InstancePerLifetimeScope();
 
             builder
                 .RegisterType<FederatedCredentialService>()
-                .As<IFederatedCredentialService>();
+                .As<IFederatedCredentialService>()
+                .InstancePerLifetimeScope();
         }
 
         // Internal for testing purposes

--- a/tests/NuGetGallery.Facts/Authentication/Federated/FederatedCredentialPolicyEvaluatorFacts.cs
+++ b/tests/NuGetGallery.Facts/Authentication/Federated/FederatedCredentialPolicyEvaluatorFacts.cs
@@ -228,6 +228,7 @@ namespace NuGetGallery.Services.Authentication
 
                 // Assert
                 Assert.Equal(OidcTokenEvaluationResultType.NoMatchingPolicy, evaluation.Type);
+                Assert.Null(evaluation.UserError);
 
                 AssertNoPoliciesCredentialAudit();
             }


### PR DESCRIPTION
This happens when there are no policies for the given `username`. This is very hard to self-diagnose for a user!

Also, I hit a null ref locally so I added the `?` in `QuietLog`.