### PR TITLE
Restore username to Application Insights telemetry

### DIFF
--- a/src/NuGetGallery.Services/Telemetry/Obfuscator.cs
+++ b/src/NuGetGallery.Services/Telemetry/Obfuscator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -12,40 +12,25 @@ namespace NuGetGallery
         /// Default user name that will replace the real user name.
         /// This value will be saved in AI instead of the real value.
         /// </summary>
-        public const string DefaultTelemetryUserName = "ObfuscatedUserName";
         public const string DefaultTelemetryReturnUrl = "ObfuscatedReturnUrl";
         public const string DefaultTelemetryToken = "ObfuscatedToken";
 
         public static readonly HashSet<string> ObfuscatedActions = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
         {
-            "Organizations/AddCertificate",
-            "Organizations/AddMember",
-            "Organizations/CancelMemberRequest",
-            "Organizations/ChangeEmailSubscription",
             "Organizations/ConfirmMemberRequest",
             "Organizations/ConfirmMemberRequestRedirect",
-            "Organizations/DeleteCertificate",
-            "Organizations/DeleteMember",
-            "Organizations/GetCertificate",
-            "Organizations/GetCertificates",
-            "Organizations/ManageOrganization",
             "Organizations/RejectMemberRequest",
             "Organizations/RejectMemberRequestRedirect",
-            "Organizations/UpdateMember",
             "Packages/CancelPendingOwnershipRequest",
             "Packages/ConfirmPendingOwnershipRequest",
             "Packages/ConfirmPendingOwnershipRequestRedirect",
             "Packages/RejectPendingOwnershipRequest",
             "Packages/RejectPendingOwnershipRequestRedirect",
-            "Packages/SetRequiredSigner",
             "Users/CancelTransformToOrganization",
             "Users/CancelTransformToOrganizationRedirect",
             "Users/Confirm",
             "Users/ConfirmTransformToOrganization",
             "Users/ConfirmTransformToOrganizationRedirect",
-            "Users/Delete",
-            "Users/Profiles",
-            "Users/GetAvatar",
             "Users/RejectTransformToOrganization",
             "Users/RejectTransformToOrganizationRedirect",
             "Users/ResetPassword",
@@ -53,7 +38,7 @@ namespace NuGetGallery
 
         public static string DefaultObfuscatedUrl(Uri url)
         {
-            return url == null ? string.Empty : $"{url.Scheme}://{url.Host}/{DefaultTelemetryUserName}";
+            return url == null ? string.Empty : $"{url.Scheme}://{url.Host}/ObfuscatedPath";
         }
     }
 }

--- a/src/NuGetGallery/App_Start/Routes.cs
+++ b/src/NuGetGallery/App_Start/Routes.cs
@@ -160,8 +160,7 @@ namespace NuGetGallery
                 RouteName.SetRequiredSigner,
                 "packages/{id}/required-signer/{username}",
                 new { controller = "Packages", action = RouteName.SetRequiredSigner, username = UrlParameter.Optional },
-                constraints: new { httpMethod = new HttpMethodConstraint("POST") },
-                obfuscationMetadata: new RouteExtensions.ObfuscatedPathMetadata(3, Obfuscator.DefaultTelemetryUserName));
+                constraints: new { httpMethod = new HttpMethodConstraint("POST") });
 
             routes.MapRoute(
                 RouteName.PackageOwnerConfirmationRedirect,
@@ -170,7 +169,6 @@ namespace NuGetGallery
                 constraints: new { httpMethod = new HttpMethodConstraint("GET") },
                 obfuscationMetadatas: new[]
                 {
-                    new RouteExtensions.ObfuscatedPathMetadata(3, Obfuscator.DefaultTelemetryUserName),
                     new RouteExtensions.ObfuscatedPathMetadata(5, Obfuscator.DefaultTelemetryToken)
                 });
 
@@ -181,7 +179,6 @@ namespace NuGetGallery
                 constraints: new { httpMethod = new HttpMethodConstraint("POST") },
                 obfuscationMetadatas: new[]
                 {
-                    new RouteExtensions.ObfuscatedPathMetadata(3, Obfuscator.DefaultTelemetryUserName),
                     new RouteExtensions.ObfuscatedPathMetadata(5, Obfuscator.DefaultTelemetryToken)
                 });
 
@@ -192,7 +189,6 @@ namespace NuGetGallery
                 constraints: new { httpMethod = new HttpMethodConstraint("GET") },
                 obfuscationMetadatas: new[]
                 {
-                    new RouteExtensions.ObfuscatedPathMetadata(3, Obfuscator.DefaultTelemetryUserName),
                     new RouteExtensions.ObfuscatedPathMetadata(5, Obfuscator.DefaultTelemetryToken)
                 });
 
@@ -203,7 +199,6 @@ namespace NuGetGallery
                 constraints: new { httpMethod = new HttpMethodConstraint("POST") },
                 obfuscationMetadatas: new[]
                 {
-                    new RouteExtensions.ObfuscatedPathMetadata(3, Obfuscator.DefaultTelemetryUserName),
                     new RouteExtensions.ObfuscatedPathMetadata(5, Obfuscator.DefaultTelemetryToken)
                 });
 
@@ -213,7 +208,6 @@ namespace NuGetGallery
                 new { controller = "Packages", action = "CancelPendingOwnershipRequest" },
                 new[]
                 {
-                    new RouteExtensions.ObfuscatedPathMetadata(3, Obfuscator.DefaultTelemetryUserName),
                     new RouteExtensions.ObfuscatedPathMetadata(5, Obfuscator.DefaultTelemetryToken)
                 });
 
@@ -363,14 +357,12 @@ namespace NuGetGallery
             routes.MapRoute(
                 RouteName.Profile,
                 "profiles/{username}",
-                new { controller = "Users", action = "Profiles" },
-                new RouteExtensions.ObfuscatedPathMetadata(1, Obfuscator.DefaultTelemetryUserName));
+                new { controller = "Users", action = "Profiles" });
 
             routes.MapRoute(
                 RouteName.GetAccountAvatar,
                 "profiles/{accountName}/avatar",
-                new { controller = "Users", action = "GetAvatar" },
-                new RouteExtensions.ObfuscatedPathMetadata(1, Obfuscator.DefaultTelemetryUserName));
+                new { controller = "Users", action = "GetAvatar" });
 
             routes.MapRoute(
                 RouteName.GetUserCertificate,
@@ -418,7 +410,6 @@ namespace NuGetGallery
                 new { controller = "Users", action = "ResetPassword", forgot = true },
                 new[]
                 {
-                    new RouteExtensions.ObfuscatedPathMetadata(2, Obfuscator.DefaultTelemetryUserName),
                     new RouteExtensions.ObfuscatedPathMetadata(3, Obfuscator.DefaultTelemetryToken)
                 });
 
@@ -428,7 +419,6 @@ namespace NuGetGallery
                 new { controller = "Users", action = "ResetPassword", forgot = false },
                 new[]
                 {
-                    new RouteExtensions.ObfuscatedPathMetadata(2, Obfuscator.DefaultTelemetryUserName),
                     new RouteExtensions.ObfuscatedPathMetadata(3, Obfuscator.DefaultTelemetryToken)
                 });
 
@@ -438,7 +428,6 @@ namespace NuGetGallery
                 new { controller = "Users", action = "Confirm" },
                 new[]
                 {
-                    new RouteExtensions.ObfuscatedPathMetadata(2, Obfuscator.DefaultTelemetryUserName),
                     new RouteExtensions.ObfuscatedPathMetadata(3, Obfuscator.DefaultTelemetryToken)
                 });
 
@@ -457,8 +446,7 @@ namespace NuGetGallery
                 routes.MapRoute(
                     RouteName.AdminDeleteAccount,
                     "account/delete/{accountName}",
-                    new { controller = "Users", action = "Delete" },
-                    new RouteExtensions.ObfuscatedPathMetadata(2, Obfuscator.DefaultTelemetryUserName));
+                    new { controller = "Users", action = "Delete" });
             }
 
             routes.MapRoute(
@@ -478,7 +466,6 @@ namespace NuGetGallery
                 new { httpMethod = new HttpMethodConstraint("GET") },
                 new[]
                 {
-                    new RouteExtensions.ObfuscatedPathMetadata(3, Obfuscator.DefaultTelemetryUserName),
                     new RouteExtensions.ObfuscatedPathMetadata(4, Obfuscator.DefaultTelemetryToken)
                 });
 
@@ -489,7 +476,6 @@ namespace NuGetGallery
                 new { httpMethod = new HttpMethodConstraint("POST") },
                 new[]
                 {
-                    new RouteExtensions.ObfuscatedPathMetadata(3, Obfuscator.DefaultTelemetryUserName),
                     new RouteExtensions.ObfuscatedPathMetadata(4, Obfuscator.DefaultTelemetryToken)
                 });
 
@@ -500,7 +486,6 @@ namespace NuGetGallery
                 new { httpMethod = new HttpMethodConstraint("GET") },
                 new[]
                 {
-                    new RouteExtensions.ObfuscatedPathMetadata(3, Obfuscator.DefaultTelemetryUserName),
                     new RouteExtensions.ObfuscatedPathMetadata(4, Obfuscator.DefaultTelemetryToken)
                 });
 
@@ -511,7 +496,6 @@ namespace NuGetGallery
                 new { httpMethod = new HttpMethodConstraint("POST") },
                 new[]
                 {
-                    new RouteExtensions.ObfuscatedPathMetadata(3, Obfuscator.DefaultTelemetryUserName),
                     new RouteExtensions.ObfuscatedPathMetadata(4, Obfuscator.DefaultTelemetryToken)
                 });
 
@@ -553,45 +537,35 @@ namespace NuGetGallery
                 RouteName.GetOrganizationCertificate,
                 "organization/{accountName}/certificates/{thumbprint}",
                 new { controller = "Organizations", action = "GetCertificate" },
-                constraints: new { httpMethod = new HttpMethodConstraint("GET") },
-                obfuscationMetadata: new RouteExtensions.ObfuscatedPathMetadata(1, Obfuscator.DefaultTelemetryUserName));
+                constraints: new { httpMethod = new HttpMethodConstraint("GET") });
 
             routes.MapRoute(
                 RouteName.DeleteOrganizationCertificate,
                 "organization/{accountName}/certificates/{thumbprint}",
                 new { controller = "Organizations", action = "DeleteCertificate" },
-                constraints: new { httpMethod = new HttpMethodConstraint("DELETE") },
-                obfuscationMetadata: new RouteExtensions.ObfuscatedPathMetadata(1, Obfuscator.DefaultTelemetryUserName));
+                constraints: new { httpMethod = new HttpMethodConstraint("DELETE") });
 
             routes.MapRoute(
                 RouteName.GetOrganizationCertificates,
                 "organization/{accountName}/certificates",
                 new { controller = "Organizations", action = "GetCertificates" },
-                constraints: new { httpMethod = new HttpMethodConstraint("GET") },
-                obfuscationMetadata: new RouteExtensions.ObfuscatedPathMetadata(1, Obfuscator.DefaultTelemetryUserName));
+                constraints: new { httpMethod = new HttpMethodConstraint("GET") });
 
             routes.MapRoute(
                 RouteName.AddOrganizationCertificate,
                 "organization/{accountName}/certificates",
                 new { controller = "Organizations", action = "AddCertificate" },
-                constraints: new { httpMethod = new HttpMethodConstraint("POST") },
-                obfuscationMetadata: new RouteExtensions.ObfuscatedPathMetadata(1, Obfuscator.DefaultTelemetryUserName));
+                constraints: new { httpMethod = new HttpMethodConstraint("POST") });
 
             routes.MapRoute(
                 RouteName.OrganizationMemberAddAjax,
                 "organization/{accountName}/members/add",
-                new { controller = "Organizations", action = nameof(OrganizationsController.AddMember) },
-                new RouteExtensions.ObfuscatedPathMetadata(1, Obfuscator.DefaultTelemetryUserName));
+                new { controller = "Organizations", action = nameof(OrganizationsController.AddMember) });
 
             routes.MapRoute(
                 RouteName.OrganizationMemberAdd,
                 "organization/{accountName}/members/add/{memberName}/{isAdmin}",
-                new { controller = "Organizations", action = nameof(OrganizationsController.AddMember) },
-                new[]
-                {
-                    new RouteExtensions.ObfuscatedPathMetadata(1, Obfuscator.DefaultTelemetryUserName),
-                    new RouteExtensions.ObfuscatedPathMetadata(4, Obfuscator.DefaultTelemetryUserName)
-                });
+                new { controller = "Organizations", action = nameof(OrganizationsController.AddMember) });
 
             routes.MapRoute(
                 RouteName.OrganizationMemberConfirmRedirect,
@@ -600,7 +574,6 @@ namespace NuGetGallery
                 new { httpMethod = new HttpMethodConstraint("GET") },
                 new[]
                 {
-                    new RouteExtensions.ObfuscatedPathMetadata(1, Obfuscator.DefaultTelemetryUserName),
                     new RouteExtensions.ObfuscatedPathMetadata(4, Obfuscator.DefaultTelemetryToken)
                 });
 
@@ -611,7 +584,6 @@ namespace NuGetGallery
                 new { httpMethod = new HttpMethodConstraint("POST") },
                 new[]
                 {
-                    new RouteExtensions.ObfuscatedPathMetadata(1, Obfuscator.DefaultTelemetryUserName),
                     new RouteExtensions.ObfuscatedPathMetadata(4, Obfuscator.DefaultTelemetryToken)
                 });
 
@@ -622,7 +594,6 @@ namespace NuGetGallery
                 new { httpMethod = new HttpMethodConstraint("GET") },
                 new[]
                 {
-                    new RouteExtensions.ObfuscatedPathMetadata(1, Obfuscator.DefaultTelemetryUserName),
                     new RouteExtensions.ObfuscatedPathMetadata(4, Obfuscator.DefaultTelemetryToken)
                 });
 
@@ -633,69 +604,48 @@ namespace NuGetGallery
                 new { httpMethod = new HttpMethodConstraint("POST") },
                 new[]
                 {
-                    new RouteExtensions.ObfuscatedPathMetadata(1, Obfuscator.DefaultTelemetryUserName),
                     new RouteExtensions.ObfuscatedPathMetadata(4, Obfuscator.DefaultTelemetryToken)
                 });
 
             routes.MapRoute(
                 RouteName.OrganizationMemberCancelAjax,
                 "organization/{accountName}/members/cancel",
-                new { controller = "Organizations", action = RouteName.OrganizationMemberCancelAjax },
-                new RouteExtensions.ObfuscatedPathMetadata(1, Obfuscator.DefaultTelemetryUserName));
+                new { controller = "Organizations", action = RouteName.OrganizationMemberCancelAjax });
 
             routes.MapRoute(
                 RouteName.OrganizationMemberCancel,
                 "organization/{accountName}/members/cancel/{memberName}",
-                new { controller = "Organizations", action = RouteName.OrganizationMemberCancelAjax },
-                new[]
-                {
-                    new RouteExtensions.ObfuscatedPathMetadata(1, Obfuscator.DefaultTelemetryUserName),
-                    new RouteExtensions.ObfuscatedPathMetadata(4, Obfuscator.DefaultTelemetryUserName)
-                });
+                new { controller = "Organizations", action = RouteName.OrganizationMemberCancelAjax });
 
             routes.MapRoute(
                 RouteName.OrganizationMemberUpdateAjax,
                 "organization/{accountName}/members/update",
-                new { controller = "Organizations", action = RouteName.OrganizationMemberUpdateAjax },
-                new RouteExtensions.ObfuscatedPathMetadata(1, Obfuscator.DefaultTelemetryUserName));
+                new { controller = "Organizations", action = RouteName.OrganizationMemberUpdateAjax });
 
             routes.MapRoute(
                 RouteName.OrganizationMemberUpdate,
                 "organization/{accountName}/members/update/{memberName}/{isAdmin}",
-                new { controller = "Organizations", action = RouteName.OrganizationMemberUpdateAjax },
-                new[]
-                {
-                    new RouteExtensions.ObfuscatedPathMetadata(1, Obfuscator.DefaultTelemetryUserName),
-                    new RouteExtensions.ObfuscatedPathMetadata(4, Obfuscator.DefaultTelemetryUserName)
-                });
+                new { controller = "Organizations", action = RouteName.OrganizationMemberUpdateAjax });
 
             routes.MapRoute(
                 RouteName.OrganizationMemberDeleteAjax,
                 "organization/{accountName}/members/delete",
-                new { controller = "Organizations", action = RouteName.OrganizationMemberDeleteAjax },
-                new RouteExtensions.ObfuscatedPathMetadata(1, Obfuscator.DefaultTelemetryUserName));
+                new { controller = "Organizations", action = RouteName.OrganizationMemberDeleteAjax });
 
             routes.MapRoute(
                 RouteName.OrganizationMemberDelete,
                 "organization/{accountName}/members/delete/{memberName}",
-                new { controller = "Organizations", action = RouteName.OrganizationMemberDeleteAjax },
-                new[]
-                {
-                    new RouteExtensions.ObfuscatedPathMetadata(1, Obfuscator.DefaultTelemetryUserName),
-                    new RouteExtensions.ObfuscatedPathMetadata(4, Obfuscator.DefaultTelemetryUserName)
-                });
+                new { controller = "Organizations", action = RouteName.OrganizationMemberDeleteAjax });
 
             routes.MapRoute(
                 RouteName.OrganizationAccount,
                 "organization/{accountName}/{action}",
-                new { controller = "Organizations", action = "ManageOrganization" },
-                new RouteExtensions.ObfuscatedPathMetadata(1, Obfuscator.DefaultTelemetryUserName));
+                new { controller = "Organizations", action = "ManageOrganization" });
 
             routes.MapRoute(
                 RouteName.ChangeOrganizationEmailSubscription,
                 "organization/{accountName}/subscription/change",
-                new { controller = "Organizations", action = "ChangeEmailSubscription" },
-                new RouteExtensions.ObfuscatedPathMetadata(1, Obfuscator.DefaultTelemetryUserName));
+                new { controller = "Organizations", action = "ChangeEmailSubscription" });
 
             routes.MapRoute(
                 RouteName.Downloads,

--- a/tests/NuGetGallery.Facts/Helpers/ObfuscationHelperFacts.cs
+++ b/tests/NuGetGallery.Facts/Helpers/ObfuscationHelperFacts.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -13,17 +13,14 @@ namespace NuGetGallery.Helpers
     {
         public class TheObfuscateCurrentRequestUrlFacts
         {
-            private const string _relativeTestPath = "profiles/user1";
+            private const string RelativeTestPath = "account/confirm/user1/token1";
             private RouteCollection _currentRoutes;
 
             public TheObfuscateCurrentRequestUrlFacts()
             {
-                if (_currentRoutes == null)
-                {
-                    _currentRoutes = new RouteCollection();
-                    Routes.RegisterApiV2Routes(_currentRoutes);
-                    Routes.RegisterUIRoutes(_currentRoutes, adminPanelEnabled: true);
-                }
+                _currentRoutes = new RouteCollection();
+                Routes.RegisterApiV2Routes(_currentRoutes);
+                Routes.RegisterUIRoutes(_currentRoutes, adminPanelEnabled: true);
             }
 
             [Fact]
@@ -53,7 +50,7 @@ namespace NuGetGallery.Helpers
 
                 // Assert + Assert
                 var result = ObfuscationHelper.ObfuscateRequestUrl(context, _currentRoutes);
-                Assert.Equal("profiles/ObfuscatedUserName", result);
+                Assert.Equal("account/confirm/user1/ObfuscatedToken", result);
             }
 
             private HttpContextBase GetMockedHttpContext()
@@ -62,8 +59,8 @@ namespace NuGetGallery.Helpers
                 var request = new Mock<HttpRequestBase>();
                 context.Setup(ctx => ctx.Request).Returns(request.Object);
                 
-                request.Setup(req => req.Url).Returns(new Uri($"https://localhost/{_relativeTestPath}"));
-                request.Setup(req => req.AppRelativeCurrentExecutionFilePath).Returns($"~/{_relativeTestPath}");
+                request.Setup(req => req.Url).Returns(new Uri($"https://localhost/{RelativeTestPath}"));
+                request.Setup(req => req.AppRelativeCurrentExecutionFilePath).Returns($"~/{RelativeTestPath}");
                 return context.Object;
             }
         }

--- a/tests/NuGetGallery.Facts/Telemetry/ClientTelemetryPIIProcessorTests.cs
+++ b/tests/NuGetGallery.Facts/Telemetry/ClientTelemetryPIIProcessorTests.cs
@@ -263,9 +263,7 @@ namespace NuGetGallery.Telemetry
 
         private static bool IsPIIUrl(string url)
         {
-            var hasPIIParameter = url.ToLower().Contains("username")
-                || url.ToLower().Contains("accountname")
-                || url.ToLower().Contains("token");
+            var hasPIIParameter = url.ToLower().Contains("token");
 
             var uri = new Uri(new Uri("https://localhost"), url);
             var isExcluded = uri.AbsolutePath == "/api/v2/token";
@@ -277,36 +275,16 @@ namespace NuGetGallery.Telemetry
         {
             foreach (var user in GenerateUserNames())
             {
-                yield return new string[] { "account/confirm/{accountName}/{token}", $"https://localhost/account/confirm/{user}/sometoken", "https://localhost/account/confirm/ObfuscatedUserName/ObfuscatedToken" };
-                yield return new string[] { "account/delete/{accountName}", $"https://localhost/account/delete/{user}", "https://localhost/account/delete/ObfuscatedUserName" };
-                yield return new string[] { "account/forgotpassword/{username}/{token}", $"https://localhost/account/forgotpassword/{user}/sometoken", "https://localhost/account/forgotpassword/ObfuscatedUserName/ObfuscatedToken" };
-                yield return new string[] { "account/setpassword/{username}/{token}", $"https://localhost/account/setpassword/{user}/sometoken", "https://localhost/account/setpassword/ObfuscatedUserName/ObfuscatedToken" };
-                yield return new string[] { "account/transform/confirm/{accountNameToTransform}/{token}", $"https://localhost/account/transform/confirm/{user}/sometoken", "https://localhost/account/transform/confirm/ObfuscatedUserName/ObfuscatedToken" };
-                yield return new string[] { "account/transform/reject/{accountNameToTransform}/{token}", $"https://localhost/account/transform/reject/{user}/sometoken", "https://localhost/account/transform/reject/ObfuscatedUserName/ObfuscatedToken" };
-                yield return new string[] { "organization/{accountName}/{action}", $"https://localhost/organization/{user}/foo", "https://localhost/organization/ObfuscatedUserName/foo" };
-                yield return new string[] { "organization/{accountName}/certificates", $"https://localhost/organization/{user}/certificates", "https://localhost/organization/ObfuscatedUserName/certificates" };
-                yield return new string[] { "organization/{accountName}/certificates/{thumbprint}", $"https://localhost/organization/{user}/certificates/thumb", "https://localhost/organization/ObfuscatedUserName/certificates/thumb" };
-                yield return new string[] { "organization/{accountName}/members/add", $"https://localhost/organization/{user}/members/add", "https://localhost/organization/ObfuscatedUserName/members/add" };
-                yield return new string[] { "organization/{accountName}/members/add/{memberName}/{isAdmin}", $"https://localhost/organization/{user}/members/add/member/true", "https://localhost/organization/ObfuscatedUserName/members/add/ObfuscatedUserName/true" };
-                yield return new string[] { "organization/{accountName}/members/add/{memberName}/{isAdmin}", $"https://localhost/organization/org/members/add/{user}/true", "https://localhost/organization/ObfuscatedUserName/members/add/ObfuscatedUserName/true" };
-                yield return new string[] { "organization/{accountName}/members/cancel", $"https://localhost/organization/{user}/members/cancel", "https://localhost/organization/ObfuscatedUserName/members/cancel" };
-                yield return new string[] { "organization/{accountName}/members/cancel/{memberName}", $"https://localhost/organization/{user}/members/cancel/member", "https://localhost/organization/ObfuscatedUserName/members/cancel/ObfuscatedUserName" };
-                yield return new string[] { "organization/{accountName}/members/cancel/{memberName}", $"https://localhost/organization/org/members/cancel/{user}", "https://localhost/organization/ObfuscatedUserName/members/cancel/ObfuscatedUserName" };
-                yield return new string[] { "organization/{accountName}/members/confirm/{confirmationToken}", $"https://localhost/organization/{user}/members/confirm/sometoken", "https://localhost/organization/ObfuscatedUserName/members/confirm/ObfuscatedToken" };
-                yield return new string[] { "organization/{accountName}/members/delete", $"https://localhost/organization/{user}/members/delete", "https://localhost/organization/ObfuscatedUserName/members/delete" };
-                yield return new string[] { "organization/{accountName}/members/delete/{memberName}", $"https://localhost/organization/{user}/members/delete/member", "https://localhost/organization/ObfuscatedUserName/members/delete/ObfuscatedUserName" };
-                yield return new string[] { "organization/{accountName}/members/delete/{memberName}", $"https://localhost/organization/org/members/delete/{user}", "https://localhost/organization/ObfuscatedUserName/members/delete/ObfuscatedUserName" };
-                yield return new string[] { "organization/{accountName}/members/reject/{confirmationToken}", $"https://localhost/organization/{user}/members/reject/sometoken", "https://localhost/organization/ObfuscatedUserName/members/reject/ObfuscatedToken" };
-                yield return new string[] { "organization/{accountName}/members/update", $"https://localhost/organization/{user}/members/update", "https://localhost/organization/ObfuscatedUserName/members/update" };
-                yield return new string[] { "organization/{accountName}/members/update/{memberName}/{isAdmin}", $"https://localhost/organization/{user}/members/update/member/true", "https://localhost/organization/ObfuscatedUserName/members/update/ObfuscatedUserName/true" };
-                yield return new string[] { "organization/{accountName}/members/update/{memberName}/{isAdmin}", $"https://localhost/organization/org/members/update/{user}/true", "https://localhost/organization/ObfuscatedUserName/members/update/ObfuscatedUserName/true" };
-                yield return new string[] { "organization/{accountName}/subscription/change", $"https://localhost/organization/{user}/subscription/change", "https://localhost/organization/ObfuscatedUserName/subscription/change" };
-                yield return new string[] { "packages/{id}/owners/{username}/cancel/{token}", $"https://localhost/packages/pack1/owners/{user}/cancel/sometoken", "https://localhost/packages/pack1/owners/ObfuscatedUserName/cancel/ObfuscatedToken" };
-                yield return new string[] { "packages/{id}/owners/{username}/confirm/{token}", $"https://localhost/packages/pack1/owners/{user}/confirm/sometoken", "https://localhost/packages/pack1/owners/ObfuscatedUserName/confirm/ObfuscatedToken" };
-                yield return new string[] { "packages/{id}/owners/{username}/reject/{token}", $"https://localhost/packages/pack1/owners/{user}/reject/sometoken", "https://localhost/packages/pack1/owners/ObfuscatedUserName/reject/ObfuscatedToken" };
-                yield return new string[] { "packages/{id}/required-signer/{username}", $"https://localhost/packages/pack1/required-signer/{user}", "https://localhost/packages/pack1/required-signer/ObfuscatedUserName" };
-                yield return new string[] { "profiles/{username}", $"https://localhost/profiles/{user}", "https://localhost/profiles/ObfuscatedUserName" };
-                yield return new string[] { "profiles/{accountName}/avatar", $"https://localhost/profiles/{user}/avatar", "https://localhost/profiles/ObfuscatedUserName/avatar" };
+                yield return new string[] { "account/confirm/{accountName}/{token}", $"https://localhost/account/confirm/{user}/sometoken", $"https://localhost/account/confirm/{user}/ObfuscatedToken" };
+                yield return new string[] { "account/forgotpassword/{username}/{token}", $"https://localhost/account/forgotpassword/{user}/sometoken", $"https://localhost/account/forgotpassword/{user}/ObfuscatedToken" };
+                yield return new string[] { "account/setpassword/{username}/{token}", $"https://localhost/account/setpassword/{user}/sometoken", $"https://localhost/account/setpassword/{user}/ObfuscatedToken" };
+                yield return new string[] { "account/transform/confirm/{accountNameToTransform}/{token}", $"https://localhost/account/transform/confirm/{user}/sometoken", $"https://localhost/account/transform/confirm/{user}/ObfuscatedToken" };
+                yield return new string[] { "account/transform/reject/{accountNameToTransform}/{token}", $"https://localhost/account/transform/reject/{user}/sometoken", $"https://localhost/account/transform/reject/{user}/ObfuscatedToken" };
+                yield return new string[] { "organization/{accountName}/members/confirm/{confirmationToken}", $"https://localhost/organization/{user}/members/confirm/sometoken", $"https://localhost/organization/{user}/members/confirm/ObfuscatedToken" };
+                yield return new string[] { "organization/{accountName}/members/reject/{confirmationToken}", $"https://localhost/organization/{user}/members/reject/sometoken", $"https://localhost/organization/{user}/members/reject/ObfuscatedToken" };
+                yield return new string[] { "packages/{id}/owners/{username}/cancel/{token}", $"https://localhost/packages/pack1/owners/{user}/cancel/sometoken", $"https://localhost/packages/pack1/owners/{user}/cancel/ObfuscatedToken" };
+                yield return new string[] { "packages/{id}/owners/{username}/confirm/{token}", $"https://localhost/packages/pack1/owners/{user}/confirm/sometoken", $"https://localhost/packages/pack1/owners/{user}/confirm/ObfuscatedToken" };
+                yield return new string[] { "packages/{id}/owners/{username}/reject/{token}", $"https://localhost/packages/pack1/owners/{user}/reject/sometoken", $"https://localhost/packages/pack1/owners/{user}/reject/ObfuscatedToken" };
             }
 
             yield return new string[] { "account/transform/cancel/{token}", "https://localhost/account/transform/cancel/sometoken", "https://localhost/account/transform/cancel/ObfuscatedToken" };

--- a/tests/NuGetGallery.Facts/Telemetry/QuietLogFacts.cs
+++ b/tests/NuGetGallery.Facts/Telemetry/QuietLogFacts.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -32,7 +32,7 @@ namespace NuGetGallery.Telemetry
         }
 
         [Theory]
-        [InlineData("Users", "Delete")]
+        [InlineData("Users", "CancelTransformToOrganization")]
         public void GetObfuscatedServerVariablesValidCase(string controller, string action)
         {
             // Arange


### PR DESCRIPTION
This is extremely useful for debugging, for example profile pages that have specific performance issuers based on their profile username.