### PR TITLE
minor File-Based naming refactor

### DIFF
--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -183,7 +183,7 @@
 
             new PackageManagerViewModel(
                 "dotnet-run-file",
-                "File-based Apps",
+                "File-Based Apps",
                 new PackageManagerViewModel.InstallPackageCommand(
                     string.Format("#:sdk {0}@{1}", Model.Id, Model.Version)
                 )


### PR DESCRIPTION
Here it says `File-based Apps` and I propose to refactor it into `File-Based Apps`
<img width="1573" height="955" alt="Screenshot 2026-01-13 at 12 53 56" src="https://github.com/user-attachments/assets/bf4cd841-0f17-4b32-bbcd-128d89df3b38" />
