### PR TITLE
Remove dependency on old NuGet.Services.Configuration

### DIFF
--- a/NuGetGallery.FunctionalTests.sln
+++ b/NuGetGallery.FunctionalTests.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 18
-VisualStudioVersion = 18.3.11322.18 main
+VisualStudioVersion = 18.3.11322.18
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{37E5C8A5-C7A6-400E-A0EA-6C2C6F9B160D}"
 	ProjectSection(SolutionItems) = preProject
@@ -11,6 +11,14 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NuGetGallery.FunctionalTests", "tests\NuGetGallery.FunctionalTests\NuGetGallery.FunctionalTests.csproj", "{073797B8-8D6C-4A82-9788-C38848D4CC59}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NuGetGallery.FunctionalTests.Core", "tests\NuGetGallery.FunctionalTests.Core\NuGetGallery.FunctionalTests.Core.csproj", "{8496C7FE-8A93-4D2E-A9DC-5DE44017187C}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NuGet.Services.KeyVault", "src\NuGet.Services.KeyVault\NuGet.Services.KeyVault.csproj", "{62CBCFA4-FD1F-5454-7934-0220E9A6651C}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{975E68D2-957C-4C58-84EB-75E900CE17E0}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NuGet.Services.Configuration", "src\NuGet.Services.Configuration\NuGet.Services.Configuration.csproj", "{2A118C67-FC6D-5A6F-035B-D41A64046CBA}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{C28C993D-C81E-4406-B711-34CF72C41C39}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -26,9 +34,23 @@ Global
 		{8496C7FE-8A93-4D2E-A9DC-5DE44017187C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{8496C7FE-8A93-4D2E-A9DC-5DE44017187C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{8496C7FE-8A93-4D2E-A9DC-5DE44017187C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{62CBCFA4-FD1F-5454-7934-0220E9A6651C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{62CBCFA4-FD1F-5454-7934-0220E9A6651C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{62CBCFA4-FD1F-5454-7934-0220E9A6651C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{62CBCFA4-FD1F-5454-7934-0220E9A6651C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2A118C67-FC6D-5A6F-035B-D41A64046CBA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2A118C67-FC6D-5A6F-035B-D41A64046CBA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2A118C67-FC6D-5A6F-035B-D41A64046CBA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2A118C67-FC6D-5A6F-035B-D41A64046CBA}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{073797B8-8D6C-4A82-9788-C38848D4CC59} = {C28C993D-C81E-4406-B711-34CF72C41C39}
+		{8496C7FE-8A93-4D2E-A9DC-5DE44017187C} = {C28C993D-C81E-4406-B711-34CF72C41C39}
+		{62CBCFA4-FD1F-5454-7934-0220E9A6651C} = {975E68D2-957C-4C58-84EB-75E900CE17E0}
+		{2A118C67-FC6D-5A6F-035B-D41A64046CBA} = {975E68D2-957C-4C58-84EB-75E900CE17E0}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {7A4EF1D3-E31D-4FE0-A407-79B054848111}

--- a/tests/NuGetGallery.FunctionalTests.Core/NuGetGallery.FunctionalTests.Core.csproj
+++ b/tests/NuGetGallery.FunctionalTests.Core/NuGetGallery.FunctionalTests.Core.csproj
@@ -8,22 +8,18 @@
     <Reference Include="System.IO.Compression" />
   </ItemGroup>
   <ItemGroup>
-    <!--
-    	NuGet.Services.Configuration wants Microsoft.Extensions.* at 2.2.0.
-    	Without it, web tests fail to run and proper fix is not trivial, so
-    	this would have to do for now.
-    	Proper fix tracked here: https://github.com/NuGet/Engineering/issues/5669
-    -->
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" VersionOverride="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
     <PackageReference Include="Microsoft.Playwright.Xunit" />
     <PackageReference Include="Microsoft.Web.Xdt" />
     <PackageReference Include="NuGet.Core" />
-    <PackageReference Include="NuGet.Services.Configuration" VersionOverride="2.94.0" />
     <PackageReference Include="NuGet.Versioning" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\NuGet.Services.Configuration\NuGet.Services.Configuration.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Resolve https://github.com/NuGet/Engineering/issues/5669.
Progress on https://github.com/NuGet/Engineering/issues/6227.

These old "special" dependencies are not needed anymore since we got rid of web tests.