### PR TITLE
Fix dotnet new install syntax: use @ instead of deprecated ::

### DIFF
--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -154,7 +154,7 @@
                 "dotnet-cli",
                 ".NET CLI",
                 new PackageManagerViewModel.InstallPackageCommand(
-                    string.Format("dotnet new install {0}::{1}", Model.Id, Model.Version)
+                    string.Format("dotnet new install {0}@{1}", Model.Id, Model.Version)
                 )
             )
             {


### PR DESCRIPTION
## Summary
This PR updates the .NET CLI template install command to use the `@` version separator instead of the deprecated `::` syntax.

## Problem
The NuGet Gallery currently displays template install commands using the deprecated double-colon (`::`) version separator:
```
dotnet new install PackageName::1.0.0
```

Modern .NET SDKs (.NET 8+) display a deprecation warning when this syntax is used.

## Solution
Updated the command to use the `@` separator:
```
dotnet new install PackageName@1.0.0
```

This matches the [official documentation](https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-new-install) and avoids deprecation warnings for users.

## Changes
- Updated `src/NuGetGallery/Views/Packages/DisplayPackage.cshtml` to use `@` instead of `::` in the template install command

Fixes #10692