### PR TITLE
Allow specific repo path for submodule

### DIFF
--- a/build/common.ps1
+++ b/build/common.ps1
@@ -560,13 +560,6 @@ Function Install-SolutionPackages {
         $opts += '-OutputDirectory', "${OutputPath}"
     }
 
-    Write-Host "----------"
-    Write-Host "CWD: $(Get-Location)"
-    Write-Host "nuget.config path: $ConfigFile"
-    Write-Host "nuget.config content:"
-    Write-Host (Get-Content $ConfigFile -Raw)
-    Write-Host "----------"
-
     Trace-Log "Installing packages @""$InstallLocation"""
     Trace-Log "$NuGetExe $opts"
     & $NuGetExe $opts


### PR DESCRIPTION
This allows the submodules to be in a different repo tree than the one containing `common.ps1`.

Best viewed with hidden whitespace: https://github.com/NuGet/NuGetGallery/pull/10706/changes?w=1

Related to https://github.com/NuGet/Engineering/issues/6227

- Use the invoke git helper in more places
- Raise an error if git returns a non-zero exit code (fail fast)
- Allow repo directory to be provided to for resetting and updating submodules
- Clean up extra whitespace (VS Code kept doing this automatically, probably from the PowerShell extension), figured it was good cleanup
- Rename $args to $gitArgs since $args has a special meaning in PowerShell