### PR TITLE
Remove X share button from package page

### DIFF
--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -1491,11 +1491,6 @@
                                 src="@Url.Absolute("~/Content/gallery/img/facebook.svg")"
                                 @ViewHelpers.ImageFallback(Url.Absolute("~/Content/gallery/img/facebook-24x24.png")) />
                     </a>
-                    <a href="https://x.com/intent/post?url=@absolutePackageUrl&text=@encodedText" target="_blank" rel="nofollow noreferrer">
-                        <img width="24" height="24" alt="Share this package on X"
-                                src="@Url.Absolute("~/Content/gallery/img/x.svg")"
-                                @ViewHelpers.ImageFallback(Url.Absolute("~/Content/gallery/img/x-24x24.png")) />
-                    </a>
                     @if (Model.IsAtomFeedEnabled && Model.Owners.Any())
                     {
                         <a href="@Url.PackageAtomFeed(Model.Id)" data-track="atom-feed">


### PR DESCRIPTION
Remove the X (Twitter) share link and its icon markup from the package display view. The anchor and image/fallback for the X share button were deleted, leaving the Facebook share and atom feed links unchanged.

fixes #10672