### PR TITLE
Remove social sharing buttons on package display page

### DIFF
--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -1486,11 +1486,6 @@
             {
                 var encodedText = Url.Encode(string.Format("Check out {0} on #NuGet.", Model.Id));
                 <p class="share-buttons">
-                    <a href="https://www.facebook.com/sharer/sharer.php?u=@absolutePackageUrl&t=@encodedText" target="_blank" rel="nofollow noreferrer">
-                        <img width="24" height="24" alt="Share this package on Facebook"
-                                src="@Url.Absolute("~/Content/gallery/img/facebook.svg")"
-                                @ViewHelpers.ImageFallback(Url.Absolute("~/Content/gallery/img/facebook-24x24.png")) />
-                    </a>
                     @if (Model.IsAtomFeedEnabled && Model.Owners.Any())
                     {
                         <a href="@Url.PackageAtomFeed(Model.Id)" data-track="atom-feed">


### PR DESCRIPTION
Remove social sharing buttons on package details page as advised by PMs.