### PR TITLE
Use standard VM image for CI

### DIFF
--- a/.pipelines/NuGetGallery-CI.yml
+++ b/.pipelines/NuGetGallery-CI.yml
@@ -52,11 +52,7 @@ extends:
     settings:
       networkIsolationPolicy: Permissive
     pool:
-      name: NuGet-1ES-Hosted-Pool
-      image: NuGet-1ESPT-Win2022
-      os: windows
-    customBuildTags:
-      - ES365AIMigrationTooling
+      vmImage: 'windows-latest'
     stages:
       - stage: common
         displayName: NuGet.Server.Common.sln


### PR DESCRIPTION
By modernizing our functional tests we can run on standard build images now.