### PR TITLE
Revise security issue reporting instructions in security.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,25 +10,13 @@ Microsoft serves as the primary maintainer of this repository. If you believe yo
 
 **Please do not report security vulnerabilities through public GitHub issues.**
 
-Instead, please report them to the Microsoft Security Response Center (MSRC) at [https://msrc.microsoft.com/create-report](https://aka.ms/opensource/security/create-report).
-
-If you prefer to submit without logging in, send email to [secure@microsoft.com](mailto:secure@microsoft.com).  If possible, encrypt your message with our PGP key; please download it from the [Microsoft Security Response Center PGP Key page](https://aka.ms/opensource/security/pgpkey).
-
-You should receive a response within 24 hours. If for some reason you do not, please follow up via email to ensure we received your original message. Additional information can be found at [microsoft.com/msrc](https://aka.ms/opensource/security/msrc). 
-
-Please include the requested information listed below (as much as you can provide) to help us better understand the nature and scope of the possible issue:
-
-  * Type of issue (e.g. buffer overflow, SQL injection, cross-site scripting, etc.)
-  * Full paths of source file(s) related to the manifestation of the issue
-  * The location of the affected source code (tag/branch/commit or direct URL)
-  * Any special configuration required to reproduce the issue
-  * Step-by-step instructions to reproduce the issue
-  * Proof-of-concept or exploit code (if possible)
-  * Impact of the issue, including how an attacker might exploit the issue
-
-This information will help us triage your report more quickly.
-
-If you are reporting for a bug bounty, more complete reports can contribute to a higher bounty award. Please visit our [Microsoft Bug Bounty Program](https://aka.ms/opensource/security/bounty) page for more details about our active programs.
+Security issues and bugs should be reported privately to the Microsoft Security Response Center (MSRC), via the [MSRC Researcher Portal](https://msrc.microsoft.com/report/vulnerability/new).
+ 
+You should receive a response within 24 hours. If for some reason you do not, please follow up via the [MSRC Researcher Portal](https://msrc.microsoft.com/report/vulnerability/), using the Message functionality found at the bottom of the Activity tab on your vulnerability report.
+ 
+Further information can be found in the MSRC [Report an issue and submission guidelines](https://www.microsoft.com/en-us/msrc/faqs-report-an-issue).
+ 
+Reports via MSRC may qualify for the Microsoft Open Source Bug Bounty. Details of the Microsoft Open Source Bug Bounty Program including terms and conditions are at [https://aka.ms/corebounty](https://aka.ms/corebounty).
 
 ## Preferred Languages
 


### PR DESCRIPTION
Updated the reporting process for security issues to use the MSRC Researcher Portal and included additional guidelines for reporting.

Addresses https://github.com/NuGet/NuGetGallery/issues/10722