### PR TITLE
Ensure trailing slash for RepositoryRootDirectory

### DIFF
--- a/build/sign-binaries.proj
+++ b/build/sign-binaries.proj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <_ProjectsToSign Condition="'$(ProjectsToSign)' == ''" Include="$(RepositoryRootDirectory)src\**\*.csproj" />
+    <_ProjectsToSign Condition="'$(ProjectsToSign)' == ''" Include="$([MSBuild]::EnsureTrailingSlash('$(RepositoryRootDirectory)'))src\**\*.csproj" />
     <_ProjectsToSign Condition="'$(ProjectsToSign)' != ''" Include="$(ProjectsToSign)" />
   </ItemGroup>
 

--- a/build/sign-packages.proj
+++ b/build/sign-packages.proj
@@ -11,7 +11,7 @@
 
   <Target Name="GetOutputNupkgs">
     <ItemGroup>
-      <FilesToSign Include="$(RepositoryRootDirectory)artifacts\*.nupkg">
+      <FilesToSign Include="$([MSBuild]::EnsureTrailingSlash('$(RepositoryRootDirectory)'))artifacts\*.nupkg">
         <Authenticode>NuGet</Authenticode>
       </FilesToSign>
     </ItemGroup>

--- a/build/sign.microbuild.targets
+++ b/build/sign.microbuild.targets
@@ -66,7 +66,7 @@
       there is a project reference pointing to the current project and there is a copy of this output assembly in the
       bin directory of another project. That assembly also needs to be signed.
       -->
-      <_ManagedOutputToSign Include="$(RepositoryRootDirectory)**\$(TargetFileName)" Condition="'$(BatchSign)' == 'true' AND '$(TargetFileName)' != ''" />
+      <_ManagedOutputToSign Include="$([MSBuild]::EnsureTrailingSlash('$(RepositoryRootDirectory)'))**\$(TargetFileName)" Condition="'$(BatchSign)' == 'true' AND '$(TargetFileName)' != ''" />
       <_ManagedOutputToSign Remove="$(RunCommand)" Condition="'$(RunCommand)' != ''" />
       <UnfilteredFilesToSign
         Include="$([System.IO.Path]::GetFullPath('%(_ManagedOutputToSign.Identity)'))"
@@ -94,7 +94,7 @@
       by default as well.
       -->
       <_UnmanagedOutputToSign Include="$(RunCommand)" KeepDuplicates="false" Condition="'$(BatchSign)' == 'true' AND '$(RunCommand)' != ''" />
-      <_UnmanagedOutputToSign Include="$(RepositoryRootDirectory)**\apphost.exe" Condition="'$(BatchSign)' == 'true'" />
+      <_UnmanagedOutputToSign Include="$([MSBuild]::EnsureTrailingSlash('$(RepositoryRootDirectory)'))**\apphost.exe" Condition="'$(BatchSign)' == 'true'" />
       <UnfilteredFilesToSign
         Include="$([System.IO.Path]::GetFullPath('%(_UnmanagedOutputToSign.Identity)'))"
         Condition="Exists('%(_UnmanagedOutputToSign.Identity)')"


### PR DESCRIPTION
This was preventing some signing flows from working, because `RepositoryRootDirectory` was set to a path without a trailing slash.

I will merge this to `dev` later. Save to be in `main` because it doesn't impact runtime.