### PR TITLE
Fix naming convention for File-Based Apps tab

### DIFF
--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -294,7 +294,7 @@
 
             new PackageManagerViewModel(
                 "dotnet-run-file",
-                "File-based Apps",
+                "File-Based Apps",
                 new PackageManagerViewModel.InstallPackageCommand(
                     string.Format("#:package {0}@{1}", Model.Id, Model.Version)
                 )


### PR DESCRIPTION
We missed a spot in the previous attempt at this fix: https://github.com/NuGet/NuGetGallery/pull/10683