### PR TITLE
Add .idea to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -437,3 +437,4 @@ src/NuGetGallery/App_Data/Files/*
 !src/NuGetGallery/Branding/Views/Packages/
 
 
+/.idea


### PR DESCRIPTION
Ignore the top-level .idea directory to prevent JetBrains IDE project files from being committed to the repository.

