### PR TITLE
Add note for .NET tool dependencies (#10020)

### DIFF
--- a/src/NuGetGallery/Helpers/ViewModelExtensions/DisplayPackageViewModelFactory.cs
+++ b/src/NuGetGallery/Helpers/ViewModelExtensions/DisplayPackageViewModelFactory.cs
@@ -74,7 +74,10 @@ namespace NuGetGallery
         {
             var dependencies = package.Dependencies.ToList();
 
-            viewModel.Dependencies = new DependencySetsViewModel(dependencies);
+            // Check if the package is a .NET Tool to pass to the DependencySetsViewModel
+            var isDotnetTool = package.PackageTypes.Any(e => e.Name.Equals("DotnetTool", StringComparison.OrdinalIgnoreCase));
+
+            viewModel.Dependencies = new DependencySetsViewModel(dependencies, isDotnetTool);
 
             var packageHistory = allVersions
                 .OrderByDescending(p => new NuGetVersion(p.Version))
@@ -108,7 +111,7 @@ namespace NuGetGallery
                 viewModel.DownloadsPerDayLabel = viewModel.DownloadsPerDay < 1 ? "<1" : viewModel.DownloadsPerDay.ToNuGetNumberString();
 
                 // Lazily load the package types from the database.
-                viewModel.IsDotnetToolPackageType = package.PackageTypes.Any(e => e.Name.Equals("DotnetTool", StringComparison.OrdinalIgnoreCase));
+                viewModel.IsDotnetToolPackageType = isDotnetTool;
                 viewModel.IsDotnetNewTemplatePackageType = package.PackageTypes.Any(e => e.Name.Equals("Template", StringComparison.OrdinalIgnoreCase));
                 viewModel.IsMSBuildSdkPackageType = package.PackageTypes.Any(e => e.Name.Equals("MSBuildSdk", StringComparison.OrdinalIgnoreCase));
                 viewModel.IsMcpServerPackageType = package.PackageTypes.Any(e => e.Name.Equals(McpHelper.McpServerPackageTypeName, StringComparison.OrdinalIgnoreCase));

--- a/src/NuGetGallery/ViewModels/DependencySetsViewModel.cs
+++ b/src/NuGetGallery/ViewModels/DependencySetsViewModel.cs
@@ -14,8 +14,10 @@ namespace NuGetGallery
 {
     public class DependencySetsViewModel
     {
-        public DependencySetsViewModel(IEnumerable<PackageDependency> packageDependencies)
+        public DependencySetsViewModel(IEnumerable<PackageDependency> packageDependencies, bool isDotnetTool = false)
         {
+            IsDotnetTool = isDotnetTool;
+
             try
             {
                 DependencySets = new Dictionary<string, IEnumerable<DependencyViewModel>>();
@@ -50,6 +52,7 @@ namespace NuGetGallery
 
         public IDictionary<string, IEnumerable<DependencyViewModel>> DependencySets { get; private set; }
         public bool OnlyHasAllFrameworks { get; private set; }
+        public bool IsDotnetTool { get; private set; }
 
         public class DependencyViewModel
         {

--- a/src/NuGetGallery/Views/Packages/_PackageDependencies.cshtml
+++ b/src/NuGetGallery/Views/Packages/_PackageDependencies.cshtml
@@ -13,7 +13,7 @@
             {
                 dependencySetTitle = "Portable Class Library";
             }
-            
+
             <li>
                 @if (!Model.OnlyHasAllFrameworks)
                 {
@@ -41,5 +41,15 @@
 }
 else
 {
-    <p>This package has no dependencies.</p>
+    if (Model.IsDotnetTool)
+    {
+        <p>
+            .NET tools have dependencies embedded in the package.
+            <a href="https://github.com/NuGet/NuGetGallery/issues/10020">See this issue</a> to vote and improve this experience.
+        </p>
+    }
+    else
+    {
+        <p>This package has no dependencies.</p>
+    }
 }

--- a/src/NuGetGallery/Views/Packages/_PackageDependencies.cshtml
+++ b/src/NuGetGallery/Views/Packages/_PackageDependencies.cshtml
@@ -45,7 +45,7 @@ else
     {
         <p>
             .NET tools have dependencies embedded in the package.
-            <a href="https://github.com/NuGet/NuGetGallery/issues/10020">See this issue</a> to vote and improve this experience.
+            Join the <a href="https://github.com/NuGet/NuGetGallery/issues/10020">discussion</a> on improving this experience.
         </p>
     }
     else


### PR DESCRIPTION
Fixes #10020 

**Description**
Updated the `DependencySetsViewModel` and `DisplayPackageViewModelFactory` to pass the `IsDotnetTool` flag. 
Modified `_PackageDependencies.cshtml` to display a note with a link to issue #10020 when a package is a .NET Tool and has no explicit dependencies in its nuspec.

**Expected Behavior**
Instead of showing "This package has no dependencies.", .NET tools will now show: ".NET tools have dependencies embedded in the package." along with a link to gather upvotes for improving the experience.