### PR TITLE
[ST] Blob Tool 1: Get pages of packages to process

### DIFF
--- a/NuGet.Jobs.sln
+++ b/NuGet.Jobs.sln
@@ -243,6 +243,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NuGet.Services.Messaging.Em
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NuGet.Services.Validation.Issues", "src\NuGet.Services.Validation.Issues\NuGet.Services.Validation.Issues.csproj", "{9B159802-2A27-42EC-A357-06AAEFA70892}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UpdateBlobProperties", "src\UpdateBlobProperties\UpdateBlobProperties.csproj", "{6F2096D0-BA21-42D1-9C49-36038C51128F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -631,6 +633,10 @@ Global
 		{9B159802-2A27-42EC-A357-06AAEFA70892}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{9B159802-2A27-42EC-A357-06AAEFA70892}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{9B159802-2A27-42EC-A357-06AAEFA70892}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6F2096D0-BA21-42D1-9C49-36038C51128F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6F2096D0-BA21-42D1-9C49-36038C51128F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6F2096D0-BA21-42D1-9C49-36038C51128F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6F2096D0-BA21-42D1-9C49-36038C51128F}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -733,6 +739,7 @@ Global
 		{63214B67-733D-4E9D-8249-25EEB2908FBE} = {54773F65-1227-4B35-8991-9E9C1CDACCF3}
 		{9F3DD471-DBEE-4680-B49D-5AA451E59C4C} = {54773F65-1227-4B35-8991-9E9C1CDACCF3}
 		{9B159802-2A27-42EC-A357-06AAEFA70892} = {54773F65-1227-4B35-8991-9E9C1CDACCF3}
+		{6F2096D0-BA21-42D1-9C49-36038C51128F} = {523E282D-A2FE-49C2-A782-0EEC435E765E}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {284A7AC3-FB43-4F1F-9C9C-2AF0E1F46C2B}

--- a/src/UpdateBlobProperties/BlobInfo.cs
+++ b/src/UpdateBlobProperties/BlobInfo.cs
@@ -1,0 +1,25 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using NuGet.Services.Entities;
+using NuGetGallery;
+
+namespace UpdateBlobProperties
+{
+    public abstract class BlobInfo
+    {
+        public abstract string GetContainerName();
+
+        public abstract string GetBlobName(PackageInfo packageInfo);
+
+        public abstract IDictionary<string, string> GetUpdatedBlobProperties();
+
+        public abstract Func<IEntityRepository<Package>, int, int, int, Task<List<PackageInfo>>> GetPageOfPackageInfosToUpdateBlobsAsync
+        {
+            get;
+        }
+    }
+}

--- a/src/UpdateBlobProperties/BlobInfoOfPackageVersionIndexInFlatContainer.cs
+++ b/src/UpdateBlobProperties/BlobInfoOfPackageVersionIndexInFlatContainer.cs
@@ -1,0 +1,51 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Azure.Storage.Blobs.Models;
+using NuGet.Services.Entities;
+using NuGetGallery;
+
+namespace UpdateBlobProperties
+{
+    public class BlobInfoOfPackageVersionIndexInFlatContainer : BlobInfo
+    {
+        public override string GetContainerName()
+        {
+            return "v3-flatcontainer";
+        }
+
+        public override string GetBlobName(PackageInfo packageInfo)
+        {
+            if (packageInfo == null)
+            {
+                throw new ArgumentNullException(nameof(packageInfo));
+            }
+
+            if (string.IsNullOrWhiteSpace(packageInfo.Id))
+            {
+                throw new ArgumentException($"Invalid package Id with null or whitespace. Package Key: {packageInfo.Key}.");
+            }
+
+            return $"/{packageInfo.Id.ToLowerInvariant()}/index.json";
+        }
+
+        public override IDictionary<string, string> GetUpdatedBlobProperties()
+        {
+            return new Dictionary<string, string>()
+            {
+                { nameof(BlobHttpHeaders.CacheControl), "max-age=10" }
+            };
+        }
+
+        public override Func<IEntityRepository<Package>, int, int, int, Task<List<PackageInfo>>> GetPageOfPackageInfosToUpdateBlobsAsync
+        {
+            get
+            {
+                return PackageInfo.GetPageOfPackageInfosWithIdOrderedByPackageRegistrationKeyAsync;
+            }
+        }
+    }
+}

--- a/src/UpdateBlobProperties/Collector.cs
+++ b/src/UpdateBlobProperties/Collector.cs
@@ -1,0 +1,61 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NuGet.Services.Entities;
+using NuGetGallery;
+
+namespace UpdateBlobProperties
+{
+    public class Collector : ICollector
+    {
+        private readonly BlobInfo _blobInfo;
+        private readonly IEntityRepository<Package> _packageRepo;
+        private readonly IOptionsSnapshot<UpdateBlobPropertiesConfiguration> _configuration;
+        private readonly ILogger<Collector> _logger;
+
+        public Collector(BlobInfo blobInfo,
+            IEntityRepository<Package> packageRepo,
+            IOptionsSnapshot<UpdateBlobPropertiesConfiguration> configuration,
+            ILogger<Collector> logger)
+        {
+            _blobInfo = blobInfo;
+            _packageRepo = packageRepo;
+            _configuration = configuration;
+            _logger = logger;
+        }
+
+        public async IAsyncEnumerable<IList<PackageInfo>> GetPagesOfPackageInfosAsync(int minKey, int maxKey)
+        {
+            int maxPageSize = _configuration.Value.MaxPageSize;
+
+            int pageIndex = 1;
+            int pageStartKey = minKey;
+            while (pageStartKey <= maxKey)
+            {
+                _logger.LogInformation("Loading page: {pageIndex} of package infos from DB. The max size of each page is {maxPageSize}.", pageIndex, maxPageSize);
+
+                var pis = await _blobInfo.GetPageOfPackageInfosToUpdateBlobsAsync(_packageRepo, pageStartKey, maxKey, maxPageSize);
+                if (pis.Count > 0)
+                {
+                    _logger.LogInformation("Loaded page: {pageIndex} of package infos from DB. The page starts from key: {startPackageKey} and ends at key: {endPackageKey}.",
+                        pageIndex, pis.First().Key, pis.Last().Key);
+
+                    pageStartKey = pis.Last().Key + 1;
+                    pageIndex++;
+
+                    yield return pis;
+                }
+                else
+                {
+                    _logger.LogInformation("No more pages to load from DB.");
+
+                    yield break;
+                }
+            }
+        }
+    }
+}

--- a/src/UpdateBlobProperties/Cursor.cs
+++ b/src/UpdateBlobProperties/Cursor.cs
@@ -1,0 +1,48 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Linq;
+using NuGet.Services.Cursor;
+using NuGet.Services.Storage;
+
+namespace UpdateBlobProperties
+{
+    public class Cursor : ReadWriteCursor<int>
+    {
+        private readonly Uri _address;
+        private readonly Storage _storage;
+        private readonly int _defaultValue;
+
+        public Cursor(Uri address, Storage storage, int defaultValue)
+        {
+            _address = address ?? throw new ArgumentNullException(nameof(address));
+            _storage = storage ?? throw new ArgumentNullException(nameof(storage));
+            _defaultValue = defaultValue;
+        }
+
+        public override async Task Save(CancellationToken cancellationToken)
+        {
+            JObject obj = new JObject { { "ProcessedMaxKey", Value } };
+            StorageContent content = new StringStorageContent(obj.ToString());
+
+            await _storage.Save(_address, content, overwrite: true, cancellationToken: cancellationToken);
+        }
+
+        public override async Task Load(CancellationToken cancellationToken)
+        {
+            string json = await _storage.LoadString(_address, cancellationToken);
+            if (json == null)
+            {
+                Value = _defaultValue;
+
+                return;
+            }
+
+            JObject obj = JObject.Parse(json);
+            Value = obj["ProcessedMaxKey"].ToObject<int>();
+        }
+    }
+}

--- a/src/UpdateBlobProperties/ICollector.cs
+++ b/src/UpdateBlobProperties/ICollector.cs
@@ -1,0 +1,12 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+
+namespace UpdateBlobProperties
+{
+    public interface ICollector
+    {
+        IAsyncEnumerable<IList<PackageInfo>> GetPagesOfPackageInfosAsync(int minKey, int maxKey);
+    }
+}

--- a/src/UpdateBlobProperties/IProcessor.cs
+++ b/src/UpdateBlobProperties/IProcessor.cs
@@ -1,0 +1,13 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace UpdateBlobProperties
+{
+    public interface IProcessor
+    {
+        Task ExecuteAsync(CancellationToken token);
+    }
+}

--- a/src/UpdateBlobProperties/Job.cs
+++ b/src/UpdateBlobProperties/Job.cs
@@ -1,0 +1,66 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.Design;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Autofac;
+using Azure.Storage.Blobs;
+using NuGet.Jobs;
+using NuGet.Jobs.Validation;
+using NuGet.Services.Entities;
+using NuGet.Services.Storage;
+using NuGetGallery;
+
+namespace UpdateBlobProperties
+{
+    public class Job : ValidationJobBase
+    {
+        private const string UpdateBlobPropertiesConfigurationSectionName = "UpdateBlobProperties";
+
+        public override void Init(IServiceContainer serviceContainer, IDictionary<string, string> jobArgsDictionary)
+        {
+            base.Init(serviceContainer, jobArgsDictionary);
+        }
+
+        public override async Task Run()
+        {
+            var processor = _serviceProvider.GetRequiredService<IProcessor>();
+
+            await processor.ExecuteAsync(CancellationToken.None);
+        }
+
+        protected override void ConfigureAutofacServices(ContainerBuilder containerBuilder, IConfigurationRoot configurationRoot)
+        {
+        }
+
+        protected override void ConfigureJobServices(IServiceCollection services, IConfigurationRoot configurationRoot)
+        {
+            // Update blob properties of package version index in FlatContainer
+            services.AddTransient<BlobInfo, BlobInfoOfPackageVersionIndexInFlatContainer>();
+
+            services.Configure<UpdateBlobPropertiesConfiguration>(configurationRoot.GetSection(UpdateBlobPropertiesConfigurationSectionName));
+            services.AddTransient<IProcessor, Processor>();
+            services.AddTransient<ICollector, Collector>();
+            services.AddTransient<IEntityRepository<Package>, EntityRepository<Package>>();
+
+            services.AddTransient(s =>
+            {
+                var address = new Uri("http://localhost");
+                var fileStorageFactory = new FileStorageFactory(
+                    address,
+                    Directory.GetCurrentDirectory(),
+                    s.GetRequiredService<ILogger<FileStorage>>());
+
+                return new Cursor(new Uri(address, "cursor.json"), fileStorageFactory.Create(), defaultValue: 0);
+            });
+        }
+    }
+}

--- a/src/UpdateBlobProperties/PackageInfo.cs
+++ b/src/UpdateBlobProperties/PackageInfo.cs
@@ -1,0 +1,68 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Data.Entity;
+using System.Linq;
+using System.Threading.Tasks;
+using NuGet.Services.Entities;
+using NuGetGallery;
+
+namespace UpdateBlobProperties
+{
+    public class PackageInfo
+    {
+        public int Key { get; }
+        public string Id { get; }
+        public string Version { get; }
+
+        public PackageInfo(int key, string id)
+        {
+            Key = key;
+            Id = id;
+        }
+
+        public PackageInfo(int key, string id, string version)
+            : this(key, id)
+        {
+            Version = version;
+        }
+
+        public static Func<IEntityRepository<Package>, int, int, int, Task<List<PackageInfo>>>
+            GetPageOfPackageInfosWithIdOrderedByPackageRegistrationKeyAsync = async (packageRepository, pageStartKey, maxKey, maxPageSize) =>
+            {
+                var prs = await packageRepository.GetAll()
+                    .Include(p => p.PackageRegistration)
+                    .Where(p => p.PackageRegistration.Key >= pageStartKey && p.PackageRegistration.Key <= maxKey)
+                    .Select(p => new { p.PackageRegistration.Key, p.PackageRegistration.Id })
+                    .Distinct()
+                    .OrderBy(pr => pr.Key)
+                    .Take(maxPageSize)
+                    .ToListAsync();
+
+                var pis = prs.Select(pr => new PackageInfo(pr.Key, pr.Id))
+                    .OrderBy(pr => pr.Key)
+                    .ToList();
+
+                return pis;
+            };
+
+        public static Func<IEntityRepository<Package>, int, int, int, Task<List<PackageInfo>>>
+            GetPageOfPackageInfosWithIdAndVersionOrderedByPackageKeyAsync = async (packageRepository, pageStartKey, maxKey, maxPageSize) =>
+            {
+                var ps = await packageRepository.GetAll()
+                    .Include(p => p.PackageRegistration)
+                    .Where(p => p.Key >= pageStartKey && p.Key <= maxKey)
+                    .OrderBy(p => p.Key)
+                    .Take(maxPageSize)
+                    .ToListAsync();
+
+                var pis = ps.Select(p => new PackageInfo(p.Key, p.PackageRegistration.Id, p.NormalizedVersion))
+                    .OrderBy(p => p.Key)
+                    .ToList();
+
+                return pis;
+            };
+    }
+}

--- a/src/UpdateBlobProperties/Processor.cs
+++ b/src/UpdateBlobProperties/Processor.cs
@@ -1,0 +1,52 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace UpdateBlobProperties
+{
+    public class Processor : IProcessor
+    {
+        private readonly ICollector _collector;
+        private readonly IOptionsSnapshot<UpdateBlobPropertiesConfiguration> _configuration;
+        private readonly Cursor _cursor;
+        private readonly ILogger<Processor> _logger;
+
+        public Processor(ICollector collector,
+            IOptionsSnapshot<UpdateBlobPropertiesConfiguration> configuration,
+            Cursor cursor,
+            ILogger<Processor> logger)
+        {
+            _collector = collector;
+            _configuration = configuration;
+            _cursor = cursor;
+            _logger = logger;
+        }
+
+        public async Task ExecuteAsync(CancellationToken token)
+        {
+            await _cursor.Load(token);
+            _logger.LogInformation("Loaded the cursor value. ProcessedMaxKey: {cursorValue}.", _cursor.Value);
+
+            var minKey = _cursor.Value + 1;
+            var maxKey = _configuration.Value.MaxKey;
+            _logger.LogInformation("Processing pages with minKey: {minKey} and maxKey: {maxKey}.", minKey, maxKey);
+
+            await foreach (IList<PackageInfo> packageInfos in _collector.GetPagesOfPackageInfosAsync(minKey: minKey, maxKey: maxKey))
+            {
+                // Update blob properties
+                // Next PR
+
+                _cursor.Value = packageInfos.Last().Key;
+                await _cursor.Save(token);
+                _logger.LogInformation("Saved the cursor value. ProcessedMaxKey: {cursorValue}.", _cursor.Value);
+            }
+        }
+    }
+}

--- a/src/UpdateBlobProperties/Program.cs
+++ b/src/UpdateBlobProperties/Program.cs
@@ -1,0 +1,16 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using NuGet.Jobs;
+
+namespace UpdateBlobProperties
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            var job = new Job();
+            JobRunner.RunOnce(job, args).GetAwaiter().GetResult();
+        }
+    }
+}

--- a/src/UpdateBlobProperties/UpdateBlobProperties.csproj
+++ b/src/UpdateBlobProperties/UpdateBlobProperties.csproj
@@ -1,0 +1,10 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net472</TargetFramework>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\NuGet.Services.Cursor\NuGet.Services.Cursor.csproj" />
+    <ProjectReference Include="..\Validation.Common.Job\Validation.Common.Job.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/UpdateBlobProperties/UpdateBlobPropertiesConfiguration.cs
+++ b/src/UpdateBlobProperties/UpdateBlobPropertiesConfiguration.cs
@@ -1,0 +1,12 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace UpdateBlobProperties
+{
+    public class UpdateBlobPropertiesConfiguration
+    {
+        public string StorageConnectionString { get; set; }
+        public int MaxPageSize { get; set; }
+        public int MaxKey { get; set; }
+    }
+}


### PR DESCRIPTION
Provide a tool to update blob properties:
1. Get pages of packages from DB to process.
2. Packages are ordered by Primary Key (`PackageRegistration` or `Package`).
3. Use a cursor to commit the processed max key, after processing a page of packages successfully.
4. Only need to implement `BlobInfo.cs` for other types of blob files.
5. No unit test coverage, as a one-time tool.

