### PR TITLE
Add removed packages to RemovedPackages.md (04/02-03/2026)

### DIFF
--- a/RemovedPackages.md
+++ b/RemovedPackages.md
@@ -122,6 +122,18 @@ Scanning is not perfect. Community partnership is a very valuable part of the ov
 |    Tracer.DotNet.APM 0.0.0                   |    04/03/2026    |   Potentially Malicious  |
 |    APMAzure.DotNet.Agent 1.8.0               |    04/03/2026    |   Potentially Malicious  |
 |    asdftest 1.0.0                            |    04/03/2026    |   Potentially Malicious  |
+|    Axis.Podracers.AudioClips 1.0.4           |    04/03/2026    |   Potentially Malicious  |
+|    Axis.Podracers.AudioClips 1.0.5           |    04/03/2026    |   Potentially Malicious  |
+|    AxisAnalyzers 10.0.0                      |    04/03/2026    |   Potentially Malicious  |
+|    AxisAnalyzers 11.0.0                      |    04/03/2026    |   Potentially Malicious  |
+|    wk10 1.0.3                                |    04/03/2026    |   Potentially Malicious  |
+|    wk10 1.0.4                                |    04/03/2026    |   Potentially Malicious  |
+|    Regorus 0.9.1                             |    04/03/2026    |   Potentially Malicious  |
+|    Regorus 0.9.2                             |    04/03/2026    |   Potentially Malicious  |
+|    Rx.Kql 3.0.5                              |    04/03/2026    |   Potentially Malicious  |
+|    Rx.Kql 3.0.6                              |    04/03/2026    |   Potentially Malicious  |
+|    vc150 1.0.0                               |    04/03/2026    |   Potentially Malicious  |
+|    vc150 1.0.1                               |    04/03/2026    |   Potentially Malicious  |
 
 
 Legend:


### PR DESCRIPTION
## Summary
Add 26 removed package versions to RemovedPackages.md, with bsure entries reordered to correct chronological position.

### Malware (04/02/2026)
- **bsure.Utils** versions 99.99.99, 0.71.2, 0.70.1
- **bsure.binsec** version 0.70.1

### Potentially Malicious (04/03/2026)
- **a0f61a05228a44f5af43662234499b68** versions 0.0.1–0.0.5
- **a170a4f911e646feb466baf21099b491** version 0.0.1
- **7da3f64d1fc340d983ef7366243fffdd** version 1.0.0
- **Tracer.DotNet.APM** version 0.0.0
- **APMAzure.DotNet.Agent** version 1.8.0
- **asdftest** version 1.0.0
- **Axis.Podracers.AudioClips** versions 1.0.4, 1.0.5
- **AxisAnalyzers** versions 10.0.0, 11.0.0
- **wk10** versions 1.0.3, 1.0.4
- **Regorus** versions 0.9.1, 0.9.2
- **Rx.Kql** versions 3.0.5, 3.0.6
- **vc150** versions 1.0.0, 1.0.1