### PR TITLE
Add Italy.Core 1.0.3 removal entry (Malware) - 2026-03-23

### DIFF
--- a/RemovedPackages.md
+++ b/RemovedPackages.md
@@ -108,6 +108,7 @@ Scanning is not perfect. Community partnership is a very valuable part of the ov
 |    NCryptYo                            |    02/20/2026    |   Malware  |
 |    SimpleWriter_                       |    02/20/2026    |   Potentially Malicious  |
 |    IRAOAuth2.0                         |    02/20/2026    |   Potentially Malicious  |
+|    Italy.Core version 1.0.3            |    03/23/2026    |   Malware  |
 
 
 Legend:


### PR DESCRIPTION
Adds an entry to RemovedPackages.md for:
- Package: Italy.Core
- Version: 1.0.3
- Removal date: 2026-03-23
- Reason: Malware

The entry is placed in chronological order based on removal date.