### PR TITLE
Not using Path.Combine for joining path segments in GithubVulnerabilities2V3 job

### DIFF
--- a/src/GitHubVulnerabilities2v3/Extensions/BlobStorageVulnerabilityWriter.cs
+++ b/src/GitHubVulnerabilities2v3/Extensions/BlobStorageVulnerabilityWriter.cs
@@ -308,7 +308,7 @@ namespace GitHubVulnerabilities2v3.Extensions
             var baseFolder = pathParts[pathParts.Length - 2];
 
             // Start special case block
-            var currentBaseContentUri = _primaryStorage.ResolveUri(Path.Combine(baseFolder, _configuration.BaseFileName));
+            var currentBaseContentUri = _primaryStorage.ResolveUri(UrlPathCombine(baseFolder, _configuration.BaseFileName));
             var currentBaseContent = await _primaryStorage.LoadString(currentBaseContentUri, CancellationToken.None);
             var baseContentObject = JsonConvert.DeserializeObject<Dictionary<string, List<Advisory>>>(currentBaseContent);
 
@@ -334,7 +334,7 @@ namespace GitHubVulnerabilities2v3.Extensions
 
             _logger.LogInformation("Writing update to files");
             var primaryIndexContent = new StringStorageContent(JsonConvert.SerializeObject(indexEntries), contentType: JsonContentType, cacheControl: _configuration.IndexCacheControlHeader);
-            var updateStorageUri = _primaryStorage.ResolveUri(Path.Combine(baseFolder, currentTime, _configuration.UpdateFileName));
+            var updateStorageUri = _primaryStorage.ResolveUri(UrlPathCombine(baseFolder, currentTime, _configuration.UpdateFileName));
             var updateContent = new StringStorageContent(stringContentOutput, contentType: JsonContentType, cacheControl: _configuration.UpdateCacheControlHeader);
 
             await _primaryStorage.Save(updateStorageUri, updateContent, overwrite: true, CancellationToken.None);
@@ -358,7 +358,7 @@ namespace GitHubVulnerabilities2v3.Extensions
                     }
                 }
                 var secondaryIndexContent = new StringStorageContent(JsonConvert.SerializeObject(indexEntries), contentType: JsonContentType, cacheControl: _configuration.IndexCacheControlHeader);
-                updateStorageUri = _secondaryStorage.ResolveUri(Path.Combine(baseFolder, currentTime, _configuration.UpdateFileName));
+                updateStorageUri = _secondaryStorage.ResolveUri(UrlPathCombine(baseFolder, currentTime, _configuration.UpdateFileName));
                 var secondaryIndexStorageUri = _secondaryStorage.ResolveUri(_configuration.IndexFileName);
 
                 await _secondaryStorage.Save(updateStorageUri, updateContent, overwrite: true, CancellationToken.None);
@@ -427,8 +427,8 @@ namespace GitHubVulnerabilities2v3.Extensions
             var indexContent = new StringStorageContent(JsonConvert.SerializeObject(indexEntries), contentType: JsonContentType, cacheControl: _configuration.IndexCacheControlHeader);
 
             var primaryIndexStorageUri = _primaryStorage.ResolveUri(_configuration.IndexFileName);
-            var baseStorageUri = _primaryStorage.ResolveUri(Path.Combine(currentTime, _configuration.BaseFileName));
-            var updateStorageUri = _primaryStorage.ResolveUri(Path.Combine(currentTime, currentTime, _configuration.UpdateFileName));
+            var baseStorageUri = _primaryStorage.ResolveUri(UrlPathCombine(currentTime, _configuration.BaseFileName));
+            var updateStorageUri = _primaryStorage.ResolveUri(UrlPathCombine(currentTime, currentTime, _configuration.UpdateFileName));
 
             await _primaryStorage.Save(baseStorageUri, baseContent, overwrite: true, CancellationToken.None);
             await _primaryStorage.Save(updateStorageUri, updateContent, overwrite: true, CancellationToken.None);
@@ -442,8 +442,8 @@ namespace GitHubVulnerabilities2v3.Extensions
 
                 _logger.LogInformation("Writing regenerated files to secondary storage");
                 var secondaryIndexStorageUri = _secondaryStorage.ResolveUri(_configuration.IndexFileName);
-                var secondaryBaseStorageUri = _secondaryStorage.ResolveUri(Path.Combine(currentTime, _configuration.BaseFileName));
-                var secondaryUpdateStorageUri = _secondaryStorage.ResolveUri(Path.Combine(currentTime, currentTime, _configuration.UpdateFileName));
+                var secondaryBaseStorageUri = _secondaryStorage.ResolveUri(UrlPathCombine(currentTime, _configuration.BaseFileName));
+                var secondaryUpdateStorageUri = _secondaryStorage.ResolveUri(UrlPathCombine(currentTime, currentTime, _configuration.UpdateFileName));
 
                 await _secondaryStorage.Save(secondaryBaseStorageUri, baseContent, overwrite: true, CancellationToken.None);
                 await _secondaryStorage.Save(secondaryUpdateStorageUri, updateContent, overwrite: true, CancellationToken.None);
@@ -453,6 +453,28 @@ namespace GitHubVulnerabilities2v3.Extensions
 
             _cursor.Value = _firstVulnWrittenTimestamp;
             await _cursor.Save(CancellationToken.None);
+        }
+
+        private static string UrlPathCombine(params string[] segments)
+        {
+            StringBuilder sb = new StringBuilder();
+            foreach (var segment in segments)
+            {
+                if (!string.IsNullOrEmpty(segment))
+                {
+                    if (segment.Contains("/") || segment.Contains("\\"))
+                    {
+                        throw new ArgumentException($"Path segments must not contain '/' or '\\' characters (segment: {segment}).", nameof(segments));
+                    }
+
+                    if (sb.Length > 0)
+                    {
+                        sb.Append('/');
+                    }
+                    sb.Append(segment);
+                }
+            }
+            return sb.ToString();
         }
     }
 }


### PR DESCRIPTION
Progress on https://github.com/NuGet/Engineering/issues/6293, https://github.com/NuGet/NuGetGallery/issues/10656

Recent changes prevented using backslash in relative paths and this job was using `Path.Combine` to produce those. It no longer does.