### PR TITLE
Add 'Your Privacy Choices' link to footer

### DIFF
--- a/src/AccountDeleter/Configuration/GalleryConfiguration.cs
+++ b/src/AccountDeleter/Configuration/GalleryConfiguration.cs
@@ -120,5 +120,6 @@ namespace NuGetGallery.AccountDeleter
         public int MaxJsonLengthOverride { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
         public int MaxOwnerPerPackageRegistration { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
         public int MaxOwnerRequestsPerPackageRegistration { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+        public string ExternalYourPrivacyChoicesUrl { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
     }
 }

--- a/src/NuGetGallery.Services/Configuration/AppConfiguration.cs
+++ b/src/NuGetGallery.Services/Configuration/AppConfiguration.cs
@@ -324,6 +324,11 @@ namespace NuGetGallery.Configuration
         public string ExternalPrivacyPolicyUrl { get; set; }
 
         /// <summary>
+        /// Gets/sets a string that is a link to an external "Your Privacy Choices" page
+        /// </summary>
+        public string ExternalYourPrivacyChoicesUrl { get; set; }
+
+        /// <summary>
         /// Gets/sets a string that is a link to an external terms of use document
         /// </summary>
         public string ExternalTermsOfUseUrl { get; set; }

--- a/src/NuGetGallery.Services/Configuration/IAppConfiguration.cs
+++ b/src/NuGetGallery.Services/Configuration/IAppConfiguration.cs
@@ -350,6 +350,11 @@ namespace NuGetGallery.Configuration
         string ExternalPrivacyPolicyUrl { get; set; }
 
         /// <summary>
+        /// Gets/sets a string that is a link to an external privacy choices page
+        /// </summary>
+        string ExternalYourPrivacyChoicesUrl { get; set; }
+
+        /// <summary>
         /// Gets/sets a string that is a link to an external terms of use document
         /// </summary>
         string ExternalTermsOfUseUrl { get; set; }

--- a/src/NuGetGallery/Content/gallery/img/privacy-choices.svg
+++ b/src/NuGetGallery/Content/gallery/img/privacy-choices.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 30 14" xml:space="preserve">
+    <title>Your Privacy Choices Opt-Out Icon</title>
+    <path d="M7.4 12.8h6.8l3.1-11.6H7.4C4.2 1.2 1.6 3.8 1.6 7s2.6 5.8 5.8 5.8z" style="fill-rule:evenodd;clip-rule:evenodd;fill:#fff"/>
+    <path d="M22.6 0H7.4c-3.9 0-7 3.1-7 7s3.1 7 7 7h15.2c3.9 0 7-3.1 7-7s-3.2-7-7-7zm-21 7c0-3.2 2.6-5.8 5.8-5.8h9.9l-3.1 11.6H7.4c-3.2 0-5.8-2.6-5.8-5.8z" style="fill-rule:evenodd;clip-rule:evenodd;fill:#06f"/>
+    <path d="M24.6 4c.2.2.2.6 0 .8L22.5 7l2.2 2.2c.2.2.2.6 0 .8-.2.2-.6.2-.8 0l-2.2-2.2-2.2 2.2c-.2.2-.6.2-.8 0-.2-.2-.2-.6 0-.8L20.8 7l-2.2-2.2c-.2-.2-.2-.6 0-.8.2-.2.6-.2.8 0l2.2 2.2L23.8 4c.2-.2.6-.2.8 0z" style="fill:#fff"/>
+    <path d="M12.7 4.1c.2.2.3.6.1.8L8.6 9.8c-.1.1-.2.2-.3.2-.2.1-.5.1-.7-.1L5.4 7.7c-.2-.2-.2-.6 0-.8.2-.2.6-.2.8 0L8 8.6l3.8-4.5c.2-.2.6-.2.9 0z" style="fill:#06f"/>
+</svg>

--- a/src/NuGetGallery/Controllers/PagesController.cs
+++ b/src/NuGetGallery/Controllers/PagesController.cs
@@ -63,6 +63,12 @@ namespace NuGetGallery
         }
 
         [HttpGet]
+        public virtual ActionResult YourPrivacyChoices()
+        {
+            return View();
+        }
+
+        [HttpGet]
         public virtual ActionResult Contact()
         {
             return View(new ContactSupportViewModel());

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -1412,6 +1412,7 @@
     <Content Include="Content\gallery\img\default-package-icon-white.png" />
     <Content Include="Content\gallery\img\dotnet-foundation-42x42.png" />
     <Content Include="Content\gallery\img\dotnet-foundation.svg" />
+    <Content Include="Content\gallery\img\privacy-choices.svg" />
     <Content Include="Content\gallery\img\git-32x32.png" />
     <Content Include="Content\gallery\img\git.svg" />
     <Content Include="Content\gallery\img\git-white.svg" />

--- a/src/NuGetGallery/UrlHelperExtensions.cs
+++ b/src/NuGetGallery/UrlHelperExtensions.cs
@@ -1471,6 +1471,16 @@ namespace NuGetGallery
             return GetActionLink(url, "Privacy", "Pages", relativeUrl);
         }
 
+        public static string YourPrivacyChoices(this UrlHelper url, bool relativeUrl = true)
+        {
+            if (!String.IsNullOrEmpty(_configuration.Current.ExternalYourPrivacyChoicesUrl))
+            {
+                return _configuration.Current.ExternalYourPrivacyChoicesUrl;
+            }
+
+            return GetActionLink(url, "Your Privacy Choices", "Pages", relativeUrl);
+        }
+
         public static string ExternalPrivacyUrl(this UrlHelper url)
         {
             return _configuration.Current.ExternalPrivacyPolicyUrl;

--- a/src/NuGetGallery/UrlHelperExtensions.cs
+++ b/src/NuGetGallery/UrlHelperExtensions.cs
@@ -1478,7 +1478,7 @@ namespace NuGetGallery
                 return _configuration.Current.ExternalYourPrivacyChoicesUrl;
             }
 
-            return GetActionLink(url, "Your Privacy Choices", "Pages", relativeUrl);
+            return GetActionLink(url, "YourPrivacyChoices", "Pages", relativeUrl);
         }
 
         public static string ExternalPrivacyUrl(this UrlHelper url)

--- a/src/NuGetGallery/Views/Pages/YourPrivacyChoices.cshtml
+++ b/src/NuGetGallery/Views/Pages/YourPrivacyChoices.cshtml
@@ -1,0 +1,14 @@
+@{
+    ViewBag.Title = "Your Privacy Choices";
+}
+
+<section role="main" class="container main-container">
+    <div class="row">
+        <div class="col-xs-12">
+            <h1>Your Privacy Choices</h1>
+            <p>
+                This page is a placeholder for the Your Privacy Choices page. Configure <code>ExternalYourPrivacyChoicesUrl</code> in your settings to redirect to an external privacy choices page.
+            </p>
+        </div>
+    </div>
+</section>

--- a/src/NuGetGallery/Views/Shared/Gallery/Footer.cshtml
+++ b/src/NuGetGallery/Views/Shared/Gallery/Footer.cshtml
@@ -54,13 +54,7 @@
                                 <a href="@Url.About()">About</a> -
                                 <a href="@Url.Terms()">Terms of Use</a> -
                                 <a href="@Url.YourPrivacyChoices()">
-                                    <svg role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 30 14" xml:space="preserve" height="16" width="43" style="vertical-align:middle">
-                                        <title>Your Privacy Choices Opt-Out Icon</title>
-                                        <path d="M7.4 12.8h6.8l3.1-11.6H7.4C4.2 1.2 1.6 3.8 1.6 7s2.6 5.8 5.8 5.8z" style="fill-rule:evenodd;clip-rule:evenodd;fill:#fff"></path>
-                                        <path d="M22.6 0H7.4c-3.9 0-7 3.1-7 7s3.1 7 7 7h15.2c3.9 0 7-3.1 7-7s-3.2-7-7-7zm-21 7c0-3.2 2.6-5.8 5.8-5.8h9.9l-3.1 11.6H7.4c-3.2 0-5.8-2.6-5.8-5.8z" style="fill-rule:evenodd;clip-rule:evenodd;fill:#06f"></path>
-                                        <path d="M24.6 4c.2.2.2.6 0 .8L22.5 7l2.2 2.2c.2.2.2.6 0 .8-.2.2-.6.2-.8 0l-2.2-2.2-2.2 2.2c-.2.2-.6.2-.8 0-.2-.2-.2-.6 0-.8L20.8 7l-2.2-2.2c-.2-.2-.2-.6 0-.8.2-.2.6-.2.8 0l2.2 2.2L23.8 4c.2-.2.6-.2.8 0z" style="fill:#fff"></path>
-                                        <path d="M12.7 4.1c.2.2.3.6.1.8L8.6 9.8c-.1.1-.2.2-.3.2-.2.1-.5.1-.7-.1L5.4 7.7c-.2-.2-.2-.6 0-.8.2-.2.6-.2.8 0L8 8.6l3.8-4.5c.2-.2.6-.2.9 0z" style="fill:#06f"></path>
-                                    </svg><span style="font-size: 16px; font-weight:400">Your Privacy Choices</span></a> -
+                                    <img src="~/Content/gallery/img/privacy-choices.svg" height="16" width="43" style="vertical-align:middle" alt="Your Privacy Choices Opt-Out Icon" /><span style="font-size: 16px; font-weight:400">Your Privacy Choices</span></a> -
                                 <a href="@Url.Privacy()" id="footer-privacy-policy-link">Privacy Statement</a>
 
                                 @if (!String.IsNullOrEmpty(this.Config.Current.TrademarksUrl))
@@ -87,13 +81,7 @@
                                 <a href="@Url.About()">About</a> -
                                 <a href="@Url.Terms()">Terms of Use</a> -
                                 <a href="@Url.YourPrivacyChoices()">
-                                    <svg role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 30 14" xml:space="preserve" height="16" width="43" style="vertical-align:middle">
-                                        <title>Your Privacy Choices Opt-Out Icon</title>
-                                        <path d="M7.4 12.8h6.8l3.1-11.6H7.4C4.2 1.2 1.6 3.8 1.6 7s2.6 5.8 5.8 5.8z" style="fill-rule:evenodd;clip-rule:evenodd;fill:#fff"></path>
-                                        <path d="M22.6 0H7.4c-3.9 0-7 3.1-7 7s3.1 7 7 7h15.2c3.9 0 7-3.1 7-7s-3.2-7-7-7zm-21 7c0-3.2 2.6-5.8 5.8-5.8h9.9l-3.1 11.6H7.4c-3.2 0-5.8-2.6-5.8-5.8z" style="fill-rule:evenodd;clip-rule:evenodd;fill:#06f"></path>
-                                        <path d="M24.6 4c.2.2.2.6 0 .8L22.5 7l2.2 2.2c.2.2.2.6 0 .8-.2.2-.6.2-.8 0l-2.2-2.2-2.2 2.2c-.2.2-.6.2-.8 0-.2-.2-.2-.6 0-.8L20.8 7l-2.2-2.2c-.2-.2-.2-.6 0-.8.2-.2.6-.2.8 0l2.2 2.2L23.8 4c.2-.2.6-.2.8 0z" style="fill:#fff"></path>
-                                        <path d="M12.7 4.1c.2.2.3.6.1.8L8.6 9.8c-.1.1-.2.2-.3.2-.2.1-.5.1-.7-.1L5.4 7.7c-.2-.2-.2-.6 0-.8.2-.2.6-.2.8 0L8 8.6l3.8-4.5c.2-.2.6-.2.9 0z" style="fill:#06f"></path>
-                                    </svg><span style="font-size: 16px; font-weight: 400">Your Privacy Choices</span></a> -
+                                    <img src="~/Content/gallery/img/privacy-choices.svg" height="16" width="43" style="vertical-align:middle" alt="Your Privacy Choices Opt-Out Icon" /><span style="font-size: 16px; font-weight: 400">Your Privacy Choices</span></a> -
                                 <a href="@Url.Privacy()" id="footer-privacy-policy-link">Privacy Policy</a>
                                 @if (!String.IsNullOrEmpty(this.Config.Current.TrademarksUrl))
                                 {

--- a/src/NuGetGallery/Views/Shared/Gallery/Footer.cshtml
+++ b/src/NuGetGallery/Views/Shared/Gallery/Footer.cshtml
@@ -34,7 +34,8 @@
                         !String.IsNullOrEmpty(this.Config.Current.ExternalBrandingUrl) ||
                         !String.IsNullOrEmpty(this.Config.Current.ExternalAboutUrl) ||
                         !String.IsNullOrEmpty(this.Config.Current.ExternalTermsOfUseUrl) ||
-                        !String.IsNullOrEmpty(this.Config.Current.ExternalPrivacyPolicyUrl))
+                        !String.IsNullOrEmpty(this.Config.Current.ExternalPrivacyPolicyUrl) ||
+                        !String.IsNullOrEmpty(this.Config.Current.ExternalYourPrivacyChoicesUrl))
                     {
                         <div class="col-md-12 footer-release-info">
                             <p>
@@ -52,7 +53,16 @@
 
                                 <a href="@Url.About()">About</a> -
                                 <a href="@Url.Terms()">Terms of Use</a> -
+                                <a href="@Url.YourPrivacyChoices()">
+                                    <svg role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 30 14" xml:space="preserve" height="16" width="43" style="vertical-align:middle">
+                                        <title>Your Privacy Choices Opt-Out Icon</title>
+                                        <path d="M7.4 12.8h6.8l3.1-11.6H7.4C4.2 1.2 1.6 3.8 1.6 7s2.6 5.8 5.8 5.8z" style="fill-rule:evenodd;clip-rule:evenodd;fill:#fff"></path>
+                                        <path d="M22.6 0H7.4c-3.9 0-7 3.1-7 7s3.1 7 7 7h15.2c3.9 0 7-3.1 7-7s-3.2-7-7-7zm-21 7c0-3.2 2.6-5.8 5.8-5.8h9.9l-3.1 11.6H7.4c-3.2 0-5.8-2.6-5.8-5.8z" style="fill-rule:evenodd;clip-rule:evenodd;fill:#06f"></path>
+                                        <path d="M24.6 4c.2.2.2.6 0 .8L22.5 7l2.2 2.2c.2.2.2.6 0 .8-.2.2-.6.2-.8 0l-2.2-2.2-2.2 2.2c-.2.2-.6.2-.8 0-.2-.2-.2-.6 0-.8L20.8 7l-2.2-2.2c-.2-.2-.2-.6 0-.8.2-.2.6-.2.8 0l2.2 2.2L23.8 4c.2-.2.6-.2.8 0z" style="fill:#fff"></path>
+                                        <path d="M12.7 4.1c.2.2.3.6.1.8L8.6 9.8c-.1.1-.2.2-.3.2-.2.1-.5.1-.7-.1L5.4 7.7c-.2-.2-.2-.6 0-.8.2-.2.6-.2.8 0L8 8.6l3.8-4.5c.2-.2.6-.2.9 0z" style="fill:#06f"></path>
+                                    </svg><span style="font-size: 16px; font-weight:400">Your Privacy Choices</span></a> -
                                 <a href="@Url.Privacy()" id="footer-privacy-policy-link">Privacy Statement</a>
+
                                 @if (!String.IsNullOrEmpty(this.Config.Current.TrademarksUrl))
                                 {
                                     @:- <a href="@this.Config.Current.TrademarksUrl">Trademarks</a>
@@ -76,6 +86,14 @@
                                 &copy; @DateTime.UtcNow.Year .NET Foundation -
                                 <a href="@Url.About()">About</a> -
                                 <a href="@Url.Terms()">Terms of Use</a> -
+                                <a href="@Url.YourPrivacyChoices()">
+                                    <svg role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 30 14" xml:space="preserve" height="16" width="43" style="vertical-align:middle">
+                                        <title>Your Privacy Choices Opt-Out Icon</title>
+                                        <path d="M7.4 12.8h6.8l3.1-11.6H7.4C4.2 1.2 1.6 3.8 1.6 7s2.6 5.8 5.8 5.8z" style="fill-rule:evenodd;clip-rule:evenodd;fill:#fff"></path>
+                                        <path d="M22.6 0H7.4c-3.9 0-7 3.1-7 7s3.1 7 7 7h15.2c3.9 0 7-3.1 7-7s-3.2-7-7-7zm-21 7c0-3.2 2.6-5.8 5.8-5.8h9.9l-3.1 11.6H7.4c-3.2 0-5.8-2.6-5.8-5.8z" style="fill-rule:evenodd;clip-rule:evenodd;fill:#06f"></path>
+                                        <path d="M24.6 4c.2.2.2.6 0 .8L22.5 7l2.2 2.2c.2.2.2.6 0 .8-.2.2-.6.2-.8 0l-2.2-2.2-2.2 2.2c-.2.2-.6.2-.8 0-.2-.2-.2-.6 0-.8L20.8 7l-2.2-2.2c-.2-.2-.2-.6 0-.8.2-.2.6-.2.8 0l2.2 2.2L23.8 4c.2-.2.6-.2.8 0z" style="fill:#fff"></path>
+                                        <path d="M12.7 4.1c.2.2.3.6.1.8L8.6 9.8c-.1.1-.2.2-.3.2-.2.1-.5.1-.7-.1L5.4 7.7c-.2-.2-.2-.6 0-.8.2-.2.6-.2.8 0L8 8.6l3.8-4.5c.2-.2.6-.2.9 0z" style="fill:#06f"></path>
+                                    </svg><span style="font-size: 16px; font-weight: 400">Your Privacy Choices</span></a> -
                                 <a href="@Url.Privacy()" id="footer-privacy-policy-link">Privacy Policy</a>
                                 @if (!String.IsNullOrEmpty(this.Config.Current.TrademarksUrl))
                                 {

--- a/src/NuGetGallery/Web.config
+++ b/src/NuGetGallery/Web.config
@@ -160,6 +160,7 @@
     <add key="Gallery.ExternalStatusUrl" value="https://status.nuget.org/"/>
     <add key="Gallery.ExternalAboutUrl" value=""/>
     <add key="Gallery.ExternalPrivacyPolicyUrl" value=""/>
+    <add key="Gallery.ExternalYourPrivacyChoicesUrl" value="https://aka.ms/yourcaliforniaprivacychoices"/>
     <add key="Gallery.ExternalTermsOfUseUrl" value=""/>
     <add key="Gallery.ExternalBrandingUrl" value=""/>
     <add key="Gallery.ExternalBrandingMessage" value=""/>

--- a/src/NuGetGallery/Web.config
+++ b/src/NuGetGallery/Web.config
@@ -160,7 +160,7 @@
     <add key="Gallery.ExternalStatusUrl" value="https://status.nuget.org/"/>
     <add key="Gallery.ExternalAboutUrl" value=""/>
     <add key="Gallery.ExternalPrivacyPolicyUrl" value=""/>
-    <add key="Gallery.ExternalYourPrivacyChoicesUrl" value="https://aka.ms/yourcaliforniaprivacychoices"/>
+    <add key="Gallery.ExternalYourPrivacyChoicesUrl" value=""/>
     <add key="Gallery.ExternalTermsOfUseUrl" value=""/>
     <add key="Gallery.ExternalBrandingUrl" value=""/>
     <add key="Gallery.ExternalBrandingMessage" value=""/>

--- a/tests/NuGetGallery.Facts/Controllers/PagesControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/PagesControllerFacts.cs
@@ -125,5 +125,48 @@ namespace NuGetGallery
                         It.IsAny<TimeSpan>()), Times.Once);
             }
         }
+
+        public class TheYourPrivacyChoicesUrl : TestContainer
+        {
+            [Fact]
+            public void WithExternalYourPrivacyChoicesUrlConfigured()
+            {
+                var expectedUrl = "https://aka.ms/yourcaliforniaprivacychoices";
+                var configuration = GetConfigurationService();
+                configuration.Current.ExternalYourPrivacyChoicesUrl = expectedUrl;
+
+                var urlHelper = TestUtility.MockUrlHelper();
+
+                var result = UrlHelperExtensions.YourPrivacyChoices(urlHelper);
+
+                Assert.Equal(expectedUrl, result);
+            }
+
+            [Fact]
+            public void WithoutExternalYourPrivacyChoicesUrlConfigured()
+            {
+                var configuration = GetConfigurationService();
+                configuration.Current.ExternalYourPrivacyChoicesUrl = "";
+
+                var urlHelper = TestUtility.MockUrlHelper();
+
+                var result = UrlHelperExtensions.YourPrivacyChoices(urlHelper);
+
+                Assert.NotEqual("https://aka.ms/yourcaliforniaprivacychoices", result);
+            }
+
+            [Fact]
+            public void WithNullExternalYourPrivacyChoicesUrlConfigured()
+            {
+                var configuration = GetConfigurationService();
+                configuration.Current.ExternalYourPrivacyChoicesUrl = null;
+
+                var urlHelper = TestUtility.MockUrlHelper();
+
+                var result = UrlHelperExtensions.YourPrivacyChoices(urlHelper);
+
+                Assert.NotEqual("https://aka.ms/yourcaliforniaprivacychoices", result);
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
Mandated link to be included in all Microsoft footer web sites. 
<img width="545" height="35" alt="image" src="https://github.com/user-attachments/assets/30fb5ff2-15e1-472e-a6b6-ca24676e2944" />


Adds a **Your Privacy Choices** link with the standard opt-out SVG icon to the NuGet Gallery footer, placed between *Terms of Use* and *Privacy Statement*.

## Changes

- **IAppConfiguration / AppConfiguration** – New \ExternalYourPrivacyChoicesUrl\ config property
- **GalleryConfiguration** (AccountDeleter) – Stubbed the new property
- **UrlHelperExtensions** – Added \YourPrivacyChoices()\ helper that uses the external URL when configured
- **Footer.cshtml** – Inserted the link with SVG icon in both footer paths (external branding & .NET Foundation)
- **Web.config** – Default value: \https://aka.ms/yourcaliforniaprivacychoices\

## Testing

- Verified the link renders at 16px font size with the opt-out icon inline