### PR TITLE
Add new CI pipeline to run publicly in dnceng

### DIFF
--- a/.pipelines/NuGetGallery-CI-dnceng.yml
+++ b/.pipelines/NuGetGallery-CI-dnceng.yml
@@ -1,0 +1,222 @@
+name: NuGetGallery CI $(Build.BuildId)
+
+trigger:
+  branches:
+    include:
+      - "*"
+  batch: True
+
+variables:
+  - name: BuildConfiguration
+    value: Release
+  - name: Codeql.Enabled
+    value: true
+  - name: NugetSecurityAnalysisWarningLevel
+    value: none
+  - name: nugetMultiFeedWarnLevel
+    value: none
+  - name: CommonPackageVersion
+    value: $(CommonAssemblyVersion)-$(SemverFriendlyBranchName)-$(Build.BuildId)
+  - name: CommonAssemblyVersion
+    value: 5.0.0
+  - name: GalleryPackageVersion
+    value: $(GalleryAssemblyVersion)-$(SemverFriendlyBranchName)-$(Build.BuildId)
+  - name: GalleryAssemblyVersion
+    value: 5.0.0
+  - name: JobsPackageVersion
+    value: $(JobsAssemblyVersion)-$(SemverFriendlyBranchName)-$(Build.BuildId)
+  - name: JobsAssemblyVersion
+    value: 5.0.0
+  - name: NuGetGalleryDirectory
+    value: ng
+  - name: NuGetGalleryPath
+    value: $(Agent.BuildDirectory)\$(NuGetGalleryDirectory)
+  - name: NuGetGalleryBranch
+    value: $(Build.SourceBranchName)
+  - name: SemverFriendlyBranchName
+    value: ${{ replace(replace(variables['Build.SourceBranchName'], '_', '-'), '/', '-') }}
+
+resources:
+  repositories:
+    - repository: self
+      type: git
+      ref: refs/heads/main
+    - repository: 1ESPipelineTemplates
+      type: git
+      name: 1ESPipelineTemplates/1ESPipelineTemplates
+      ref: refs/tags/release
+
+extends:
+  template: v1/1ES.Unofficial.PipelineTemplate.yml@1ESPipelineTemplates
+  parameters:
+    settings:
+      networkIsolationPolicy: Permissive
+    pool:
+      name: NuGet-1ES-Hosted-Pool
+      image: NuGet-1ESPT-Win2022
+      os: windows
+    customBuildTags:
+      - ES365AIMigrationTooling
+    stages:
+      - stage: common
+        displayName: NuGet.Server.Common.sln
+        dependsOn: []
+        jobs:
+          - job: build_and_test
+            displayName: common build and test
+            cancelTimeoutInMinutes: 1
+            steps:
+              - checkout: self
+                fetchDepth: 1
+                clean: true
+                fetchTags: false
+                path: $(NuGetGalleryDirectory)
+              - task: PowerShell@1
+                name: build
+                displayName: Build
+                inputs:
+                  scriptName: $(NuGetGalleryPath)\build.ps1
+                  arguments: -Configuration $(BuildConfiguration) -BuildNumber $(Build.BuildId) -SkipArtifacts -SkipGallery -SkipJobs -CommonAssemblyVersion $(CommonAssemblyVersion) -CommonPackageVersion $(CommonPackageVersion) -GalleryAssemblyVersion $(GalleryAssemblyVersion) -GalleryPackageVersion $(GalleryPackageVersion) -JobsAssemblyVersion $(JobsAssemblyVersion) -JobsPackageVersion $(JobsPackageVersion) -Branch $(NuGetGalleryBranch) -CommitSHA $(Build.SourceVersion)
+                  workingFolder: $(NuGetGalleryPath)
+              - task: PowerShell@1
+                name: test
+                displayName: Run tests
+                inputs:
+                  scriptName: $(NuGetGalleryPath)\test.ps1
+                  arguments: -Configuration $(BuildConfiguration) -BuildNumber $(Build.BuildId) -SkipGallery -SkipJobs
+                  workingFolder: $(NuGetGalleryPath)
+              - task: PublishTestResults@2
+                name: publish_test_results
+                displayName: Publish test results
+                condition: succeededOrFailed()
+                inputs:
+                  testRunner: VSTest
+                  testResultsFiles: $(NuGetGalleryPath)\Results.*.xml
+                  failTaskOnFailedTests: true
+
+      - stage: gallery
+        displayName: NuGetGallery.sln
+        dependsOn: []
+        jobs:
+          - job: build_and_test
+            displayName: gallery build and test
+            cancelTimeoutInMinutes: 1
+            steps:
+              - checkout: self
+                fetchDepth: 1
+                clean: true
+                fetchTags: false
+                path: $(NuGetGalleryDirectory)
+              - task: PowerShell@1
+                name: build
+                displayName: Build
+                inputs:
+                  scriptName: $(NuGetGalleryPath)\build.ps1
+                  arguments: -Configuration $(BuildConfiguration) -BuildNumber $(Build.BuildId) -SkipArtifacts -SkipCommon -SkipJobs -CommonAssemblyVersion $(CommonAssemblyVersion) -CommonPackageVersion $(CommonPackageVersion) -GalleryAssemblyVersion $(GalleryAssemblyVersion) -GalleryPackageVersion $(GalleryPackageVersion) -JobsAssemblyVersion $(JobsAssemblyVersion) -JobsPackageVersion $(JobsPackageVersion) -Branch $(NuGetGalleryBranch) -CommitSHA $(Build.SourceVersion)
+                  workingFolder: $(NuGetGalleryPath)
+              - task: PowerShell@1
+                name: test
+                displayName: Run tests
+                inputs:
+                  scriptName: $(NuGetGalleryPath)\test.ps1
+                  arguments: -Configuration $(BuildConfiguration) -BuildNumber $(Build.BuildId) -SkipCommon -SkipJobs
+                  workingFolder: $(NuGetGalleryPath)
+              - task: PublishTestResults@2
+                name: publish_test_results
+                displayName: Publish test results
+                condition: succeededOrFailed()
+                inputs:
+                  testRunner: VSTest
+                  testResultsFiles: $(NuGetGalleryPath)\Results.*.xml
+                  failTaskOnFailedTests: true
+
+      - stage: statslogparser
+        displayName: StatsLogPasrser
+        dependsOn: []
+        jobs:
+          - job: build_and_test
+            displayName: statslogparser build and test
+            cancelTimeoutInMinutes: 1
+            variables:
+              PIPX_HOME: $(Agent.ToolsDirectory)\pipx
+            steps:
+              - checkout: self
+                fetchDepth: 1
+                clean: true
+                fetchTags: false
+                path: $(NuGetGalleryDirectory)
+              - task: UsePythonVersion@0
+                inputs:
+                  versionSpec: '3.10'
+              - script: |
+                  python -m pip install --user pipx
+                  pipx ensurepath
+                displayName: 'Install tools'
+              - script: |
+                  pipx install poetry
+                  poetry install
+                  poetry build
+                  poetry run pytest tests/ --cov loginterpretation --cov-report html
+                workingDirectory: $(NuGetGalleryPath)\python\StatsLogParser
+            templateContext:
+              outputs:
+                - output: pipelineArtifact
+                  path: $(NuGetGalleryPath)\python\StatsLogParser\dist
+                  artifact: StatsLogParser
+
+      - stage: jobs
+        displayName: NuGet.Jobs.sln
+        dependsOn: []
+        jobs:
+          - job: build_and_test
+            displayName: jobs build and test
+            cancelTimeoutInMinutes: 1
+            steps:
+              - checkout: self
+                fetchDepth: 1
+                clean: true
+                fetchTags: false
+                path: $(NuGetGalleryDirectory)
+              - task: PowerShell@1
+                name: build
+                displayName: Build
+                inputs:
+                  scriptName: $(NuGetGalleryPath)\build.ps1
+                  arguments: -Configuration $(BuildConfiguration) -BuildNumber $(Build.BuildId) -SkipArtifacts -SkipCommon -SkipGallery -CommonAssemblyVersion $(CommonAssemblyVersion) -CommonPackageVersion $(CommonPackageVersion) -GalleryAssemblyVersion $(GalleryAssemblyVersion) -GalleryPackageVersion $(GalleryPackageVersion) -JobsAssemblyVersion $(JobsAssemblyVersion) -JobsPackageVersion $(JobsPackageVersion) -Branch $(NuGetGalleryBranch) -CommitSHA $(Build.SourceVersion)
+                  workingFolder: $(NuGetGalleryPath)
+              - task: PowerShell@1
+                name: test
+                displayName: Run tests
+                inputs:
+                  scriptName: $(NuGetGalleryPath)\test.ps1
+                  arguments: -Configuration $(BuildConfiguration) -BuildNumber $(Build.BuildId) -SkipCommon -SkipGallery
+                  workingFolder: $(NuGetGalleryPath)
+              - task: PublishTestResults@2
+                name: publish_test_results
+                displayName: Publish test results
+                condition: succeededOrFailed()
+                inputs:
+                  testRunner: VSTest
+                  testResultsFiles: $(NuGetGalleryPath)\Results.*.xml
+                  failTaskOnFailedTests: true
+
+      - stage: artifacts
+        displayName: Artifacts
+        dependsOn: []
+        jobs:
+          - job: build_artifacts
+            displayName: build
+            cancelTimeoutInMinutes: 1
+            steps:
+              - checkout: self
+                fetchDepth: 1
+                clean: true
+                fetchTags: false
+                path: $(NuGetGalleryDirectory)
+              - task: PowerShell@1
+                name: build_artifacts
+                displayName: Build
+                inputs:
+                  scriptName: $(NuGetGalleryPath)\build.ps1
+                  arguments: -Configuration $(BuildConfiguration) -BuildNumber $(Build.BuildId) -CommonAssemblyVersion $(CommonAssemblyVersion) -CommonPackageVersion $(CommonPackageVersion) -GalleryAssemblyVersion $(GalleryAssemblyVersion) -GalleryPackageVersion $(GalleryPackageVersion) -JobsAssemblyVersion $(JobsAssemblyVersion) -JobsPackageVersion $(JobsPackageVersion) -Branch $(NuGetGalleryBranch) -CommitSHA $(Build.SourceVersion)
+                  workingFolder: $(NuGetGalleryPath)

--- a/.pipelines/NuGetGallery-CI-dnceng.yml
+++ b/.pipelines/NuGetGallery-CI-dnceng.yml
@@ -3,8 +3,14 @@ name: NuGetGallery CI $(Build.BuildId)
 trigger:
   branches:
     include:
-      - "*"
+      - main
+      - dev
   batch: True
+
+pr:
+  branches:
+    include:
+      - "*"
 
 variables:
   - name: BuildConfiguration

--- a/.pipelines/NuGetGallery-CI-dnceng.yml
+++ b/.pipelines/NuGetGallery-CI-dnceng.yml
@@ -41,182 +41,169 @@ resources:
     - repository: self
       type: git
       ref: refs/heads/main
-    - repository: 1ESPipelineTemplates
-      type: git
-      name: 1ESPipelineTemplates/1ESPipelineTemplates
-      ref: refs/tags/release
 
-extends:
-  template: v1/1ES.Unofficial.PipelineTemplate.yml@1ESPipelineTemplates
-  parameters:
-    settings:
-      networkIsolationPolicy: Permissive
-    pool:
-      name: NuGet-1ES-Hosted-Pool
-      image: NuGet-1ESPT-Win2022
-      os: windows
-    customBuildTags:
-      - ES365AIMigrationTooling
-    stages:
-      - stage: common
-        displayName: NuGet.Server.Common.sln
-        dependsOn: []
-        jobs:
-          - job: build_and_test
-            displayName: common build and test
-            cancelTimeoutInMinutes: 1
-            steps:
-              - checkout: self
-                fetchDepth: 1
-                clean: true
-                fetchTags: false
-                path: $(NuGetGalleryDirectory)
-              - task: PowerShell@1
-                name: build
-                displayName: Build
-                inputs:
-                  scriptName: $(NuGetGalleryPath)\build.ps1
-                  arguments: -Configuration $(BuildConfiguration) -BuildNumber $(Build.BuildId) -SkipArtifacts -SkipGallery -SkipJobs -CommonAssemblyVersion $(CommonAssemblyVersion) -CommonPackageVersion $(CommonPackageVersion) -GalleryAssemblyVersion $(GalleryAssemblyVersion) -GalleryPackageVersion $(GalleryPackageVersion) -JobsAssemblyVersion $(JobsAssemblyVersion) -JobsPackageVersion $(JobsPackageVersion) -Branch $(NuGetGalleryBranch) -CommitSHA $(Build.SourceVersion)
-                  workingFolder: $(NuGetGalleryPath)
-              - task: PowerShell@1
-                name: test
-                displayName: Run tests
-                inputs:
-                  scriptName: $(NuGetGalleryPath)\test.ps1
-                  arguments: -Configuration $(BuildConfiguration) -BuildNumber $(Build.BuildId) -SkipGallery -SkipJobs
-                  workingFolder: $(NuGetGalleryPath)
-              - task: PublishTestResults@2
-                name: publish_test_results
-                displayName: Publish test results
-                condition: succeededOrFailed()
-                inputs:
-                  testRunner: VSTest
-                  testResultsFiles: $(NuGetGalleryPath)\Results.*.xml
-                  failTaskOnFailedTests: true
+pool:
+  vmImage: windows-latest
 
-      - stage: gallery
-        displayName: NuGetGallery.sln
-        dependsOn: []
-        jobs:
-          - job: build_and_test
-            displayName: gallery build and test
-            cancelTimeoutInMinutes: 1
-            steps:
-              - checkout: self
-                fetchDepth: 1
-                clean: true
-                fetchTags: false
-                path: $(NuGetGalleryDirectory)
-              - task: PowerShell@1
-                name: build
-                displayName: Build
-                inputs:
-                  scriptName: $(NuGetGalleryPath)\build.ps1
-                  arguments: -Configuration $(BuildConfiguration) -BuildNumber $(Build.BuildId) -SkipArtifacts -SkipCommon -SkipJobs -CommonAssemblyVersion $(CommonAssemblyVersion) -CommonPackageVersion $(CommonPackageVersion) -GalleryAssemblyVersion $(GalleryAssemblyVersion) -GalleryPackageVersion $(GalleryPackageVersion) -JobsAssemblyVersion $(JobsAssemblyVersion) -JobsPackageVersion $(JobsPackageVersion) -Branch $(NuGetGalleryBranch) -CommitSHA $(Build.SourceVersion)
-                  workingFolder: $(NuGetGalleryPath)
-              - task: PowerShell@1
-                name: test
-                displayName: Run tests
-                inputs:
-                  scriptName: $(NuGetGalleryPath)\test.ps1
-                  arguments: -Configuration $(BuildConfiguration) -BuildNumber $(Build.BuildId) -SkipCommon -SkipJobs
-                  workingFolder: $(NuGetGalleryPath)
-              - task: PublishTestResults@2
-                name: publish_test_results
-                displayName: Publish test results
-                condition: succeededOrFailed()
-                inputs:
-                  testRunner: VSTest
-                  testResultsFiles: $(NuGetGalleryPath)\Results.*.xml
-                  failTaskOnFailedTests: true
+stages:
+  - stage: common
+    displayName: NuGet.Server.Common.sln
+    dependsOn: []
+    jobs:
+      - job: build_and_test
+        displayName: common build and test
+        cancelTimeoutInMinutes: 1
+        steps:
+          - checkout: self
+            fetchDepth: 1
+            clean: true
+            fetchTags: false
+            path: $(NuGetGalleryDirectory)
+          - task: PowerShell@1
+            name: build
+            displayName: Build
+            inputs:
+              scriptName: $(NuGetGalleryPath)\build.ps1
+              arguments: -Configuration $(BuildConfiguration) -BuildNumber $(Build.BuildId) -SkipArtifacts -SkipGallery -SkipJobs -CommonAssemblyVersion $(CommonAssemblyVersion) -CommonPackageVersion $(CommonPackageVersion) -GalleryAssemblyVersion $(GalleryAssemblyVersion) -GalleryPackageVersion $(GalleryPackageVersion) -JobsAssemblyVersion $(JobsAssemblyVersion) -JobsPackageVersion $(JobsPackageVersion) -Branch $(NuGetGalleryBranch) -CommitSHA $(Build.SourceVersion)
+              workingFolder: $(NuGetGalleryPath)
+          - task: PowerShell@1
+            name: test
+            displayName: Run tests
+            inputs:
+              scriptName: $(NuGetGalleryPath)\test.ps1
+              arguments: -Configuration $(BuildConfiguration) -BuildNumber $(Build.BuildId) -SkipGallery -SkipJobs
+              workingFolder: $(NuGetGalleryPath)
+          - task: PublishTestResults@2
+            name: publish_test_results
+            displayName: Publish test results
+            condition: succeededOrFailed()
+            inputs:
+              testRunner: VSTest
+              testResultsFiles: $(NuGetGalleryPath)\Results.*.xml
+              failTaskOnFailedTests: true
 
-      - stage: statslogparser
-        displayName: StatsLogPasrser
-        dependsOn: []
-        jobs:
-          - job: build_and_test
-            displayName: statslogparser build and test
-            cancelTimeoutInMinutes: 1
-            variables:
-              PIPX_HOME: $(Agent.ToolsDirectory)\pipx
-            steps:
-              - checkout: self
-                fetchDepth: 1
-                clean: true
-                fetchTags: false
-                path: $(NuGetGalleryDirectory)
-              - task: UsePythonVersion@0
-                inputs:
-                  versionSpec: '3.10'
-              - script: |
-                  python -m pip install --user pipx
-                  pipx ensurepath
-                displayName: 'Install tools'
-              - script: |
-                  pipx install poetry
-                  poetry install
-                  poetry build
-                  poetry run pytest tests/ --cov loginterpretation --cov-report html
-                workingDirectory: $(NuGetGalleryPath)\python\StatsLogParser
-            templateContext:
-              outputs:
-                - output: pipelineArtifact
-                  path: $(NuGetGalleryPath)\python\StatsLogParser\dist
-                  artifact: StatsLogParser
+  - stage: gallery
+    displayName: NuGetGallery.sln
+    dependsOn: []
+    jobs:
+      - job: build_and_test
+        displayName: gallery build and test
+        cancelTimeoutInMinutes: 1
+        steps:
+          - checkout: self
+            fetchDepth: 1
+            clean: true
+            fetchTags: false
+            path: $(NuGetGalleryDirectory)
+          - task: PowerShell@1
+            name: build
+            displayName: Build
+            inputs:
+              scriptName: $(NuGetGalleryPath)\build.ps1
+              arguments: -Configuration $(BuildConfiguration) -BuildNumber $(Build.BuildId) -SkipArtifacts -SkipCommon -SkipJobs -CommonAssemblyVersion $(CommonAssemblyVersion) -CommonPackageVersion $(CommonPackageVersion) -GalleryAssemblyVersion $(GalleryAssemblyVersion) -GalleryPackageVersion $(GalleryPackageVersion) -JobsAssemblyVersion $(JobsAssemblyVersion) -JobsPackageVersion $(JobsPackageVersion) -Branch $(NuGetGalleryBranch) -CommitSHA $(Build.SourceVersion)
+              workingFolder: $(NuGetGalleryPath)
+          - task: PowerShell@1
+            name: test
+            displayName: Run tests
+            inputs:
+              scriptName: $(NuGetGalleryPath)\test.ps1
+              arguments: -Configuration $(BuildConfiguration) -BuildNumber $(Build.BuildId) -SkipCommon -SkipJobs
+              workingFolder: $(NuGetGalleryPath)
+          - task: PublishTestResults@2
+            name: publish_test_results
+            displayName: Publish test results
+            condition: succeededOrFailed()
+            inputs:
+              testRunner: VSTest
+              testResultsFiles: $(NuGetGalleryPath)\Results.*.xml
+              failTaskOnFailedTests: true
 
-      - stage: jobs
-        displayName: NuGet.Jobs.sln
-        dependsOn: []
-        jobs:
-          - job: build_and_test
-            displayName: jobs build and test
-            cancelTimeoutInMinutes: 1
-            steps:
-              - checkout: self
-                fetchDepth: 1
-                clean: true
-                fetchTags: false
-                path: $(NuGetGalleryDirectory)
-              - task: PowerShell@1
-                name: build
-                displayName: Build
-                inputs:
-                  scriptName: $(NuGetGalleryPath)\build.ps1
-                  arguments: -Configuration $(BuildConfiguration) -BuildNumber $(Build.BuildId) -SkipArtifacts -SkipCommon -SkipGallery -CommonAssemblyVersion $(CommonAssemblyVersion) -CommonPackageVersion $(CommonPackageVersion) -GalleryAssemblyVersion $(GalleryAssemblyVersion) -GalleryPackageVersion $(GalleryPackageVersion) -JobsAssemblyVersion $(JobsAssemblyVersion) -JobsPackageVersion $(JobsPackageVersion) -Branch $(NuGetGalleryBranch) -CommitSHA $(Build.SourceVersion)
-                  workingFolder: $(NuGetGalleryPath)
-              - task: PowerShell@1
-                name: test
-                displayName: Run tests
-                inputs:
-                  scriptName: $(NuGetGalleryPath)\test.ps1
-                  arguments: -Configuration $(BuildConfiguration) -BuildNumber $(Build.BuildId) -SkipCommon -SkipGallery
-                  workingFolder: $(NuGetGalleryPath)
-              - task: PublishTestResults@2
-                name: publish_test_results
-                displayName: Publish test results
-                condition: succeededOrFailed()
-                inputs:
-                  testRunner: VSTest
-                  testResultsFiles: $(NuGetGalleryPath)\Results.*.xml
-                  failTaskOnFailedTests: true
+  - stage: statslogparser
+    displayName: StatsLogPasrser
+    dependsOn: []
+    jobs:
+      - job: build_and_test
+        displayName: statslogparser build and test
+        cancelTimeoutInMinutes: 1
+        variables:
+          PIPX_HOME: $(Agent.ToolsDirectory)\pipx
+        steps:
+          - checkout: self
+            fetchDepth: 1
+            clean: true
+            fetchTags: false
+            path: $(NuGetGalleryDirectory)
+          - task: UsePythonVersion@0
+            inputs:
+              versionSpec: '3.10'
+          - script: |
+              python -m pip install --user pipx
+              pipx ensurepath
+            displayName: 'Install tools'
+          - script: |
+              pipx install poetry
+              poetry install
+              poetry build
+              poetry run pytest tests/ --cov loginterpretation --cov-report html
+            workingDirectory: $(NuGetGalleryPath)\python\StatsLogParser
+          - task: PublishPipelineArtifact@1
+            inputs:
+              targetPath: $(NuGetGalleryPath)\python\StatsLogParser\dist
+              artifact: StatsLogParser
 
-      - stage: artifacts
-        displayName: Artifacts
-        dependsOn: []
-        jobs:
-          - job: build_artifacts
-            displayName: build
-            cancelTimeoutInMinutes: 1
-            steps:
-              - checkout: self
-                fetchDepth: 1
-                clean: true
-                fetchTags: false
-                path: $(NuGetGalleryDirectory)
-              - task: PowerShell@1
-                name: build_artifacts
-                displayName: Build
-                inputs:
-                  scriptName: $(NuGetGalleryPath)\build.ps1
-                  arguments: -Configuration $(BuildConfiguration) -BuildNumber $(Build.BuildId) -CommonAssemblyVersion $(CommonAssemblyVersion) -CommonPackageVersion $(CommonPackageVersion) -GalleryAssemblyVersion $(GalleryAssemblyVersion) -GalleryPackageVersion $(GalleryPackageVersion) -JobsAssemblyVersion $(JobsAssemblyVersion) -JobsPackageVersion $(JobsPackageVersion) -Branch $(NuGetGalleryBranch) -CommitSHA $(Build.SourceVersion)
-                  workingFolder: $(NuGetGalleryPath)
+  - stage: jobs
+    displayName: NuGet.Jobs.sln
+    dependsOn: []
+    jobs:
+      - job: build_and_test
+        displayName: jobs build and test
+        cancelTimeoutInMinutes: 1
+        steps:
+          - checkout: self
+            fetchDepth: 1
+            clean: true
+            fetchTags: false
+            path: $(NuGetGalleryDirectory)
+          - task: PowerShell@1
+            name: build
+            displayName: Build
+            inputs:
+              scriptName: $(NuGetGalleryPath)\build.ps1
+              arguments: -Configuration $(BuildConfiguration) -BuildNumber $(Build.BuildId) -SkipArtifacts -SkipCommon -SkipGallery -CommonAssemblyVersion $(CommonAssemblyVersion) -CommonPackageVersion $(CommonPackageVersion) -GalleryAssemblyVersion $(GalleryAssemblyVersion) -GalleryPackageVersion $(GalleryPackageVersion) -JobsAssemblyVersion $(JobsAssemblyVersion) -JobsPackageVersion $(JobsPackageVersion) -Branch $(NuGetGalleryBranch) -CommitSHA $(Build.SourceVersion)
+              workingFolder: $(NuGetGalleryPath)
+          - task: PowerShell@1
+            name: test
+            displayName: Run tests
+            inputs:
+              scriptName: $(NuGetGalleryPath)\test.ps1
+              arguments: -Configuration $(BuildConfiguration) -BuildNumber $(Build.BuildId) -SkipCommon -SkipGallery
+              workingFolder: $(NuGetGalleryPath)
+          - task: PublishTestResults@2
+            name: publish_test_results
+            displayName: Publish test results
+            condition: succeededOrFailed()
+            inputs:
+              testRunner: VSTest
+              testResultsFiles: $(NuGetGalleryPath)\Results.*.xml
+              failTaskOnFailedTests: true
+
+  - stage: artifacts
+    displayName: Artifacts
+    dependsOn: []
+    jobs:
+      - job: build_artifacts
+        displayName: build
+        cancelTimeoutInMinutes: 1
+        steps:
+          - checkout: self
+            fetchDepth: 1
+            clean: true
+            fetchTags: false
+            path: $(NuGetGalleryDirectory)
+          - task: PowerShell@1
+            name: build_artifacts
+            displayName: Build
+            inputs:
+              scriptName: $(NuGetGalleryPath)\build.ps1
+              arguments: -Configuration $(BuildConfiguration) -BuildNumber $(Build.BuildId) -CommonAssemblyVersion $(CommonAssemblyVersion) -CommonPackageVersion $(CommonPackageVersion) -GalleryAssemblyVersion $(GalleryAssemblyVersion) -GalleryPackageVersion $(GalleryPackageVersion) -JobsAssemblyVersion $(JobsAssemblyVersion) -JobsPackageVersion $(JobsPackageVersion) -Branch $(NuGetGalleryBranch) -CommitSHA $(Build.SourceVersion)
+              workingFolder: $(NuGetGalleryPath)

--- a/.pipelines/NuGetGallery-CI-dnceng.yml
+++ b/.pipelines/NuGetGallery-CI-dnceng.yml
@@ -43,7 +43,8 @@ resources:
       ref: refs/heads/main
 
 pool:
-  name: NetCore-Public
+  name: $(DncEngPublicBuildPool)
+  demands: ImageOverride -equals windows.vs2026.amd64.open
 
 stages:
   - stage: common

--- a/.pipelines/NuGetGallery-CI-dnceng.yml
+++ b/.pipelines/NuGetGallery-CI-dnceng.yml
@@ -60,6 +60,11 @@ stages:
             clean: true
             fetchTags: false
             path: $(NuGetGalleryDirectory)
+          - task: UseDotNet@2
+            displayName: Install .NET 8.0 SDK
+            inputs:
+              packageType: sdk
+              version: 8.0.x
           - task: PowerShell@1
             name: build
             displayName: Build
@@ -96,6 +101,11 @@ stages:
             clean: true
             fetchTags: false
             path: $(NuGetGalleryDirectory)
+          - task: UseDotNet@2
+            displayName: Install .NET 8.0 SDK
+            inputs:
+              packageType: sdk
+              version: 8.0.x
           - task: PowerShell@1
             name: build
             displayName: Build
@@ -165,6 +175,11 @@ stages:
             clean: true
             fetchTags: false
             path: $(NuGetGalleryDirectory)
+          - task: UseDotNet@2
+            displayName: Install .NET 8.0 SDK
+            inputs:
+              packageType: sdk
+              version: 8.0.x
           - task: PowerShell@1
             name: build
             displayName: Build
@@ -201,6 +216,11 @@ stages:
             clean: true
             fetchTags: false
             path: $(NuGetGalleryDirectory)
+          - task: UseDotNet@2
+            displayName: Install .NET 8.0 SDK
+            inputs:
+              packageType: sdk
+              version: 8.0.x
           - task: PowerShell@1
             name: build_artifacts
             displayName: Build

--- a/.pipelines/NuGetGallery-CI-dnceng.yml
+++ b/.pipelines/NuGetGallery-CI-dnceng.yml
@@ -149,13 +149,12 @@ stages:
               versionSpec: '3.10'
           - script: |
               python -m pip install --user pipx
-              pipx ensurepath
-            displayName: 'Install tools'
-          - script: |
+              set PATH=%USERPROFILE%\.local\bin;%PATH%
               pipx install poetry
               poetry install
               poetry build
               poetry run pytest tests/ --cov loginterpretation --cov-report html
+            displayName: 'Install tools and run tests'
             workingDirectory: $(NuGetGalleryPath)\python\StatsLogParser
           - task: PublishPipelineArtifact@1
             inputs:

--- a/.pipelines/NuGetGallery-CI-dnceng.yml
+++ b/.pipelines/NuGetGallery-CI-dnceng.yml
@@ -43,7 +43,7 @@ resources:
       ref: refs/heads/main
 
 pool:
-  vmImage: windows-latest
+  name: NetCore-Public
 
 stages:
   - stage: common

--- a/.pipelines/NuGetGallery-CI-dnceng.yml
+++ b/.pipelines/NuGetGallery-CI-dnceng.yml
@@ -43,7 +43,7 @@ resources:
       ref: refs/heads/main
 
 pool:
-  name: $(DncEngPublicBuildPool)
+  name: NetCore-Public
   demands: ImageOverride -equals windows.vs2026.amd64.open
 
 stages:


### PR DESCRIPTION
I want a separate pipeline so I can iterate independently from the existing CI pipeline, for now.
The content is just copied from the existing CI pipeline.

This is working now here:
https://dev.azure.com/dnceng-public/public/_build/results?buildId=1384246&view=results