### PR TITLE
[ST] 7. Update minIntervalBeforeToReadUpdate

### DIFF
--- a/src/Catalog/Dnx/DnxConstants.cs
+++ b/src/Catalog/Dnx/DnxConstants.cs
@@ -25,7 +25,7 @@ namespace NuGet.Services.Metadata.Catalog.Dnx
         public static readonly TimeSpan CacheDurationOfPackageVersionIndex = TimeSpan.FromSeconds(60);
 
         // Front Cursor with Updates
-        // (MaxNumberOfUpdatesToKeepOfFrontCursor - 1) * MinIntervalBetweenTwoUpdatesOfFrontCursor > CacheDurationOfPackageVersionIndex
+        // (MaxNumberOfUpdatesToKeepOfFrontCursor - 1) * MinIntervalBetweenTwoUpdatesOfFrontCursor > CacheDurationOfPackageVersionIndex + 1
         public const int MaxNumberOfUpdatesToKeepOfFrontCursor = 31;
         public static readonly TimeSpan MinIntervalBetweenTwoUpdatesOfFrontCursor = TimeSpan.FromSeconds(60);
     }

--- a/src/Catalog/Dnx/DnxConstants.cs
+++ b/src/Catalog/Dnx/DnxConstants.cs
@@ -25,8 +25,10 @@ namespace NuGet.Services.Metadata.Catalog.Dnx
         public static readonly TimeSpan CacheDurationOfPackageVersionIndex = TimeSpan.FromSeconds(60);
 
         // Front Cursor with Updates
-        // (MaxNumberOfUpdatesToKeepOfFrontCursor - 1) * MinIntervalBetweenTwoUpdatesOfFrontCursor > CacheDurationOfPackageVersionIndex + 1
+        // (MaxNumberOfUpdatesToKeepOfFrontCursor - 1) * MinIntervalBetweenTwoUpdatesOfFrontCursor > MinIntervalBeforeToReadUpdateOfFrontCursor
         public const int MaxNumberOfUpdatesToKeepOfFrontCursor = 31;
         public static readonly TimeSpan MinIntervalBetweenTwoUpdatesOfFrontCursor = TimeSpan.FromSeconds(60);
+        // MinIntervalBeforeToReadUpdateOfFrontCursor >= CacheDurationOfPackageVersionIndex + 1 second
+        public static readonly TimeSpan MinIntervalBeforeToReadUpdateOfFrontCursor = CacheDurationOfPackageVersionIndex + TimeSpan.FromSeconds(1);
     }
 }

--- a/src/Ng/Jobs/Catalog2DnxJob.cs
+++ b/src/Ng/Jobs/Catalog2DnxJob.cs
@@ -103,7 +103,7 @@ namespace Ng.Jobs
             var storage = storageFactory.Create();
             _front = new DurableCursorWithUpdates(storage.ResolveUri("cursor.json"), storage, MemoryCursor.MinValue, Logger,
                 DnxConstants.MaxNumberOfUpdatesToKeepOfFrontCursor, DnxConstants.MinIntervalBetweenTwoUpdatesOfFrontCursor,
-                minIntervalBeforeToReadUpdate: DnxConstants.CacheDurationOfPackageVersionIndex + TimeSpan.FromSeconds(1));
+                minIntervalBeforeToReadUpdate: DnxConstants.MinIntervalBeforeToReadUpdateOfFrontCursor);
             _back = MemoryCursor.CreateMax();
 
             _destination = storageFactory.BaseAddress;

--- a/tests/CatalogTests/Dnx/DnxConstantsTests.cs
+++ b/tests/CatalogTests/Dnx/DnxConstantsTests.cs
@@ -18,7 +18,8 @@ namespace CatalogTests.Dnx
                 totalTimeSpan += DnxConstants.MinIntervalBetweenTwoUpdatesOfFrontCursor;
             }
 
-            Assert.True(totalTimeSpan > DnxConstants.CacheDurationOfPackageVersionIndex + TimeSpan.FromSeconds(1));
+            Assert.True(totalTimeSpan > DnxConstants.MinIntervalBeforeToReadUpdateOfFrontCursor);
+            Assert.True(DnxConstants.MinIntervalBeforeToReadUpdateOfFrontCursor >= DnxConstants.CacheDurationOfPackageVersionIndex + TimeSpan.FromSeconds(1));
         }
     }
 }

--- a/tests/CatalogTests/Dnx/DnxConstantsTests.cs
+++ b/tests/CatalogTests/Dnx/DnxConstantsTests.cs
@@ -18,7 +18,7 @@ namespace CatalogTests.Dnx
                 totalTimeSpan += DnxConstants.MinIntervalBetweenTwoUpdatesOfFrontCursor;
             }
 
-            Assert.True(totalTimeSpan > DnxConstants.CacheDurationOfPackageVersionIndex);
+            Assert.True(totalTimeSpan > DnxConstants.CacheDurationOfPackageVersionIndex + TimeSpan.FromSeconds(1));
         }
     }
 }


### PR DESCRIPTION
1. Place the value of `MinIntervalBeforeToReadUpdateOfFrontCursor` into `DnxConstants.cs`.
2. Update the test and ensure that `totalTimeSpan` is larger than `DnxConstants.CacheDurationOfPackageVersionIndex + TimeSpan.FromSeconds(1)`, not just `DnxConstants.CacheDurationOfPackageVersionIndex`.