### PR TITLE
Enrich user-centric telemetry with Username and AccountKey

### DIFF
--- a/src/GitHubVulnerabilities2Db/Gallery/ThrowingTelemetryService.cs
+++ b/src/GitHubVulnerabilities2Db/Gallery/ThrowingTelemetryService.cs
@@ -41,7 +41,7 @@ namespace GitHubVulnerabilities2Db.Gallery
             throw new NotImplementedException();
         }
 
-        public void TrackCertificateActivated(string thumbprint)
+        public void TrackCertificateActivated(string thumbprint, User account)
         {
             throw new NotImplementedException();
         }
@@ -51,7 +51,7 @@ namespace GitHubVulnerabilities2Db.Gallery
             throw new NotImplementedException();
         }
 
-        public void TrackCertificateDeactivated(string thumbprint)
+        public void TrackCertificateDeactivated(string thumbprint, User account)
         {
             throw new NotImplementedException();
         }
@@ -371,7 +371,7 @@ namespace GitHubVulnerabilities2Db.Gallery
             throw new NotImplementedException();
         }
 
-        public void TrackUserPackageDeleteExecuted(int packageKey, string packageId, string packageVersion, ReportPackageReason reason, bool success)
+        public void TrackUserPackageDeleteExecuted(int packageKey, string packageId, string packageVersion, ReportPackageReason reason, bool success, User user)
         {
             throw new NotImplementedException();
         }

--- a/src/NuGetGallery.Services/Telemetry/ITelemetryService.cs
+++ b/src/NuGetGallery.Services/Telemetry/ITelemetryService.cs
@@ -92,7 +92,7 @@ namespace NuGetGallery
         /// <summary>
         /// A telemetry event emitted when a user package delete is executed.
         /// </summary>
-        void TrackUserPackageDeleteExecuted(int packageKey, string packageId, string packageVersion, ReportPackageReason reason, bool success);
+        void TrackUserPackageDeleteExecuted(int packageKey, string packageId, string packageVersion, ReportPackageReason reason, bool success, User user);
 
         /// <summary>
         /// A telemetry event emitted when a certificate is added to the database.
@@ -113,17 +113,19 @@ namespace NuGetGallery
         /// A telemetry event emitted when a certificate is activated for an account.
         /// </summary>
         /// <param name="thumbprint">The certificate thumbprint.</param>
+        /// <param name="account">The <see cref="User"/> whose certificate is being activated.</param>
         /// <exception cref="ArgumentException">Thrown if <paramref name="thumbprint" /> is <c>null</c>
         /// or empty.</exception>
-        void TrackCertificateActivated(string thumbprint);
+        void TrackCertificateActivated(string thumbprint, User account);
 
         /// <summary>
         /// A telemetry event emitted when a certificate is deactivated for an account.
         /// </summary>
         /// <param name="thumbprint">The certificate thumbprint.</param>
+        /// <param name="account">The <see cref="User"/> whose certificate is being deactivated.</param>
         /// <exception cref="ArgumentException">Thrown if <paramref name="thumbprint" /> is <c>null</c>
         /// or empty.</exception>
-        void TrackCertificateDeactivated(string thumbprint);
+        void TrackCertificateDeactivated(string thumbprint, User account);
 
         /// <summary>
         /// A telemetry event emitted when the required signer is set on a package registration.

--- a/src/NuGetGallery.Services/Telemetry/TelemetryService.cs
+++ b/src/NuGetGallery.Services/Telemetry/TelemetryService.cs
@@ -189,6 +189,17 @@ namespace NuGetGallery
         public const string AccountDeletedIsOrganization = "AccountDeletedIsOrganization";
         public const string CreatedDateForAccountToBeDeleted = "CreatedDateForAccountToBeDeleted";
         public const string AccountDeleteSucceeded = "AccountDeleteSucceeded";
+        public const string DeletedUsername = "DeletedUsername";
+        public const string DeletedByUsername = "DeletedByUsername";
+        public const string DeletedAccountKey = "DeletedAccountKey";
+        public const string DeletedByAccountKey = "DeletedByAccountKey";
+
+        // User properties
+        public const string Username = "Username";
+        public const string AccountKey = "AccountKey";
+
+        // Organization user properties
+        public const string OrganizationUsername = "OrganizationUsername";
 
         // Package metadata compliance properties
         public const string ComplianceFailures = "ComplianceFailures";
@@ -454,7 +465,7 @@ namespace NuGetGallery
             });
         }
 
-        public void TrackUserPackageDeleteExecuted(int packageKey, string packageId, string packageVersion, ReportPackageReason reason, bool success)
+        public void TrackUserPackageDeleteExecuted(int packageKey, string packageId, string packageVersion, ReportPackageReason reason, bool success, User user)
         {
             if (packageId == null)
             {
@@ -466,6 +477,11 @@ namespace NuGetGallery
                 throw new ArgumentNullException(nameof(packageVersion));
             }
 
+            if (user == null)
+            {
+                throw new ArgumentNullException(nameof(user));
+            }
+
             TrackMetric(Events.UserPackageDeleteExecuted, 1, properties =>
             {
                 properties.Add(PackageKey, packageKey.ToString());
@@ -473,6 +489,8 @@ namespace NuGetGallery
                 properties.Add(PackageVersion, packageVersion);
                 properties.Add(ReportPackageReason, reason.ToString());
                 properties.Add(Success, success.ToString());
+                properties.Add(Username, user.Username);
+                properties.Add(AccountKey, user.Key.ToString());
             });
         }
 
@@ -583,14 +601,14 @@ namespace NuGetGallery
             TrackMetricForCertificateActivity(Events.CertificateAdded, thumbprint);
         }
 
-        public void TrackCertificateActivated(string thumbprint)
+        public void TrackCertificateActivated(string thumbprint, User account)
         {
-            TrackMetricForCertificateActivity(Events.CertificateActivated, thumbprint);
+            TrackMetricForCertificateActivity(Events.CertificateActivated, thumbprint, account);
         }
 
-        public void TrackCertificateDeactivated(string thumbprint)
+        public void TrackCertificateDeactivated(string thumbprint, User account)
         {
-            TrackMetricForCertificateActivity(Events.CertificateDeactivated, thumbprint);
+            TrackMetricForCertificateActivity(Events.CertificateDeactivated, thumbprint, account);
         }
 
         public void TrackRequiredSignerSet(string packageId)
@@ -669,6 +687,26 @@ namespace NuGetGallery
             TrackMetric(eventName, 1, properties =>
             {
                 properties.Add(Sha256Thumbprint, thumbprint);
+            });
+        }
+
+        private void TrackMetricForCertificateActivity(string eventName, string thumbprint, User account)
+        {
+            if (string.IsNullOrEmpty(thumbprint))
+            {
+                throw new ArgumentException(ServicesStrings.ArgumentCannotBeNullOrEmpty, nameof(thumbprint));
+            }
+
+            if (account == null)
+            {
+                throw new ArgumentNullException(nameof(account));
+            }
+
+            TrackMetric(eventName, 1, properties =>
+            {
+                properties.Add(Sha256Thumbprint, thumbprint);
+                properties.Add(Username, account.Username);
+                properties.Add(AccountKey, account.Key.ToString());
             });
         }
         private static string GetClientVersion()
@@ -863,6 +901,7 @@ namespace NuGetGallery
             TrackMetric(metricName, 1, properties =>
             {
                 properties.Add(OrganizationAccountKey, user.Key.ToString());
+                properties.Add(OrganizationUsername, user.Username);
                 properties.Add(AccountCreationDate, GetAccountCreationDate(user));
                 properties.Add(OrganizationIsRestrictedToOrganizationTenantPolicy, user.IsRestrictedToOrganizationTenantPolicy().ToString());
                 addProperties?.Invoke(properties);
@@ -911,6 +950,10 @@ namespace NuGetGallery
                 properties.Add(AccountIsSelfDeleted, $"{deletedUser.Key == deletedBy.Key}");
                 properties.Add(AccountDeletedIsOrganization, $"{deletedUser is Organization}");
                 properties.Add(AccountDeleteSucceeded, $"{success}");
+                properties.Add(DeletedUsername, deletedUser.Username);
+                properties.Add(DeletedByUsername, deletedBy.Username);
+                properties.Add(DeletedAccountKey, deletedUser.Key.ToString());
+                properties.Add(DeletedByAccountKey, deletedBy.Key.ToString());
             });
         }
 
@@ -924,6 +967,8 @@ namespace NuGetGallery
             TrackMetric(Events.AccountDeleteRequested, 1, properties =>
             {
                 properties.Add(CreatedDateForAccountToBeDeleted, $"{user.CreatedUtc}");
+                properties.Add(Username, user.Username);
+                properties.Add(AccountKey, user.Key.ToString());
             });
         }
 

--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -1683,7 +1683,8 @@ namespace NuGetGallery
                     package.PackageRegistration.Id,
                     package.NormalizedVersion,
                     reportForm.Reason.Value,
-                    deleted);
+                    deleted,
+                    user);
             }
 
             if (!deleted)

--- a/src/NuGetGallery/Services/CertificateService.cs
+++ b/src/NuGetGallery/Services/CertificateService.cs
@@ -117,7 +117,7 @@ namespace NuGetGallery
                 await _auditingService.SaveAuditRecordAsync(
                     new CertificateAuditRecord(AuditedCertificateAction.Activate, certificate.Thumbprint));
 
-                _telemetryService.TrackCertificateActivated(thumbprint);
+                _telemetryService.TrackCertificateActivated(thumbprint, account);
             }
         }
 
@@ -151,7 +151,7 @@ namespace NuGetGallery
                 await _auditingService.SaveAuditRecordAsync(
                     new CertificateAuditRecord(AuditedCertificateAction.Deactivate, certificate.Thumbprint));
 
-                _telemetryService.TrackCertificateDeactivated(thumbprint);
+                _telemetryService.TrackCertificateDeactivated(thumbprint, account);
             }
         }
 

--- a/src/VerifyMicrosoftPackage/Fakes/FakeTelemetryService.cs
+++ b/src/VerifyMicrosoftPackage/Fakes/FakeTelemetryService.cs
@@ -38,7 +38,7 @@ namespace NuGet.VerifyMicrosoftPackage.Fakes
             throw new NotImplementedException();
         }
 
-        public void TrackCertificateActivated(string thumbprint)
+        public void TrackCertificateActivated(string thumbprint, User account)
         {
             throw new NotImplementedException();
         }
@@ -48,7 +48,7 @@ namespace NuGet.VerifyMicrosoftPackage.Fakes
             throw new NotImplementedException();
         }
 
-        public void TrackCertificateDeactivated(string thumbprint)
+        public void TrackCertificateDeactivated(string thumbprint, User account)
         {
             throw new NotImplementedException();
         }
@@ -373,7 +373,7 @@ namespace NuGet.VerifyMicrosoftPackage.Fakes
             throw new NotImplementedException();
         }
 
-        public void TrackUserPackageDeleteExecuted(int packageKey, string packageId, string packageVersion, ReportPackageReason reason, bool success)
+        public void TrackUserPackageDeleteExecuted(int packageKey, string packageId, string packageVersion, ReportPackageReason reason, bool success, User user)
         {
             throw new NotImplementedException();
         }

--- a/tests/NuGetGallery.Facts/Services/CertificateServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/CertificateServiceFacts.cs
@@ -333,7 +333,8 @@ namespace NuGetGallery.Services
                         record.Thumbprint == _sha256Thumbprint)))
                 .Returns(Task.CompletedTask);
             _telemetryService.Setup(x => x.TrackCertificateActivated(
-                It.Is<string>(thumbprint => thumbprint == _sha256Thumbprint)));
+                It.Is<string>(thumbprint => thumbprint == _sha256Thumbprint),
+                It.Is<User>(account => account == _user)));
 
             var service = GetCertificateService();
 
@@ -461,7 +462,8 @@ namespace NuGetGallery.Services
                         record.Thumbprint == _sha256Thumbprint)))
                 .Returns(Task.CompletedTask);
             _telemetryService.Setup(x => x.TrackCertificateDeactivated(
-                It.Is<string>(thumbprint => thumbprint == _sha256Thumbprint)));
+                It.Is<string>(thumbprint => thumbprint == _sha256Thumbprint),
+                It.Is<User>(account => account == _user)));
 
             var service = GetCertificateService();
 

--- a/tests/NuGetGallery.Facts/Services/TelemetryServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/TelemetryServiceFacts.cs
@@ -45,7 +45,7 @@ namespace NuGetGallery
                     var package = packages.First();
                     var identity = Fakes.ToIdentity(fakes.User);
                     yield return new object[] { "CertificateActivated",
-                        (TrackAction)(s => s.TrackCertificateActivated("thumbprint"))
+                        (TrackAction)(s => s.TrackCertificateActivated("thumbprint", fakes.User))
                     };
 
                     yield return new object[] { "CertificateAdded",
@@ -53,7 +53,7 @@ namespace NuGetGallery
                     };
 
                     yield return new object[] { "CertificateDeactivated",
-                        (TrackAction)(s => s.TrackCertificateDeactivated("thumbprint"))
+                        (TrackAction)(s => s.TrackCertificateDeactivated("thumbprint", fakes.User))
                     };
 
                     yield return new object[] { "PackageRegistrationRequiredSignerSet",
@@ -201,7 +201,8 @@ namespace NuGetGallery
                             "NuGet.Versioning",
                             "4.5.0",
                             ReportPackageReason.ReleasedInPublicByAccident,
-                            success: true))
+                            success: true,
+                            user: fakes.User))
                     };
 
                     yield return new object[] { "OrganizationTransformInitiated",
@@ -539,7 +540,8 @@ namespace NuGetGallery
                         packageId: null,
                         packageVersion: "4.5.0",
                         reason: ReportPackageReason.ReleasedInPublicByAccident,
-                        success: true));
+                        success: true,
+                        user: fakes.User));
             }
 
             [Fact]
@@ -555,7 +557,8 @@ namespace NuGetGallery
                         packageId: "NuGet.Versioning",
                         packageVersion: null,
                         reason: ReportPackageReason.ReleasedInPublicByAccident,
-                        success: true));
+                        success: true,
+                        user: fakes.User));
             }
 
             [Fact]
@@ -645,7 +648,7 @@ namespace NuGetGallery
             {
                 var service = CreateService();
                 var exception = Assert.Throws<ArgumentException>(
-                    () => service.TrackCertificateActivated(thumbprint));
+                    () => service.TrackCertificateActivated(thumbprint, fakes.User));
 
                 Assert.Equal("thumbprint", exception.ParamName);
                 Assert.StartsWith("The argument cannot be null or empty.", exception.Message);
@@ -656,9 +659,19 @@ namespace NuGetGallery
             {
                 const string thumbprint = "a";
 
-                var service = CreateServiceForCertificateTelemetry("CertificateActivated", thumbprint);
+                var service = CreateService();
 
-                service.TrackCertificateActivated(thumbprint);
+                service.TelemetryClient.Setup(
+                   x => x.TrackMetric(
+                       It.Is<string>(name => name == "CertificateActivated"),
+                       It.Is<double>(value => value == 1),
+                       It.Is<IDictionary<string, string>>(
+                           properties => properties.Count == 3 &&
+                               properties["Sha256Thumbprint"] == thumbprint &&
+                               properties["Username"] == fakes.User.Username &&
+                               properties["AccountKey"] == fakes.User.Key.ToString())));
+
+                service.TrackCertificateActivated(thumbprint, fakes.User);
 
                 service.TelemetryClient.VerifyAll();
             }
@@ -670,7 +683,7 @@ namespace NuGetGallery
             {
                 var service = CreateService();
                 var exception = Assert.Throws<ArgumentException>(
-                    () => service.TrackCertificateDeactivated(thumbprint));
+                    () => service.TrackCertificateDeactivated(thumbprint, fakes.User));
 
                 Assert.Equal("thumbprint", exception.ParamName);
                 Assert.StartsWith("The argument cannot be null or empty.", exception.Message);
@@ -681,9 +694,19 @@ namespace NuGetGallery
             {
                 const string thumbprint = "a";
 
-                var service = CreateServiceForCertificateTelemetry("CertificateDeactivated", thumbprint);
+                var service = CreateService();
 
-                service.TrackCertificateDeactivated(thumbprint);
+                service.TelemetryClient.Setup(
+                   x => x.TrackMetric(
+                       It.Is<string>(name => name == "CertificateDeactivated"),
+                       It.Is<double>(value => value == 1),
+                       It.Is<IDictionary<string, string>>(
+                           properties => properties.Count == 3 &&
+                               properties["Sha256Thumbprint"] == thumbprint &&
+                               properties["Username"] == fakes.User.Username &&
+                               properties["AccountKey"] == fakes.User.Key.ToString())));
+
+                service.TrackCertificateDeactivated(thumbprint, fakes.User);
 
                 service.TelemetryClient.VerifyAll();
             }
@@ -745,11 +768,15 @@ namespace NuGetGallery
                        It.Is<string>(name => name == "AccountDeleteCompleted"),
                        It.Is<double>(value => value == 1),
                        It.Is<IDictionary<string, string>>(
-                           properties => properties.Count == 4 &&
+                           properties => properties.Count == 8 &&
                                properties["AccountDeletedByRole"] == "[\"Admins\"]" &&
                                properties["AccountIsSelfDeleted"] == "False" &&
                                properties["AccountDeletedIsOrganization"] == "True" &&
-                               properties["AccountDeleteSucceeded"] == "True")
+                               properties["AccountDeleteSucceeded"] == "True" &&
+                               properties["DeletedUsername"] == "testOrganization" &&
+                               properties["DeletedByUsername"] == "testAdmin" &&
+                               properties["DeletedAccountKey"] == fakes.Organization.Key.ToString() &&
+                               properties["DeletedByAccountKey"] == fakes.Admin.Key.ToString())
                                ));
 
                 service.TrackAccountDeletionCompleted(fakes.Organization, fakes.Admin, true);
@@ -779,8 +806,10 @@ namespace NuGetGallery
                        It.Is<string>(name => name == "AccountDeleteRequested"),
                        It.Is<double>(value => value == 1),
                        It.Is<IDictionary<string, string>>(
-                           properties => properties.Count == 1 &&
-                               properties["CreatedDateForAccountToBeDeleted"] == $"{user.CreatedUtc}"
+                           properties => properties.Count == 3 &&
+                               properties["CreatedDateForAccountToBeDeleted"] == $"{user.CreatedUtc}" &&
+                               properties["Username"] == "testUser" &&
+                               properties["AccountKey"] == user.Key.ToString()
                                )));
 
                 service.TrackRequestForAccountDeletion(fakes.User);


### PR DESCRIPTION
User-centric telemetry events were missing the username, making it difficult to correlate events to specific users when debugging issues or investigating incidents. This PR adds `Username` and `AccountKey` custom dimensions to improve debuggability.

## Changes

**Account deletion telemetry:**
- `TrackRequestForAccountDeletion` — added `Username`, `AccountKey`
- `TrackAccountDeletionCompleted` — added `DeletedUsername`, `DeletedByUsername`, `DeletedAccountKey`, `DeletedByAccountKey`

**Organization lifecycle telemetry** (5 methods via shared helper):
- `TrackMetricForOrganization` — added `OrganizationUsername` (parallels existing `OrganizationAccountKey`)

**Certificate management telemetry:**
- `TrackCertificateActivated` / `TrackCertificateDeactivated` — added `User` parameter with `Username`, `AccountKey`
- `TrackCertificateAdded` left unchanged (no user context available without changing `ICertificateService`; always followed by `ActivateCertificate`)

**User package delete telemetry:**
- `TrackUserPackageDeleteExecuted` — added `User` parameter with `Username`, `AccountKey`

## Testing
- Updated all relevant unit tests in `TelemetryServiceFacts` and `CertificateServiceFacts`
- 157 tests pass locally