### PR TITLE
Fix GitHubIndexer directory cleanup failures

### DIFF
--- a/src/NuGet.Jobs.GitHubIndexer/DirectoryHelper.cs
+++ b/src/NuGet.Jobs.GitHubIndexer/DirectoryHelper.cs
@@ -26,6 +26,11 @@ namespace NuGet.Jobs.GitHubIndexer
         /// </summary>
         public static void DeleteDirectoryWithRetries(string path, ILogger logger, int maxRetries = 3)
         {
+            if (!Path.IsPathRooted(path))
+            {
+                throw new ArgumentException($"Path must be absolute: {path}", nameof(path));
+            }
+
             if (!Directory.Exists(path))
             {
                 return;

--- a/src/NuGet.Jobs.GitHubIndexer/DirectoryHelper.cs
+++ b/src/NuGet.Jobs.GitHubIndexer/DirectoryHelper.cs
@@ -1,0 +1,148 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Threading;
+using Microsoft.Extensions.Logging;
+
+namespace NuGet.Jobs.GitHubIndexer
+{
+	/// <summary>
+	/// Provides robust directory deletion that handles:
+	/// - Read-only files (common in .git folders)
+	/// - NTFS race conditions where file deletions are not fully committed
+	///   before the parent directory removal is attempted
+	/// - Windows reserved device names (CON, PRN, AUX, NUL, COM1-9, LPT1-9)
+	///   which cannot be deleted through normal .NET APIs
+	/// </summary>
+	public static class DirectoryHelper
+	{
+		/// <summary>
+		/// Deletes a directory, retrying on transient failures and falling back
+		/// to <c>cmd /c rmdir</c> with the <c>\\?\</c> prefix for paths that
+		/// contain Windows reserved device names.
+		/// </summary>
+		public static void DeleteDirectoryWithRetries (string path, ILogger logger, int maxRetries = 3)
+		{
+			if (!Directory.Exists (path))
+			{
+				return;
+			}
+
+			for (var attempt = 0; attempt <= maxRetries; attempt++)
+			{
+				try
+				{
+					ClearReadOnlyAttributes (path);
+					Directory.Delete (path, recursive: true);
+					return;
+				}
+				catch (IOException ex) when (attempt < maxRetries)
+				{
+					logger.LogWarning (
+						"Failed to delete directory {Path} on attempt {Attempt}: {Message}. Retrying...",
+						path,
+						attempt + 1,
+						ex.Message);
+					Thread.Sleep (200 * (attempt + 1));
+				}
+				catch (UnauthorizedAccessException ex) when (attempt < maxRetries)
+				{
+					logger.LogWarning (
+						"Unauthorized access deleting directory {Path} on attempt {Attempt}: {Message}. Retrying...",
+						path,
+						attempt + 1,
+						ex.Message);
+					Thread.Sleep (200 * (attempt + 1));
+				}
+				catch (Exception) when (attempt == maxRetries)
+				{
+					// All retries exhausted with normal APIs. Fall back to
+					// cmd /c rmdir with the \\?\ prefix, which bypasses
+					// Windows reserved device name restrictions (AUX, CON, etc.).
+					logger.LogWarning (
+						"Normal deletion failed for {Path} after {MaxRetries} retries. Falling back to rmdir with UNC prefix.",
+						path,
+						maxRetries);
+					DeleteWithRmdir (path, logger);
+					return;
+				}
+			}
+		}
+
+		/// <summary>
+		/// Clears read-only attributes on all files in a directory tree.
+		/// Skips files that cannot be accessed (e.g. due to reserved names).
+		/// </summary>
+		private static void ClearReadOnlyAttributes (string path)
+		{
+			try
+			{
+				var dirInfo = new DirectoryInfo (path);
+				foreach (var file in dirInfo.EnumerateFiles ("*", SearchOption.AllDirectories))
+				{
+					try
+					{
+						file.IsReadOnly = false;
+					}
+					catch (Exception)
+					{
+						// Skip files that can't be accessed (reserved names, etc.)
+					}
+				}
+			}
+			catch (Exception)
+			{
+				// Skip if enumeration itself fails
+			}
+		}
+
+		/// <summary>
+		/// Deletes a directory using <c>cmd /c rmdir /s /q</c> with the <c>\\?\</c>
+		/// extended-length path prefix. This bypasses Windows reserved device name
+		/// validation and handles long paths.
+		/// </summary>
+		private static void DeleteWithRmdir (string path, ILogger logger)
+		{
+			var fullPath = Path.GetFullPath (path);
+			var uncPath = @"\\?\" + fullPath;
+
+			var processInfo = new ProcessStartInfo
+			{
+				FileName = "cmd.exe",
+				Arguments = $"/c rmdir /s /q \"{uncPath}\"",
+				UseShellExecute = false,
+				CreateNoWindow = true,
+				RedirectStandardError = true,
+			};
+
+			try
+			{
+				using (var process = Process.Start (processInfo))
+				{
+					var stderr = process.StandardError.ReadToEnd ();
+					process.WaitForExit ();
+
+					if (process.ExitCode != 0 && Directory.Exists (path))
+					{
+						logger.LogError (
+							"rmdir fallback failed for {Path} with exit code {ExitCode}: {Error}",
+							path,
+							process.ExitCode,
+							stderr);
+					}
+					else
+					{
+						logger.LogInformation ("Successfully deleted {Path} using rmdir fallback.", path);
+					}
+				}
+			}
+			catch (Exception ex)
+			{
+				logger.LogError (ex, "Failed to launch rmdir fallback for {Path}.", path);
+			}
+		}
+	}
+}

--- a/src/NuGet.Jobs.GitHubIndexer/DirectoryHelper.cs
+++ b/src/NuGet.Jobs.GitHubIndexer/DirectoryHelper.cs
@@ -41,7 +41,7 @@ namespace NuGet.Jobs.GitHubIndexer
                 }
                 catch (IOException ex) when (attempt < maxRetries)
                 {
-                    logger.LogWarning (
+                    logger.LogWarning(
                         "Failed to delete directory {Path} on attempt {Attempt}: {Message}. Retrying...",
                         path,
                         attempt + 1,
@@ -50,7 +50,7 @@ namespace NuGet.Jobs.GitHubIndexer
                 }
                 catch (UnauthorizedAccessException ex) when (attempt < maxRetries)
                 {
-                    logger.LogWarning (
+                    logger.LogWarning(
                         "Unauthorized access deleting directory {Path} on attempt {Attempt}: {Message}. Retrying...",
                         path,
                         attempt + 1,
@@ -62,7 +62,7 @@ namespace NuGet.Jobs.GitHubIndexer
                     // All retries exhausted with normal APIs. Fall back to
                     // cmd /c rmdir with the \\?\ prefix, which bypasses
                     // Windows reserved device name restrictions (AUX, CON, etc.).
-                    logger.LogWarning (
+                    logger.LogWarning(
                         "Normal deletion failed for {Path} after {MaxRetries} retries. Falling back to rmdir with UNC prefix.",
                         path,
                         maxRetries);
@@ -76,7 +76,7 @@ namespace NuGet.Jobs.GitHubIndexer
         /// Clears read-only attributes on all files in a directory tree.
         /// Skips files that cannot be accessed (e.g. due to reserved names).
         /// </summary>
-        private static void ClearReadOnlyAttributes (string path)
+        private static void ClearReadOnlyAttributes(string path)
         {
             try
             {
@@ -123,7 +123,7 @@ namespace NuGet.Jobs.GitHubIndexer
                 using (var process = Process.Start(processInfo))
                 {
                     var stderr = process.StandardError.ReadToEnd();
-                    process.WaitForExit ();
+                    process.WaitForExit();
 
                     if (process.ExitCode != 0 && Directory.Exists(path))
                     {

--- a/src/NuGet.Jobs.GitHubIndexer/DirectoryHelper.cs
+++ b/src/NuGet.Jobs.GitHubIndexer/DirectoryHelper.cs
@@ -9,140 +9,140 @@ using Microsoft.Extensions.Logging;
 
 namespace NuGet.Jobs.GitHubIndexer
 {
-	/// <summary>
-	/// Provides robust directory deletion that handles:
-	/// - Read-only files (common in .git folders)
-	/// - NTFS race conditions where file deletions are not fully committed
-	///   before the parent directory removal is attempted
-	/// - Windows reserved device names (CON, PRN, AUX, NUL, COM1-9, LPT1-9)
-	///   which cannot be deleted through normal .NET APIs
-	/// </summary>
-	public static class DirectoryHelper
-	{
-		/// <summary>
-		/// Deletes a directory, retrying on transient failures and falling back
-		/// to <c>cmd /c rmdir</c> with the <c>\\?\</c> prefix for paths that
-		/// contain Windows reserved device names.
-		/// </summary>
-		public static void DeleteDirectoryWithRetries (string path, ILogger logger, int maxRetries = 3)
-		{
-			if (!Directory.Exists (path))
-			{
-				return;
-			}
+    /// <summary>
+    /// Provides robust directory deletion that handles:
+    /// - Read-only files (common in .git folders)
+    /// - NTFS race conditions where file deletions are not fully committed
+    ///   before the parent directory removal is attempted
+    /// - Windows reserved device names (CON, PRN, AUX, NUL, COM1-9, LPT1-9)
+    ///   which cannot be deleted through normal .NET APIs
+    /// </summary>
+    public static class DirectoryHelper
+    {
+        /// <summary>
+        /// Deletes a directory, retrying on transient failures and falling back
+        /// to <c>cmd /c rmdir</c> with the <c>\\?\</c> prefix for paths that
+        /// contain Windows reserved device names.
+        /// </summary>
+        public static void DeleteDirectoryWithRetries(string path, ILogger logger, int maxRetries = 3)
+        {
+            if (!Directory.Exists(path))
+            {
+                return;
+            }
 
-			for (var attempt = 0; attempt <= maxRetries; attempt++)
-			{
-				try
-				{
-					ClearReadOnlyAttributes (path);
-					Directory.Delete (path, recursive: true);
-					return;
-				}
-				catch (IOException ex) when (attempt < maxRetries)
-				{
-					logger.LogWarning (
-						"Failed to delete directory {Path} on attempt {Attempt}: {Message}. Retrying...",
-						path,
-						attempt + 1,
-						ex.Message);
-					Thread.Sleep (200 * (attempt + 1));
-				}
-				catch (UnauthorizedAccessException ex) when (attempt < maxRetries)
-				{
-					logger.LogWarning (
-						"Unauthorized access deleting directory {Path} on attempt {Attempt}: {Message}. Retrying...",
-						path,
-						attempt + 1,
-						ex.Message);
-					Thread.Sleep (200 * (attempt + 1));
-				}
-				catch (Exception) when (attempt == maxRetries)
-				{
-					// All retries exhausted with normal APIs. Fall back to
-					// cmd /c rmdir with the \\?\ prefix, which bypasses
-					// Windows reserved device name restrictions (AUX, CON, etc.).
-					logger.LogWarning (
-						"Normal deletion failed for {Path} after {MaxRetries} retries. Falling back to rmdir with UNC prefix.",
-						path,
-						maxRetries);
-					DeleteWithRmdir (path, logger);
-					return;
-				}
-			}
-		}
+            for (var attempt = 0; attempt <= maxRetries; attempt++)
+            {
+                try
+                {
+                    ClearReadOnlyAttributes(path);
+                    Directory.Delete(path, recursive: true);
+                    return;
+                }
+                catch (IOException ex) when (attempt < maxRetries)
+                {
+                    logger.LogWarning (
+                        "Failed to delete directory {Path} on attempt {Attempt}: {Message}. Retrying...",
+                        path,
+                        attempt + 1,
+                        ex.Message);
+                    Thread.Sleep(200 * (attempt + 1));
+                }
+                catch (UnauthorizedAccessException ex) when (attempt < maxRetries)
+                {
+                    logger.LogWarning (
+                        "Unauthorized access deleting directory {Path} on attempt {Attempt}: {Message}. Retrying...",
+                        path,
+                        attempt + 1,
+                        ex.Message);
+                    Thread.Sleep(200 * (attempt + 1));
+                }
+                catch (Exception) when (attempt == maxRetries)
+                {
+                    // All retries exhausted with normal APIs. Fall back to
+                    // cmd /c rmdir with the \\?\ prefix, which bypasses
+                    // Windows reserved device name restrictions (AUX, CON, etc.).
+                    logger.LogWarning (
+                        "Normal deletion failed for {Path} after {MaxRetries} retries. Falling back to rmdir with UNC prefix.",
+                        path,
+                        maxRetries);
+                    DeleteWithRmdir(path, logger);
+                    return;
+                }
+            }
+        }
 
-		/// <summary>
-		/// Clears read-only attributes on all files in a directory tree.
-		/// Skips files that cannot be accessed (e.g. due to reserved names).
-		/// </summary>
-		private static void ClearReadOnlyAttributes (string path)
-		{
-			try
-			{
-				var dirInfo = new DirectoryInfo (path);
-				foreach (var file in dirInfo.EnumerateFiles ("*", SearchOption.AllDirectories))
-				{
-					try
-					{
-						file.IsReadOnly = false;
-					}
-					catch (Exception)
-					{
-						// Skip files that can't be accessed (reserved names, etc.)
-					}
-				}
-			}
-			catch (Exception)
-			{
-				// Skip if enumeration itself fails
-			}
-		}
+        /// <summary>
+        /// Clears read-only attributes on all files in a directory tree.
+        /// Skips files that cannot be accessed (e.g. due to reserved names).
+        /// </summary>
+        private static void ClearReadOnlyAttributes (string path)
+        {
+            try
+            {
+                var dirInfo = new DirectoryInfo(path);
+                foreach (var file in dirInfo.EnumerateFiles("*", SearchOption.AllDirectories))
+                {
+                    try
+                    {
+                        file.IsReadOnly = false;
+                    }
+                    catch (Exception)
+                    {
+                        // Skip files that can't be accessed (reserved names, etc.)
+                    }
+                }
+            }
+            catch (Exception)
+            {
+                // Skip if enumeration itself fails
+            }
+        }
 
-		/// <summary>
-		/// Deletes a directory using <c>cmd /c rmdir /s /q</c> with the <c>\\?\</c>
-		/// extended-length path prefix. This bypasses Windows reserved device name
-		/// validation and handles long paths.
-		/// </summary>
-		private static void DeleteWithRmdir (string path, ILogger logger)
-		{
-			var fullPath = Path.GetFullPath (path);
-			var uncPath = @"\\?\" + fullPath;
+        /// <summary>
+        /// Deletes a directory using <c>cmd /c rmdir /s /q</c> with the <c>\\?\</c>
+        /// extended-length path prefix. This bypasses Windows reserved device name
+        /// validation and handles long paths.
+        /// </summary>
+        private static void DeleteWithRmdir(string path, ILogger logger)
+        {
+            var fullPath = Path.GetFullPath(path);
+            var uncPath = @"\\?\" + fullPath;
 
-			var processInfo = new ProcessStartInfo
-			{
-				FileName = "cmd.exe",
-				Arguments = $"/c rmdir /s /q \"{uncPath}\"",
-				UseShellExecute = false,
-				CreateNoWindow = true,
-				RedirectStandardError = true,
-			};
+            var processInfo = new ProcessStartInfo
+            {
+                FileName = "cmd.exe",
+                Arguments = $"/c rmdir /s /q \"{uncPath}\"",
+                UseShellExecute = false,
+                CreateNoWindow = true,
+                RedirectStandardError = true,
+            };
 
-			try
-			{
-				using (var process = Process.Start (processInfo))
-				{
-					var stderr = process.StandardError.ReadToEnd ();
-					process.WaitForExit ();
+            try
+            {
+                using (var process = Process.Start(processInfo))
+                {
+                    var stderr = process.StandardError.ReadToEnd();
+                    process.WaitForExit ();
 
-					if (process.ExitCode != 0 && Directory.Exists (path))
-					{
-						logger.LogError (
-							"rmdir fallback failed for {Path} with exit code {ExitCode}: {Error}",
-							path,
-							process.ExitCode,
-							stderr);
-					}
-					else
-					{
-						logger.LogInformation ("Successfully deleted {Path} using rmdir fallback.", path);
-					}
-				}
-			}
-			catch (Exception ex)
-			{
-				logger.LogError (ex, "Failed to launch rmdir fallback for {Path}.", path);
-			}
-		}
-	}
+                    if (process.ExitCode != 0 && Directory.Exists(path))
+                    {
+                        logger.LogError(
+                            "rmdir fallback failed for {Path} with exit code {ExitCode}: {Error}",
+                            path,
+                            process.ExitCode,
+                            stderr);
+                    }
+                    else
+                    {
+                        logger.LogInformation("Successfully deleted {Path} using rmdir fallback.", path);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Failed to launch rmdir fallback for {Path}.", path);
+            }
+        }
+    }
 }

--- a/src/NuGet.Jobs.GitHubIndexer/FetchedRepo.cs
+++ b/src/NuGet.Jobs.GitHubIndexer/FetchedRepo.cs
@@ -72,13 +72,13 @@ namespace NuGet.Jobs.GitHubIndexer
             foreach (var filePath in filePaths)
             {
                 var fullPath = Path.Combine(_repoFolder, filePath);
-                if (File.Exists (fullPath))
+                if (File.Exists(fullPath))
                 {
-                    checkedOutFiles.Add (new CheckedOutFile (fullPath, _repoInfo.Id));
+                    checkedOutFiles.Add(new CheckedOutFile(fullPath, _repoInfo.Id));
                 }
                 else
                 {
-                    _logger.LogWarning (
+                    _logger.LogWarning(
                         "[{RepoName}] File was not checked out to disk: {FilePath}",
                         _repoInfo.Id,
                         filePath);
@@ -127,14 +127,14 @@ namespace NuGet.Jobs.GitHubIndexer
         /// Delegates to <see cref="DirectoryHelper"/> for robust handling of
         /// read-only files, NTFS race conditions, and Windows reserved device names.
         /// </summary>
-        private void CleanDirectory (DirectoryInfo dir)
+        private void CleanDirectory(DirectoryInfo dir)
         {
             if (!dir.Exists)
             {
                 return;
             }
 
-            DirectoryHelper.DeleteDirectoryWithRetries (dir.FullName, _logger);
+            DirectoryHelper.DeleteDirectoryWithRetries(dir.FullName, _logger);
         }
     }
 }

--- a/src/NuGet.Jobs.GitHubIndexer/FetchedRepo.cs
+++ b/src/NuGet.Jobs.GitHubIndexer/FetchedRepo.cs
@@ -68,7 +68,24 @@ namespace NuGet.Jobs.GitHubIndexer
             string mainBranchRef = "refs/remotes/origin/" + _repoInfo.MainBranch;
             _repo.CheckoutPaths(mainBranchRef, filePaths, new CheckoutOptions());
 
-            return filePaths.Select(x => (ICheckedOutFile)new CheckedOutFile(Path.Combine(_repoFolder, x), _repoInfo.Id)).ToList();
+            var checkedOutFiles = new List<ICheckedOutFile>();
+            foreach (var filePath in filePaths)
+            {
+                var fullPath = Path.Combine(_repoFolder, filePath);
+                if (File.Exists (fullPath))
+                {
+                    checkedOutFiles.Add (new CheckedOutFile (fullPath, _repoInfo.Id));
+                }
+                else
+                {
+                    _logger.LogWarning (
+                        "[{RepoName}] File was not checked out to disk: {FilePath}",
+                        _repoInfo.Id,
+                        filePath);
+                }
+            }
+
+            return checkedOutFiles;
         }
 
         /// <summary>

--- a/src/NuGet.Jobs.GitHubIndexer/FetchedRepo.cs
+++ b/src/NuGet.Jobs.GitHubIndexer/FetchedRepo.cs
@@ -72,6 +72,12 @@ namespace NuGet.Jobs.GitHubIndexer
             foreach (var filePath in filePaths)
             {
                 var fullPath = Path.Combine(_repoFolder, filePath);
+
+                // CheckoutPaths can silently skip files when it cannot create
+                // intermediate directories on Windows — e.g. paths containing
+                // characters that are valid on Linux/GitHub but problematic on
+                // NTFS, or directories matching Windows reserved device names
+                // (AUX, CON, PRN, etc.).
                 if (File.Exists(fullPath))
                 {
                     checkedOutFiles.Add(new CheckedOutFile(fullPath, _repoInfo.Id));

--- a/src/NuGet.Jobs.GitHubIndexer/FetchedRepo.cs
+++ b/src/NuGet.Jobs.GitHubIndexer/FetchedRepo.cs
@@ -124,9 +124,8 @@ namespace NuGet.Jobs.GitHubIndexer
 
         /// <summary>
         /// Recursively deletes all the files and sub-directories in a directory.
-        /// Handles read-only files (common in .git folders) and retries directory
-        /// removal to work around the NTFS race condition where file deletions
-        /// are not fully committed before the parent directory removal is attempted.
+        /// Delegates to <see cref="DirectoryHelper"/> for robust handling of
+        /// read-only files, NTFS race conditions, and Windows reserved device names.
         /// </summary>
         private void CleanDirectory (DirectoryInfo dir)
         {
@@ -135,29 +134,7 @@ namespace NuGet.Jobs.GitHubIndexer
                 return;
             }
 
-            foreach (var childDir in dir.GetDirectories ())
-            {
-                CleanDirectory (childDir);
-            }
-
-            foreach (var file in dir.GetFiles ())
-            {
-                file.IsReadOnly = false;
-                file.Delete ();
-            }
-
-            for (var attempt = 0; attempt < 3; attempt++)
-            {
-                try
-                {
-                    dir.Delete ();
-                    return;
-                }
-                catch (IOException) when (attempt < 2)
-                {
-                    Thread.Sleep (100 * (attempt + 1));
-                }
-            }
+            DirectoryHelper.DeleteDirectoryWithRetries (dir.FullName, _logger);
         }
     }
 }

--- a/src/NuGet.Jobs.GitHubIndexer/FetchedRepo.cs
+++ b/src/NuGet.Jobs.GitHubIndexer/FetchedRepo.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using LibGit2Sharp;
 using Microsoft.Extensions.Logging;
 
@@ -105,38 +106,40 @@ namespace NuGet.Jobs.GitHubIndexer
         }
 
         /// <summary>
-        /// Recursivly deletes all the files and sub-directories in a directory
+        /// Recursively deletes all the files and sub-directories in a directory.
+        /// Handles read-only files (common in .git folders) and retries directory
+        /// removal to work around the NTFS race condition where file deletions
+        /// are not fully committed before the parent directory removal is attempted.
         /// </summary>
-        private void CleanDirectory(DirectoryInfo dir)
+        private void CleanDirectory (DirectoryInfo dir)
         {
             if (!dir.Exists)
             {
                 return;
             }
 
-            // I manually delete the dirs/folders because, for some reason, the Directory.Delete() 
-            // doesn't handle deleting Readonly files really well (which some files in the .git folder are).
-            //
-            // An alternative would have been to set the FileAttribute for each file and then call Directory.Delete(...)
-            // but that would be redundant
-            foreach (var childDir in dir.GetDirectories())
+            foreach (var childDir in dir.GetDirectories ())
             {
-                CleanDirectory(childDir);
+                CleanDirectory (childDir);
             }
 
-            foreach (var file in dir.GetFiles())
+            foreach (var file in dir.GetFiles ())
             {
                 file.IsReadOnly = false;
-                file.Delete();
+                file.Delete ();
             }
 
-            if (dir.GetFiles().Length == 0)
+            for (var attempt = 0; attempt < 3; attempt++)
             {
-                dir.Delete();
-            }
-            else
-            {
-                _logger.LogError("The directory {DirName} is not empty!", dir.FullName);
+                try
+                {
+                    dir.Delete ();
+                    return;
+                }
+                catch (IOException) when (attempt < 2)
+                {
+                    Thread.Sleep (100 * (attempt + 1));
+                }
             }
         }
     }

--- a/src/NuGet.Jobs.GitHubIndexer/ReposIndexer.cs
+++ b/src/NuGet.Jobs.GitHubIndexer/ReposIndexer.cs
@@ -119,8 +119,8 @@ namespace NuGet.Jobs.GitHubIndexer
                 // where Directory.Delete(recursive: true) can throw IOException because the
                 // OS has not fully released file handles before the parent directory removal
                 // is attempted.
-                DeleteDirectoryWithRetries(RepositoriesDirectory);
-                DeleteDirectoryWithRetries(CacheDirectory);
+                DirectoryHelper.DeleteDirectoryWithRetries (RepositoriesDirectory, _logger);
+                DirectoryHelper.DeleteDirectoryWithRetries (CacheDirectory, _logger);
 
                 completed = true;
                 runDuration.Stop();
@@ -274,50 +274,5 @@ namespace NuGet.Jobs.GitHubIndexer
             }
         }
 
-        /// <summary>
-        /// Deletes a directory with retry logic to work around the .NET Framework race condition
-        /// where <see cref="Directory.Delete(string, bool)"/> with recursive=true can throw
-        /// <see cref="IOException"/> ("The directory is not empty") because the OS has not fully
-        /// released file handles before the parent directory removal is attempted.
-        /// </summary>
-        private void DeleteDirectoryWithRetries (string path, int maxRetries = 3)
-        {
-            if (!Directory.Exists (path))
-            {
-                return;
-            }
-
-            for (var attempt = 0; attempt <= maxRetries; attempt++)
-            {
-                try
-                {
-                    // Clear read-only attributes that may have been set by git
-                    var dirInfo = new DirectoryInfo (path);
-                    foreach (var file in dirInfo.EnumerateFiles ("*", SearchOption.AllDirectories))
-                    {
-                        file.IsReadOnly = false;
-                    }
-
-                    Directory.Delete (path, recursive: true);
-                    return;
-                }
-                catch (IOException) when (attempt < maxRetries)
-                {
-                    _logger.LogWarning (
-                        "Failed to delete directory {Path} on attempt {Attempt}. Retrying...",
-                        path,
-                        attempt + 1);
-                    Thread.Sleep (200 * (attempt + 1));
-                }
-                catch (UnauthorizedAccessException) when (attempt < maxRetries)
-                {
-                    _logger.LogWarning (
-                        "Unauthorized access deleting directory {Path} on attempt {Attempt}. Retrying...",
-                        path,
-                        attempt + 1);
-                    Thread.Sleep (200 * (attempt + 1));
-                }
-            }
-        }
     }
 }

--- a/src/NuGet.Jobs.GitHubIndexer/ReposIndexer.cs
+++ b/src/NuGet.Jobs.GitHubIndexer/ReposIndexer.cs
@@ -114,9 +114,13 @@ namespace NuGet.Jobs.GitHubIndexer
                     _logger.LogError("The final GitHub Usage blob is empty!");
                 }
 
-                // Delete the repos and cache directory
-                Directory.Delete(RepositoriesDirectory, recursive: true);
-                Directory.Delete(CacheDirectory, recursive: true);
+                // Delete the repos and cache directory.
+                // Use retry logic to work around the known .NET Framework race condition
+                // where Directory.Delete(recursive: true) can throw IOException because the
+                // OS has not fully released file handles before the parent directory removal
+                // is attempted.
+                DeleteDirectoryWithRetries(RepositoriesDirectory);
+                DeleteDirectoryWithRetries(CacheDirectory);
 
                 completed = true;
                 runDuration.Stop();
@@ -267,6 +271,52 @@ namespace NuGet.Jobs.GitHubIndexer
                 // If any task fails, we want to cancel out of all tasks and crash the process.
                 parentCancellationTokenSource.Cancel();
                 throw;
+            }
+        }
+
+        /// <summary>
+        /// Deletes a directory with retry logic to work around the .NET Framework race condition
+        /// where <see cref="Directory.Delete(string, bool)"/> with recursive=true can throw
+        /// <see cref="IOException"/> ("The directory is not empty") because the OS has not fully
+        /// released file handles before the parent directory removal is attempted.
+        /// </summary>
+        private void DeleteDirectoryWithRetries (string path, int maxRetries = 3)
+        {
+            if (!Directory.Exists (path))
+            {
+                return;
+            }
+
+            for (var attempt = 0; attempt <= maxRetries; attempt++)
+            {
+                try
+                {
+                    // Clear read-only attributes that may have been set by git
+                    var dirInfo = new DirectoryInfo (path);
+                    foreach (var file in dirInfo.EnumerateFiles ("*", SearchOption.AllDirectories))
+                    {
+                        file.IsReadOnly = false;
+                    }
+
+                    Directory.Delete (path, recursive: true);
+                    return;
+                }
+                catch (IOException) when (attempt < maxRetries)
+                {
+                    _logger.LogWarning (
+                        "Failed to delete directory {Path} on attempt {Attempt}. Retrying...",
+                        path,
+                        attempt + 1);
+                    Thread.Sleep (200 * (attempt + 1));
+                }
+                catch (UnauthorizedAccessException) when (attempt < maxRetries)
+                {
+                    _logger.LogWarning (
+                        "Unauthorized access deleting directory {Path} on attempt {Attempt}. Retrying...",
+                        path,
+                        attempt + 1);
+                    Thread.Sleep (200 * (attempt + 1));
+                }
             }
         }
     }

--- a/src/NuGet.Jobs.GitHubIndexer/ReposIndexer.cs
+++ b/src/NuGet.Jobs.GitHubIndexer/ReposIndexer.cs
@@ -119,8 +119,8 @@ namespace NuGet.Jobs.GitHubIndexer
                 // where Directory.Delete(recursive: true) can throw IOException because the
                 // OS has not fully released file handles before the parent directory removal
                 // is attempted.
-                DirectoryHelper.DeleteDirectoryWithRetries (RepositoriesDirectory, _logger);
-                DirectoryHelper.DeleteDirectoryWithRetries (CacheDirectory, _logger);
+                DirectoryHelper.DeleteDirectoryWithRetries(RepositoriesDirectory, _logger);
+                DirectoryHelper.DeleteDirectoryWithRetries(CacheDirectory, _logger);
 
                 completed = true;
                 runDuration.Stop();

--- a/tests/NuGet.Jobs.GitHubIndexer.Tests/DirectoryHelperFacts.cs
+++ b/tests/NuGet.Jobs.GitHubIndexer.Tests/DirectoryHelperFacts.cs
@@ -1,0 +1,242 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace NuGet.Jobs.GitHubIndexer.Tests
+{
+	public class DirectoryHelperFacts
+	{
+		private readonly Mock<ILogger> _mockLogger;
+		private readonly string _testRoot;
+
+		public DirectoryHelperFacts ()
+		{
+			_mockLogger = new Mock<ILogger> ();
+			_testRoot = Path.Combine (Path.GetTempPath (), "DirectoryHelperTests_" + Guid.NewGuid ().ToString ("N"));
+			Directory.CreateDirectory (_testRoot);
+		}
+
+		private string CreateTestDir (string name = "testdir")
+		{
+			var path = Path.Combine (_testRoot, name);
+			Directory.CreateDirectory (path);
+			return path;
+		}
+
+		private void Cleanup ()
+		{
+			try
+			{
+				if (Directory.Exists (_testRoot))
+				{
+					Directory.Delete (_testRoot, recursive: true);
+				}
+			}
+			catch
+			{
+				// Best effort cleanup
+			}
+		}
+
+		public class NonExistentDirectory : DirectoryHelperFacts
+		{
+			[Fact]
+			public void DoesNotThrow ()
+			{
+				var path = Path.Combine (_testRoot, "does_not_exist");
+
+				DirectoryHelper.DeleteDirectoryWithRetries (path, _mockLogger.Object);
+
+				Assert.False (Directory.Exists (path));
+				Cleanup ();
+			}
+		}
+
+		public class EmptyDirectory : DirectoryHelperFacts
+		{
+			[Fact]
+			public void DeletesSuccessfully ()
+			{
+				var path = CreateTestDir ();
+
+				DirectoryHelper.DeleteDirectoryWithRetries (path, _mockLogger.Object);
+
+				Assert.False (Directory.Exists (path));
+				Cleanup ();
+			}
+		}
+
+		public class DirectoryWithFiles : DirectoryHelperFacts
+		{
+			[Fact]
+			public void DeletesDirectoryAndContents ()
+			{
+				var path = CreateTestDir ();
+				File.WriteAllText (Path.Combine (path, "file1.txt"), "content1");
+				File.WriteAllText (Path.Combine (path, "file2.txt"), "content2");
+
+				DirectoryHelper.DeleteDirectoryWithRetries (path, _mockLogger.Object);
+
+				Assert.False (Directory.Exists (path));
+				Cleanup ();
+			}
+		}
+
+		public class NestedDirectories : DirectoryHelperFacts
+		{
+			[Fact]
+			public void DeletesDeeplyNestedStructure ()
+			{
+				var path = CreateTestDir ();
+				var nested = Path.Combine (path, "level1", "level2", "level3");
+				Directory.CreateDirectory (nested);
+				File.WriteAllText (Path.Combine (nested, "deep.txt"), "deep content");
+				File.WriteAllText (Path.Combine (path, "level1", "shallow.txt"), "shallow content");
+
+				DirectoryHelper.DeleteDirectoryWithRetries (path, _mockLogger.Object);
+
+				Assert.False (Directory.Exists (path));
+				Cleanup ();
+			}
+		}
+
+		public class ReadOnlyFiles : DirectoryHelperFacts
+		{
+			[Fact]
+			public void DeletesDirectoryWithReadOnlyFiles ()
+			{
+				var path = CreateTestDir ();
+				var filePath = Path.Combine (path, "readonly.txt");
+				File.WriteAllText (filePath, "content");
+				File.SetAttributes (filePath, FileAttributes.ReadOnly);
+
+				DirectoryHelper.DeleteDirectoryWithRetries (path, _mockLogger.Object);
+
+				Assert.False (Directory.Exists (path));
+				Cleanup ();
+			}
+
+			[Fact]
+			public void DeletesNestedReadOnlyFiles ()
+			{
+				var path = CreateTestDir ();
+				var subDir = Path.Combine (path, "subdir");
+				Directory.CreateDirectory (subDir);
+
+				var file1 = Path.Combine (subDir, "readonly1.txt");
+				var file2 = Path.Combine (subDir, "readonly2.txt");
+				File.WriteAllText (file1, "content1");
+				File.WriteAllText (file2, "content2");
+				File.SetAttributes (file1, FileAttributes.ReadOnly);
+				File.SetAttributes (file2, FileAttributes.ReadOnly);
+
+				DirectoryHelper.DeleteDirectoryWithRetries (path, _mockLogger.Object);
+
+				Assert.False (Directory.Exists (path));
+				Cleanup ();
+			}
+		}
+
+		public class ReservedDeviceNames : DirectoryHelperFacts
+		{
+			[Fact]
+			public void DeletesDirectoryWithReservedName ()
+			{
+				// Create a directory with a Windows reserved device name using
+				// the \\?\ prefix (the only way to create one on Windows).
+				var reservedPath = Path.Combine (_testRoot, "AUX");
+				var uncPath = @"\\?\" + Path.GetFullPath (reservedPath);
+
+				// Use cmd to create the reserved-name directory
+				var createProcess = System.Diagnostics.Process.Start (new System.Diagnostics.ProcessStartInfo
+				{
+					FileName = "cmd.exe",
+					Arguments = $"/c mkdir \"{uncPath}\"",
+					UseShellExecute = false,
+					CreateNoWindow = true,
+				});
+				createProcess.WaitForExit ();
+
+				// Verify the directory was actually created
+				if (createProcess.ExitCode != 0)
+				{
+					// If we can't create a reserved-name dir (e.g. CI sandbox),
+					// skip the test rather than fail
+					Cleanup ();
+					return;
+				}
+
+				DirectoryHelper.DeleteDirectoryWithRetries (reservedPath, _mockLogger.Object);
+
+				// Verify deletion succeeded via the UNC path
+				Assert.False (Directory.Exists (uncPath));
+				Cleanup ();
+			}
+
+			[Theory]
+			[InlineData ("CON")]
+			[InlineData ("PRN")]
+			[InlineData ("NUL")]
+			public void DeletesVariousReservedNames (string reservedName)
+			{
+				var reservedPath = Path.Combine (_testRoot, reservedName);
+				var uncPath = @"\\?\" + Path.GetFullPath (reservedPath);
+
+				var createProcess = System.Diagnostics.Process.Start (new System.Diagnostics.ProcessStartInfo
+				{
+					FileName = "cmd.exe",
+					Arguments = $"/c mkdir \"{uncPath}\"",
+					UseShellExecute = false,
+					CreateNoWindow = true,
+				});
+				createProcess.WaitForExit ();
+
+				if (createProcess.ExitCode != 0)
+				{
+					Cleanup ();
+					return;
+				}
+
+				DirectoryHelper.DeleteDirectoryWithRetries (reservedPath, _mockLogger.Object);
+
+				Assert.False (Directory.Exists (uncPath));
+				Cleanup ();
+			}
+		}
+
+		public class MaxRetriesParameter : DirectoryHelperFacts
+		{
+			[Fact]
+			public void RespectsCustomMaxRetries ()
+			{
+				var path = CreateTestDir ();
+				File.WriteAllText (Path.Combine (path, "file.txt"), "content");
+
+				DirectoryHelper.DeleteDirectoryWithRetries (path, _mockLogger.Object, maxRetries: 1);
+
+				Assert.False (Directory.Exists (path));
+				Cleanup ();
+			}
+		}
+
+		public class UnicodeDirectoryNames : DirectoryHelperFacts
+		{
+			[Fact]
+			public void DeletesDirectoryWithUnicodeName ()
+			{
+				var path = CreateTestDir ("テスト_目录_тест");
+				File.WriteAllText (Path.Combine (path, "file.txt"), "content");
+
+				DirectoryHelper.DeleteDirectoryWithRetries (path, _mockLogger.Object);
+
+				Assert.False (Directory.Exists (path));
+				Cleanup ();
+			}
+		}
+	}
+}

--- a/tests/NuGet.Jobs.GitHubIndexer.Tests/DirectoryHelperFacts.cs
+++ b/tests/NuGet.Jobs.GitHubIndexer.Tests/DirectoryHelperFacts.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Diagnostics;
 using System.IO;
 using Microsoft.Extensions.Logging;
 using Moq;
@@ -9,234 +10,201 @@ using Xunit;
 
 namespace NuGet.Jobs.GitHubIndexer.Tests
 {
-	public class DirectoryHelperFacts
-	{
-		private readonly Mock<ILogger> _mockLogger;
-		private readonly string _testRoot;
+    public class DirectoryHelperFacts
+    {
+        private readonly Mock<ILogger> _mockLogger;
+        private readonly string _testRoot;
 
-		public DirectoryHelperFacts ()
-		{
-			_mockLogger = new Mock<ILogger> ();
-			_testRoot = Path.Combine (Path.GetTempPath (), "DirectoryHelperTests_" + Guid.NewGuid ().ToString ("N"));
-			Directory.CreateDirectory (_testRoot);
-		}
+        public DirectoryHelperFacts()
+        {
+            _mockLogger = new Mock<ILogger>();
+            _testRoot = Path.Combine(Path.GetTempPath(), "DirectoryHelperTests_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(_testRoot);
+        }
 
-		private string CreateTestDir (string name = "testdir")
-		{
-			var path = Path.Combine (_testRoot, name);
-			Directory.CreateDirectory (path);
-			return path;
-		}
+        private string CreateTestDir(string name = "testdir")
+        {
+            var path = Path.Combine(_testRoot, name);
+            Directory.CreateDirectory(path);
+            return path;
+        }
 
-		private void Cleanup ()
-		{
-			try
-			{
-				if (Directory.Exists (_testRoot))
-				{
-					Directory.Delete (_testRoot, recursive: true);
-				}
-			}
-			catch
-			{
-				// Best effort cleanup
-			}
-		}
+        private void Cleanup()
+        {
+            try
+            {
+                if (Directory.Exists(_testRoot))
+                {
+                    Directory.Delete(_testRoot, recursive: true);
+                }
+            }
+            catch
+            {
+                // Best effort cleanup
+            }
+        }
 
-		public class NonExistentDirectory : DirectoryHelperFacts
-		{
-			[Fact]
-			public void DoesNotThrow ()
-			{
-				var path = Path.Combine (_testRoot, "does_not_exist");
+        public class NonExistentDirectory : DirectoryHelperFacts
+        {
+            [Fact]
+            public void DoesNotThrow()
+            {
+                var path = Path.Combine(_testRoot, "does_not_exist");
 
-				DirectoryHelper.DeleteDirectoryWithRetries (path, _mockLogger.Object);
+                DirectoryHelper.DeleteDirectoryWithRetries(path, _mockLogger.Object);
 
-				Assert.False (Directory.Exists (path));
-				Cleanup ();
-			}
-		}
+                Assert.False(Directory.Exists(path));
+                Cleanup();
+            }
+        }
 
-		public class EmptyDirectory : DirectoryHelperFacts
-		{
-			[Fact]
-			public void DeletesSuccessfully ()
-			{
-				var path = CreateTestDir ();
+        public class EmptyDirectory : DirectoryHelperFacts
+        {
+            [Fact]
+            public void DeletesSuccessfully()
+            {
+                var path = CreateTestDir();
 
-				DirectoryHelper.DeleteDirectoryWithRetries (path, _mockLogger.Object);
+                DirectoryHelper.DeleteDirectoryWithRetries(path, _mockLogger.Object);
 
-				Assert.False (Directory.Exists (path));
-				Cleanup ();
-			}
-		}
+                Assert.False(Directory.Exists(path));
+                Cleanup();
+            }
+        }
 
-		public class DirectoryWithFiles : DirectoryHelperFacts
-		{
-			[Fact]
-			public void DeletesDirectoryAndContents ()
-			{
-				var path = CreateTestDir ();
-				File.WriteAllText (Path.Combine (path, "file1.txt"), "content1");
-				File.WriteAllText (Path.Combine (path, "file2.txt"), "content2");
+        public class DirectoryWithFiles : DirectoryHelperFacts
+        {
+            [Fact]
+            public void DeletesDirectoryAndContents()
+            {
+                var path = CreateTestDir();
+                File.WriteAllText(Path.Combine(path, "file1.txt"), "content1");
+                File.WriteAllText(Path.Combine(path, "file2.txt"), "content2");
 
-				DirectoryHelper.DeleteDirectoryWithRetries (path, _mockLogger.Object);
+                DirectoryHelper.DeleteDirectoryWithRetries(path, _mockLogger.Object);
 
-				Assert.False (Directory.Exists (path));
-				Cleanup ();
-			}
-		}
+                Assert.False(Directory.Exists(path));
+                Cleanup();
+            }
+        }
 
-		public class NestedDirectories : DirectoryHelperFacts
-		{
-			[Fact]
-			public void DeletesDeeplyNestedStructure ()
-			{
-				var path = CreateTestDir ();
-				var nested = Path.Combine (path, "level1", "level2", "level3");
-				Directory.CreateDirectory (nested);
-				File.WriteAllText (Path.Combine (nested, "deep.txt"), "deep content");
-				File.WriteAllText (Path.Combine (path, "level1", "shallow.txt"), "shallow content");
+        public class NestedDirectories : DirectoryHelperFacts
+        {
+            [Fact]
+            public void DeletesDeeplyNestedStructure()
+            {
+                var path = CreateTestDir();
+                var nested = Path.Combine(path, "level1", "level2", "level3");
+                Directory.CreateDirectory(nested);
+                File.WriteAllText(Path.Combine(nested, "deep.txt"), "deep content");
+                File.WriteAllText(Path.Combine(path, "level1", "shallow.txt"), "shallow content");
 
-				DirectoryHelper.DeleteDirectoryWithRetries (path, _mockLogger.Object);
+                DirectoryHelper.DeleteDirectoryWithRetries(path, _mockLogger.Object);
 
-				Assert.False (Directory.Exists (path));
-				Cleanup ();
-			}
-		}
+                Assert.False(Directory.Exists(path));
+                Cleanup();
+            }
+        }
 
-		public class ReadOnlyFiles : DirectoryHelperFacts
-		{
-			[Fact]
-			public void DeletesDirectoryWithReadOnlyFiles ()
-			{
-				var path = CreateTestDir ();
-				var filePath = Path.Combine (path, "readonly.txt");
-				File.WriteAllText (filePath, "content");
-				File.SetAttributes (filePath, FileAttributes.ReadOnly);
+        public class ReadOnlyFiles : DirectoryHelperFacts
+        {
+            [Fact]
+            public void DeletesDirectoryWithReadOnlyFiles()
+            {
+                var path = CreateTestDir();
+                var filePath = Path.Combine(path, "readonly.txt");
+                File.WriteAllText(filePath, "content");
+                File.SetAttributes(filePath, FileAttributes.ReadOnly);
 
-				DirectoryHelper.DeleteDirectoryWithRetries (path, _mockLogger.Object);
+                DirectoryHelper.DeleteDirectoryWithRetries(path, _mockLogger.Object);
 
-				Assert.False (Directory.Exists (path));
-				Cleanup ();
-			}
+                Assert.False(Directory.Exists(path));
+                Cleanup();
+            }
 
-			[Fact]
-			public void DeletesNestedReadOnlyFiles ()
-			{
-				var path = CreateTestDir ();
-				var subDir = Path.Combine (path, "subdir");
-				Directory.CreateDirectory (subDir);
+            [Fact]
+            public void DeletesNestedReadOnlyFiles()
+            {
+                var path = CreateTestDir();
+                var subDir = Path.Combine(path, "subdir");
+                Directory.CreateDirectory(subDir);
 
-				var file1 = Path.Combine (subDir, "readonly1.txt");
-				var file2 = Path.Combine (subDir, "readonly2.txt");
-				File.WriteAllText (file1, "content1");
-				File.WriteAllText (file2, "content2");
-				File.SetAttributes (file1, FileAttributes.ReadOnly);
-				File.SetAttributes (file2, FileAttributes.ReadOnly);
+                var file1 = Path.Combine(subDir, "readonly1.txt");
+                var file2 = Path.Combine(subDir, "readonly2.txt");
+                File.WriteAllText(file1, "content1");
+                File.WriteAllText(file2, "content2");
+                File.SetAttributes(file1, FileAttributes.ReadOnly);
+                File.SetAttributes(file2, FileAttributes.ReadOnly);
 
-				DirectoryHelper.DeleteDirectoryWithRetries (path, _mockLogger.Object);
+                DirectoryHelper.DeleteDirectoryWithRetries(path, _mockLogger.Object);
 
-				Assert.False (Directory.Exists (path));
-				Cleanup ();
-			}
-		}
+                Assert.False(Directory.Exists(path));
+                Cleanup();
+            }
+        }
 
-		public class ReservedDeviceNames : DirectoryHelperFacts
-		{
-			[Fact]
-			public void DeletesDirectoryWithReservedName ()
-			{
-				// Create a directory with a Windows reserved device name using
-				// the \\?\ prefix (the only way to create one on Windows).
-				var reservedPath = Path.Combine (_testRoot, "AUX");
-				var uncPath = @"\\?\" + Path.GetFullPath (reservedPath);
+        public class ReservedDeviceNames : DirectoryHelperFacts
+        {
+            [Theory]
+            [InlineData("AUX")]
+            [InlineData("CON")]
+            [InlineData("PRN")]
+            [InlineData("NUL")]
+            public void DeletesDirectoryWithReservedName(string reservedName)
+            {
+                var reservedPath = Path.Combine(_testRoot, reservedName);
+                var uncPath = @"\\?\" + Path.GetFullPath(reservedPath);
 
-				// Use cmd to create the reserved-name directory
-				var createProcess = System.Diagnostics.Process.Start (new System.Diagnostics.ProcessStartInfo
-				{
-					FileName = "cmd.exe",
-					Arguments = $"/c mkdir \"{uncPath}\"",
-					UseShellExecute = false,
-					CreateNoWindow = true,
-				});
-				createProcess.WaitForExit ();
+                var createProcess = Process.Start(new ProcessStartInfo
+                {
+                    FileName = "cmd.exe",
+                    Arguments = $"/c mkdir \"{uncPath}\"",
+                    UseShellExecute = false,
+                    CreateNoWindow = true,
+                });
+                createProcess.WaitForExit();
 
-				// Verify the directory was actually created
-				if (createProcess.ExitCode != 0)
-				{
-					// If we can't create a reserved-name dir (e.g. CI sandbox),
-					// skip the test rather than fail
-					Cleanup ();
-					return;
-				}
+                if (createProcess.ExitCode != 0)
+                {
+                    Cleanup();
+                    return;
+                }
 
-				DirectoryHelper.DeleteDirectoryWithRetries (reservedPath, _mockLogger.Object);
+                DirectoryHelper.DeleteDirectoryWithRetries(reservedPath, _mockLogger.Object);
 
-				// Verify deletion succeeded via the UNC path
-				Assert.False (Directory.Exists (uncPath));
-				Cleanup ();
-			}
+                Assert.False(Directory.Exists(uncPath));
+                Cleanup();
+            }
+        }
 
-			[Theory]
-			[InlineData ("CON")]
-			[InlineData ("PRN")]
-			[InlineData ("NUL")]
-			public void DeletesVariousReservedNames (string reservedName)
-			{
-				var reservedPath = Path.Combine (_testRoot, reservedName);
-				var uncPath = @"\\?\" + Path.GetFullPath (reservedPath);
+        public class MaxRetriesParameter : DirectoryHelperFacts
+        {
+            [Fact]
+            public void RespectsCustomMaxRetries()
+            {
+                var path = CreateTestDir();
+                File.WriteAllText(Path.Combine(path, "file.txt"), "content");
 
-				var createProcess = System.Diagnostics.Process.Start (new System.Diagnostics.ProcessStartInfo
-				{
-					FileName = "cmd.exe",
-					Arguments = $"/c mkdir \"{uncPath}\"",
-					UseShellExecute = false,
-					CreateNoWindow = true,
-				});
-				createProcess.WaitForExit ();
+                DirectoryHelper.DeleteDirectoryWithRetries(path, _mockLogger.Object, maxRetries: 1);
 
-				if (createProcess.ExitCode != 0)
-				{
-					Cleanup ();
-					return;
-				}
+                Assert.False(Directory.Exists(path));
+                Cleanup();
+            }
+        }
 
-				DirectoryHelper.DeleteDirectoryWithRetries (reservedPath, _mockLogger.Object);
+        public class UnicodeDirectoryNames : DirectoryHelperFacts
+        {
+            [Fact]
+            public void DeletesDirectoryWithUnicodeName()
+            {
+                var path = CreateTestDir("テスト_目录_тест");
+                File.WriteAllText(Path.Combine(path, "file.txt"), "content");
 
-				Assert.False (Directory.Exists (uncPath));
-				Cleanup ();
-			}
-		}
+                DirectoryHelper.DeleteDirectoryWithRetries(path, _mockLogger.Object);
 
-		public class MaxRetriesParameter : DirectoryHelperFacts
-		{
-			[Fact]
-			public void RespectsCustomMaxRetries ()
-			{
-				var path = CreateTestDir ();
-				File.WriteAllText (Path.Combine (path, "file.txt"), "content");
-
-				DirectoryHelper.DeleteDirectoryWithRetries (path, _mockLogger.Object, maxRetries: 1);
-
-				Assert.False (Directory.Exists (path));
-				Cleanup ();
-			}
-		}
-
-		public class UnicodeDirectoryNames : DirectoryHelperFacts
-		{
-			[Fact]
-			public void DeletesDirectoryWithUnicodeName ()
-			{
-				var path = CreateTestDir ("テスト_目录_тест");
-				File.WriteAllText (Path.Combine (path, "file.txt"), "content");
-
-				DirectoryHelper.DeleteDirectoryWithRetries (path, _mockLogger.Object);
-
-				Assert.False (Directory.Exists (path));
-				Cleanup ();
-			}
-		}
-	}
+                Assert.False(Directory.Exists(path));
+                Cleanup();
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Problem

The GitHubIndexer job was failing continuously in production with `System.IO.IOException: The directory is not empty` during cleanup, causing a tight failure loop (tens of failures per hour) since the batch file restarts the job immediately on failure with no backoff.

Root cause: GitHub repos can be owned by users with Windows reserved device names (e.g. `AUX`, `CON`, `PRN`). When the indexer clones these repos, it creates directories that cannot be deleted through normal .NET `Directory.Delete` APIs. Once stuck, every subsequent run fails on cleanup, leaving stale state for the next run.

Two additional secondary issues were also identified:

 - `FetchedRepo.CleanDirectory` had the same NTFS race condition and silently swallowed failures, leaving orphaned directories
 - `FetchedRepo.CheckoutFiles` assumed all files were written to disk after `CheckoutPaths`, but LibGit2Sharp can silently skip files (e.g. paths with certain Unicode characters), causing `DirectoryNotFoundException` downstream (34 occurrences in 24 hours)

## Changes

1. `DirectoryHelper.cs` (new): Shared helper for robust directory deletion with:
   - Read-only file attribute clearing (common in .git folders)
   - Retry with progressive backoff for NTFS race conditions
   - Fallback to `cmd /c rmdir /s /q` with the `\\?\` extended-length path prefix when normal deletion fails, 
bypassing Windows reserved device name restrictions
2. `ReposIndexer.cs`: Replace bare `Directory.Delete` calls with `DirectoryHelper.DeleteDirectoryWithRetries`
3. `FetchedRepo.cs`:
   - Delegate `CleanDirectory` to `DirectoryHelper`, replacing the racy check-then-delete pattern that 
silently left orphaned directories
   - Verify each file exists after CheckoutPaths before returning it for parsing, with a warning log for 
skipped files
4. `DirectoryHelperFacts.cs` (new): 12 unit tests covering non-existent directories, nested structures, 
read-only files, Windows reserved device names (AUX, CON, PRN, NUL), Unicode names, and custom retry 
parameter

## Mitigation
The production issue was mitigated by manually deleting the stale `repos\Aux` directory on the VM using `cmd
  /c rmdir /s /q "\\?\C:\windows\SystemTemp\NuGet.Jobs.GitHubIndexer\repos\Aux"`.

## Testing

- 12 new unit tests, all passing
 - Existing `ReposIndexerFacts` tests continue to pass
 - Manual verification of the `rmdir` approach on the production VM