### PR TITLE
Add GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/nugetgallery-ci.yml
+++ b/.github/workflows/nugetgallery-ci.yml
@@ -123,11 +123,9 @@ jobs:
           fetch-depth: 1
 
       - name: Install Python 3.10
-        shell: pwsh
-        run: |
-          $pythonPath = (Get-Command python -ErrorAction SilentlyContinue).Source
-          Write-Host "Python: $pythonPath"
-          python --version
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
 
       - name: Install tools and run tests
         shell: cmd
@@ -139,6 +137,12 @@ jobs:
           poetry install
           poetry build
           poetry run pytest tests/ --cov loginterpretation --cov-report html
+
+      - name: Upload StatsLogParser artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: StatsLogParser
+          path: python/StatsLogParser/dist
 
   aspire:
     name: Aspire Functional Tests

--- a/.github/workflows/nugetgallery-ci.yml
+++ b/.github/workflows/nugetgallery-ci.yml
@@ -1,9 +1,6 @@
 name: NuGetGallery CI
 
 on:
-  push:
-    branches:
-      - users/jver/gha
   workflow_dispatch:
 
 env:

--- a/.github/workflows/nugetgallery-ci.yml
+++ b/.github/workflows/nugetgallery-ci.yml
@@ -46,15 +46,6 @@ jobs:
             -BuildNumber ${{ github.run_number }} `
             -SkipGallery -SkipJobs
 
-      - name: Publish test results
-        uses: dorny/test-reporter@v1
-        if: always()
-        with:
-          name: Common Tests
-          path: Results.*.xml
-          reporter: dotnet-trx
-          fail-on-error: true
-
   gallery:
     name: NuGetGallery build and test
     runs-on: windows-2025-vs2026
@@ -88,15 +79,6 @@ jobs:
             -Configuration $env:BuildConfiguration `
             -BuildNumber ${{ github.run_number }} `
             -SkipCommon -SkipJobs
-
-      - name: Publish test results
-        uses: dorny/test-reporter@v1
-        if: always()
-        with:
-          name: Gallery Tests
-          path: Results.*.xml
-          reporter: dotnet-trx
-          fail-on-error: true
 
   jobs:
     name: NuGet.Jobs build and test
@@ -132,15 +114,6 @@ jobs:
             -BuildNumber ${{ github.run_number }} `
             -SkipCommon -SkipGallery
 
-      - name: Publish test results
-        uses: dorny/test-reporter@v1
-        if: always()
-        with:
-          name: Jobs Tests
-          path: Results.*.xml
-          reporter: dotnet-trx
-          fail-on-error: true
-
   statslogparser:
     name: StatsLogParser build and test
     runs-on: windows-2025-vs2026
@@ -149,9 +122,12 @@ jobs:
         with:
           fetch-depth: 1
 
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.10'
+      - name: Install Python 3.10
+        shell: pwsh
+        run: |
+          $pythonPath = (Get-Command python -ErrorAction SilentlyContinue).Source
+          Write-Host "Python: $pythonPath"
+          python --version
 
       - name: Install tools and run tests
         shell: cmd
@@ -163,12 +139,6 @@ jobs:
           poetry install
           poetry build
           poetry run pytest tests/ --cov loginterpretation --cov-report html
-
-      - name: Upload StatsLogParser artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: StatsLogParser
-          path: python/StatsLogParser/dist
 
   aspire:
     name: Aspire Functional Tests
@@ -251,15 +221,6 @@ jobs:
             Write-Host "=== Stopping Aspire Host ==="
             & "$repoRoot\tools\Stop-AspireHost.ps1" -HostPid $hostPid
           }
-
-      - name: Publish test results
-        uses: dorny/test-reporter@v1
-        if: always()
-        with:
-          name: Functional Tests (P0, P1, P2)
-          path: tests/TestResults/**/*.trx
-          reporter: dotnet-trx
-          fail-on-error: true
 
   artifacts:
     name: Build artifacts

--- a/.github/workflows/nugetgallery-ci.yml
+++ b/.github/workflows/nugetgallery-ci.yml
@@ -6,11 +6,6 @@ on:
       - users/jver/gha
   workflow_dispatch:
 
-permissions:
-  checks: write
-  pull-requests: write
-  contents: read
-
 env:
   BuildConfiguration: Release
   CommonAssemblyVersion: '5.0.0'
@@ -61,13 +56,6 @@ jobs:
           name: test-results-common
           path: Results.Common.*.xml
 
-      - name: Publish test results
-        if: always()
-        uses: dorny/test-reporter@a6ddd83ac95ff4586f5d3aceeb314d9a1841db95 # v3.0.0
-        with:
-          name: Common Test Results
-          path: Results.Common.*.xml
-          reporter: dotnet-trx
 
   gallery:
     name: NuGetGallery build and test
@@ -110,13 +98,6 @@ jobs:
           name: test-results-gallery
           path: Results.Gallery.*.xml
 
-      - name: Publish test results
-        if: always()
-        uses: dorny/test-reporter@a6ddd83ac95ff4586f5d3aceeb314d9a1841db95 # v3.0.0
-        with:
-          name: Gallery Test Results
-          path: Results.Gallery.*.xml
-          reporter: dotnet-trx
 
   jobs:
     name: NuGet.Jobs build and test
@@ -159,13 +140,6 @@ jobs:
           name: test-results-jobs
           path: Results.Jobs.*.xml
 
-      - name: Publish test results
-        if: always()
-        uses: dorny/test-reporter@a6ddd83ac95ff4586f5d3aceeb314d9a1841db95 # v3.0.0
-        with:
-          name: Jobs Test Results
-          path: Results.Jobs.*.xml
-          reporter: dotnet-trx
 
   statslogparser:
     name: StatsLogParser build and test
@@ -204,13 +178,6 @@ jobs:
           name: test-results-statslogparser
           path: Results.StatsLogParser.xml
 
-      - name: Publish test results
-        if: always()
-        uses: dorny/test-reporter@a6ddd83ac95ff4586f5d3aceeb314d9a1841db95 # v3.0.0
-        with:
-          name: StatsLogParser Test Results
-          path: Results.StatsLogParser.xml
-          reporter: java-junit
 
   aspire:
     name: Aspire Functional Tests
@@ -287,13 +254,6 @@ jobs:
           name: test-results-aspire
           path: tests/TestResults/*.trx
 
-      - name: Publish test results
-        if: always()
-        uses: dorny/test-reporter@a6ddd83ac95ff4586f5d3aceeb314d9a1841db95 # v3.0.0
-        with:
-          name: Aspire Functional Test Results
-          path: tests/TestResults/*.trx
-          reporter: dotnet-trx
 
   artifacts:
     name: Build artifacts

--- a/.github/workflows/nugetgallery-ci.yml
+++ b/.github/workflows/nugetgallery-ci.yml
@@ -238,14 +238,13 @@ jobs:
           fetch-depth: 1
 
       - name: Build
-        shell: pwsh
+        shell: powershell
         run: |
           $buildNumber = "${{ github.run_number }}"
           $branch = "${{ github.ref_name }}" -replace '[_/]', '-'
           .\build.ps1 `
             -Configuration $env:BuildConfiguration `
             -BuildNumber $buildNumber `
-            -SkipArtifacts `
             -CommonAssemblyVersion $env:CommonAssemblyVersion `
             -CommonPackageVersion "$env:CommonAssemblyVersion-$branch-$buildNumber" `
             -GalleryAssemblyVersion $env:GalleryAssemblyVersion `

--- a/.github/workflows/nugetgallery-ci.yml
+++ b/.github/workflows/nugetgallery-ci.yml
@@ -1,6 +1,9 @@
 name: NuGetGallery CI
 
 on:
+  push:
+    branches:
+      - users/jver/gha
   workflow_dispatch:
 
 env:
@@ -46,6 +49,20 @@ jobs:
             -BuildNumber ${{ github.run_number }} `
             -SkipGallery -SkipJobs
 
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results-common
+          path: Results.Common.*.xml
+
+      - name: Publish test results
+        if: always()
+        uses: EnricoMi/publish-unit-test-result-action/windows@c950f6fb443cb5af20a377fd0dfaa78838901040 # v2.23.0
+        with:
+          files: Results.Common.*.xml
+          check_name: Common Test Results
+
   gallery:
     name: NuGetGallery build and test
     runs-on: windows-2025-vs2026
@@ -79,6 +96,20 @@ jobs:
             -Configuration $env:BuildConfiguration `
             -BuildNumber ${{ github.run_number }} `
             -SkipCommon -SkipJobs
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results-gallery
+          path: Results.Gallery.*.xml
+
+      - name: Publish test results
+        if: always()
+        uses: EnricoMi/publish-unit-test-result-action/windows@c950f6fb443cb5af20a377fd0dfaa78838901040 # v2.23.0
+        with:
+          files: Results.Gallery.*.xml
+          check_name: Gallery Test Results
 
   jobs:
     name: NuGet.Jobs build and test
@@ -114,6 +145,20 @@ jobs:
             -BuildNumber ${{ github.run_number }} `
             -SkipCommon -SkipGallery
 
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results-jobs
+          path: Results.Jobs.*.xml
+
+      - name: Publish test results
+        if: always()
+        uses: EnricoMi/publish-unit-test-result-action/windows@c950f6fb443cb5af20a377fd0dfaa78838901040 # v2.23.0
+        with:
+          files: Results.Jobs.*.xml
+          check_name: Jobs Test Results
+
   statslogparser:
     name: StatsLogParser build and test
     runs-on: windows-2025-vs2026
@@ -136,13 +181,27 @@ jobs:
           pipx install poetry
           poetry install
           poetry build
-          poetry run pytest tests/ --cov loginterpretation --cov-report html
+          poetry run pytest tests/ --cov loginterpretation --cov-report html --junitxml=../../Results.StatsLogParser.xml
 
       - name: Upload StatsLogParser artifact
         uses: actions/upload-artifact@v4
         with:
           name: StatsLogParser
           path: python/StatsLogParser/dist
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results-statslogparser
+          path: Results.StatsLogParser.xml
+
+      - name: Publish test results
+        if: always()
+        uses: EnricoMi/publish-unit-test-result-action/windows@c950f6fb443cb5af20a377fd0dfaa78838901040 # v2.23.0
+        with:
+          files: Results.StatsLogParser.xml
+          check_name: StatsLogParser Test Results
 
   aspire:
     name: Aspire Functional Tests
@@ -211,6 +270,20 @@ jobs:
             Write-Host "=== Stopping Aspire Host ==="
             & "$repoRoot\tools\Stop-AspireHost.ps1" -HostPid $hostPid
           }
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results-aspire
+          path: tests/TestResults/*.trx
+
+      - name: Publish test results
+        if: always()
+        uses: EnricoMi/publish-unit-test-result-action/windows@c950f6fb443cb5af20a377fd0dfaa78838901040 # v2.23.0
+        with:
+          files: tests/TestResults/*.trx
+          check_name: Aspire Functional Test Results
 
   artifacts:
     name: Build artifacts

--- a/.github/workflows/nugetgallery-ci.yml
+++ b/.github/workflows/nugetgallery-ci.yml
@@ -6,6 +6,11 @@ on:
       - users/jver/gha
   workflow_dispatch:
 
+permissions:
+  checks: write
+  pull-requests: write
+  contents: read
+
 env:
   BuildConfiguration: Release
   CommonAssemblyVersion: '5.0.0'

--- a/.github/workflows/nugetgallery-ci.yml
+++ b/.github/workflows/nugetgallery-ci.yml
@@ -23,16 +23,6 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Cache NuGet packages
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.nuget/packages
-            packages
-          key: nuget-${{ hashFiles('**/*.csproj', '**/*.props', '**/*.targets', 'packages.config', 'NuGet.config') }}
-          restore-keys: |
-            nuget-
-
       - name: Build
         shell: pwsh
         run: |
@@ -67,16 +57,6 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Cache NuGet packages
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.nuget/packages
-            packages
-          key: nuget-${{ hashFiles('**/*.csproj', '**/*.props', '**/*.targets', 'packages.config', 'NuGet.config') }}
-          restore-keys: |
-            nuget-
-
       - name: Build
         shell: pwsh
         run: |
@@ -110,16 +90,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 1
-
-      - name: Cache NuGet packages
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.nuget/packages
-            packages
-          key: nuget-${{ hashFiles('**/*.csproj', '**/*.props', '**/*.targets', 'packages.config', 'NuGet.config') }}
-          restore-keys: |
-            nuget-
 
       - name: Build
         shell: pwsh
@@ -186,33 +156,9 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Cache NuGet packages
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.nuget/packages
-            packages
-          key: nuget-${{ hashFiles('**/*.csproj', '**/*.props', '**/*.targets', 'packages.config', 'NuGet.config') }}
-          restore-keys: |
-            nuget-
-
-      - name: Build Gallery
+      - name: Build AppHost
         shell: pwsh
-        run: |
-          $buildNumber = "${{ github.run_number }}"
-          $branch = "${{ github.ref_name }}" -replace '[_/]', '-'
-          .\build.ps1 `
-            -Configuration $env:BuildConfiguration `
-            -BuildNumber $buildNumber `
-            -SkipArtifacts -SkipCommon -SkipJobs `
-            -CommonAssemblyVersion $env:CommonAssemblyVersion `
-            -CommonPackageVersion "$env:CommonAssemblyVersion-$branch-$buildNumber" `
-            -GalleryAssemblyVersion $env:GalleryAssemblyVersion `
-            -GalleryPackageVersion "$env:GalleryAssemblyVersion-$branch-$buildNumber" `
-            -JobsAssemblyVersion $env:JobsAssemblyVersion `
-            -JobsPackageVersion "$env:JobsAssemblyVersion-$branch-$buildNumber" `
-            -Branch "${{ github.ref_name }}" `
-            -CommitSHA "${{ github.sha }}"
+        run: dotnet build src\NuGetGallery.AppHost\NuGetGallery.AppHost.csproj -c $env:BuildConfiguration
 
       - name: Setup Dev Environment
         shell: pwsh
@@ -276,16 +222,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 1
-
-      - name: Cache NuGet packages
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.nuget/packages
-            packages
-          key: nuget-${{ hashFiles('**/*.csproj', '**/*.props', '**/*.targets', 'packages.config', 'NuGet.config') }}
-          restore-keys: |
-            nuget-
 
       - name: Build
         shell: powershell

--- a/.github/workflows/nugetgallery-ci.yml
+++ b/.github/workflows/nugetgallery-ci.yml
@@ -2,9 +2,6 @@ name: NuGetGallery CI
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - users/jver/gha
 
 env:
   BuildConfiguration: Release

--- a/.github/workflows/nugetgallery-ci.yml
+++ b/.github/workflows/nugetgallery-ci.yml
@@ -2,6 +2,9 @@ name: NuGetGallery CI
 
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - users/jver/gha
 
 env:
   BuildConfiguration: Release

--- a/.github/workflows/nugetgallery-ci.yml
+++ b/.github/workflows/nugetgallery-ci.yml
@@ -63,10 +63,11 @@ jobs:
 
       - name: Publish test results
         if: always()
-        uses: EnricoMi/publish-unit-test-result-action/windows@c950f6fb443cb5af20a377fd0dfaa78838901040 # v2.23.0
+        uses: dorny/test-reporter@a6ddd83ac95ff4586f5d3aceeb314d9a1841db95 # v3.0.0
         with:
-          files: Results.Common.*.xml
-          check_name: Common Test Results
+          name: Common Test Results
+          path: Results.Common.*.xml
+          reporter: dotnet-trx
 
   gallery:
     name: NuGetGallery build and test
@@ -111,10 +112,11 @@ jobs:
 
       - name: Publish test results
         if: always()
-        uses: EnricoMi/publish-unit-test-result-action/windows@c950f6fb443cb5af20a377fd0dfaa78838901040 # v2.23.0
+        uses: dorny/test-reporter@a6ddd83ac95ff4586f5d3aceeb314d9a1841db95 # v3.0.0
         with:
-          files: Results.Gallery.*.xml
-          check_name: Gallery Test Results
+          name: Gallery Test Results
+          path: Results.Gallery.*.xml
+          reporter: dotnet-trx
 
   jobs:
     name: NuGet.Jobs build and test
@@ -159,10 +161,11 @@ jobs:
 
       - name: Publish test results
         if: always()
-        uses: EnricoMi/publish-unit-test-result-action/windows@c950f6fb443cb5af20a377fd0dfaa78838901040 # v2.23.0
+        uses: dorny/test-reporter@a6ddd83ac95ff4586f5d3aceeb314d9a1841db95 # v3.0.0
         with:
-          files: Results.Jobs.*.xml
-          check_name: Jobs Test Results
+          name: Jobs Test Results
+          path: Results.Jobs.*.xml
+          reporter: dotnet-trx
 
   statslogparser:
     name: StatsLogParser build and test
@@ -203,10 +206,11 @@ jobs:
 
       - name: Publish test results
         if: always()
-        uses: EnricoMi/publish-unit-test-result-action/windows@c950f6fb443cb5af20a377fd0dfaa78838901040 # v2.23.0
+        uses: dorny/test-reporter@a6ddd83ac95ff4586f5d3aceeb314d9a1841db95 # v3.0.0
         with:
-          files: Results.StatsLogParser.xml
-          check_name: StatsLogParser Test Results
+          name: StatsLogParser Test Results
+          path: Results.StatsLogParser.xml
+          reporter: java-junit
 
   aspire:
     name: Aspire Functional Tests
@@ -285,10 +289,11 @@ jobs:
 
       - name: Publish test results
         if: always()
-        uses: EnricoMi/publish-unit-test-result-action/windows@c950f6fb443cb5af20a377fd0dfaa78838901040 # v2.23.0
+        uses: dorny/test-reporter@a6ddd83ac95ff4586f5d3aceeb314d9a1841db95 # v3.0.0
         with:
-          files: tests/TestResults/*.trx
-          check_name: Aspire Functional Test Results
+          name: Aspire Functional Test Results
+          path: tests/TestResults/*.trx
+          reporter: dotnet-trx
 
   artifacts:
     name: Build artifacts

--- a/.github/workflows/nugetgallery-ci.yml
+++ b/.github/workflows/nugetgallery-ci.yml
@@ -23,6 +23,16 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Cache NuGet packages
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.nuget/packages
+            packages
+          key: nuget-${{ hashFiles('**/*.csproj', '**/*.props', '**/*.targets', 'packages.config', 'NuGet.config') }}
+          restore-keys: |
+            nuget-
+
       - name: Build
         shell: pwsh
         run: |
@@ -57,6 +67,16 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Cache NuGet packages
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.nuget/packages
+            packages
+          key: nuget-${{ hashFiles('**/*.csproj', '**/*.props', '**/*.targets', 'packages.config', 'NuGet.config') }}
+          restore-keys: |
+            nuget-
+
       - name: Build
         shell: pwsh
         run: |
@@ -90,6 +110,16 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 1
+
+      - name: Cache NuGet packages
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.nuget/packages
+            packages
+          key: nuget-${{ hashFiles('**/*.csproj', '**/*.props', '**/*.targets', 'packages.config', 'NuGet.config') }}
+          restore-keys: |
+            nuget-
 
       - name: Build
         shell: pwsh
@@ -155,6 +185,16 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 1
+
+      - name: Cache NuGet packages
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.nuget/packages
+            packages
+          key: nuget-${{ hashFiles('**/*.csproj', '**/*.props', '**/*.targets', 'packages.config', 'NuGet.config') }}
+          restore-keys: |
+            nuget-
 
       - name: Build Gallery
         shell: pwsh
@@ -236,6 +276,16 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 1
+
+      - name: Cache NuGet packages
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.nuget/packages
+            packages
+          key: nuget-${{ hashFiles('**/*.csproj', '**/*.props', '**/*.targets', 'packages.config', 'NuGet.config') }}
+          restore-keys: |
+            nuget-
 
       - name: Build
         shell: powershell

--- a/.github/workflows/nugetgallery-ci.yml
+++ b/.github/workflows/nugetgallery-ci.yml
@@ -245,6 +245,7 @@ jobs:
           .\build.ps1 `
             -Configuration $env:BuildConfiguration `
             -BuildNumber $buildNumber `
+            -SkipArtifacts `
             -CommonAssemblyVersion $env:CommonAssemblyVersion `
             -CommonPackageVersion "$env:CommonAssemblyVersion-$branch-$buildNumber" `
             -GalleryAssemblyVersion $env:GalleryAssemblyVersion `

--- a/.github/workflows/nugetgallery-ci.yml
+++ b/.github/workflows/nugetgallery-ci.yml
@@ -1,6 +1,13 @@
 name: NuGetGallery CI
 
 on:
+  pull_request:
+  push:
+    branches:
+      - dev
+      - main
+  schedule:
+    - cron: '0 12 * * 1-5' # Weekdays at 8 AM Eastern (UTC 12:00)
   workflow_dispatch:
 
 env:

--- a/.github/workflows/nugetgallery-ci.yml
+++ b/.github/workflows/nugetgallery-ci.yml
@@ -1,0 +1,287 @@
+name: NuGetGallery CI
+
+on:
+  workflow_dispatch:
+
+env:
+  BuildConfiguration: Release
+  CommonAssemblyVersion: '5.0.0'
+  GalleryAssemblyVersion: '5.0.0'
+  JobsAssemblyVersion: '5.0.0'
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+  DOTNET_NOLOGO: true
+
+jobs:
+  common:
+    name: NuGet.Server.Common build and test
+    runs-on: windows-2025-vs2026
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Build
+        shell: pwsh
+        run: |
+          $buildNumber = "${{ github.run_number }}"
+          $branch = "${{ github.ref_name }}" -replace '[_/]', '-'
+          .\build.ps1 `
+            -Configuration $env:BuildConfiguration `
+            -BuildNumber $buildNumber `
+            -SkipArtifacts -SkipGallery -SkipJobs `
+            -CommonAssemblyVersion $env:CommonAssemblyVersion `
+            -CommonPackageVersion "$env:CommonAssemblyVersion-$branch-$buildNumber" `
+            -GalleryAssemblyVersion $env:GalleryAssemblyVersion `
+            -GalleryPackageVersion "$env:GalleryAssemblyVersion-$branch-$buildNumber" `
+            -JobsAssemblyVersion $env:JobsAssemblyVersion `
+            -JobsPackageVersion "$env:JobsAssemblyVersion-$branch-$buildNumber" `
+            -Branch "${{ github.ref_name }}" `
+            -CommitSHA "${{ github.sha }}"
+
+      - name: Run tests
+        shell: pwsh
+        run: |
+          .\test.ps1 `
+            -Configuration $env:BuildConfiguration `
+            -BuildNumber ${{ github.run_number }} `
+            -SkipGallery -SkipJobs
+
+      - name: Publish test results
+        uses: dorny/test-reporter@v1
+        if: always()
+        with:
+          name: Common Tests
+          path: Results.*.xml
+          reporter: dotnet-trx
+          fail-on-error: true
+
+  gallery:
+    name: NuGetGallery build and test
+    runs-on: windows-2025-vs2026
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Build
+        shell: pwsh
+        run: |
+          $buildNumber = "${{ github.run_number }}"
+          $branch = "${{ github.ref_name }}" -replace '[_/]', '-'
+          .\build.ps1 `
+            -Configuration $env:BuildConfiguration `
+            -BuildNumber $buildNumber `
+            -SkipArtifacts -SkipCommon -SkipJobs `
+            -CommonAssemblyVersion $env:CommonAssemblyVersion `
+            -CommonPackageVersion "$env:CommonAssemblyVersion-$branch-$buildNumber" `
+            -GalleryAssemblyVersion $env:GalleryAssemblyVersion `
+            -GalleryPackageVersion "$env:GalleryAssemblyVersion-$branch-$buildNumber" `
+            -JobsAssemblyVersion $env:JobsAssemblyVersion `
+            -JobsPackageVersion "$env:JobsAssemblyVersion-$branch-$buildNumber" `
+            -Branch "${{ github.ref_name }}" `
+            -CommitSHA "${{ github.sha }}"
+
+      - name: Run tests
+        shell: pwsh
+        run: |
+          .\test.ps1 `
+            -Configuration $env:BuildConfiguration `
+            -BuildNumber ${{ github.run_number }} `
+            -SkipCommon -SkipJobs
+
+      - name: Publish test results
+        uses: dorny/test-reporter@v1
+        if: always()
+        with:
+          name: Gallery Tests
+          path: Results.*.xml
+          reporter: dotnet-trx
+          fail-on-error: true
+
+  jobs:
+    name: NuGet.Jobs build and test
+    runs-on: windows-2025-vs2026
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Build
+        shell: pwsh
+        run: |
+          $buildNumber = "${{ github.run_number }}"
+          $branch = "${{ github.ref_name }}" -replace '[_/]', '-'
+          .\build.ps1 `
+            -Configuration $env:BuildConfiguration `
+            -BuildNumber $buildNumber `
+            -SkipArtifacts -SkipCommon -SkipGallery `
+            -CommonAssemblyVersion $env:CommonAssemblyVersion `
+            -CommonPackageVersion "$env:CommonAssemblyVersion-$branch-$buildNumber" `
+            -GalleryAssemblyVersion $env:GalleryAssemblyVersion `
+            -GalleryPackageVersion "$env:GalleryAssemblyVersion-$branch-$buildNumber" `
+            -JobsAssemblyVersion $env:JobsAssemblyVersion `
+            -JobsPackageVersion "$env:JobsAssemblyVersion-$branch-$buildNumber" `
+            -Branch "${{ github.ref_name }}" `
+            -CommitSHA "${{ github.sha }}"
+
+      - name: Run tests
+        shell: pwsh
+        run: |
+          .\test.ps1 `
+            -Configuration $env:BuildConfiguration `
+            -BuildNumber ${{ github.run_number }} `
+            -SkipCommon -SkipGallery
+
+      - name: Publish test results
+        uses: dorny/test-reporter@v1
+        if: always()
+        with:
+          name: Jobs Tests
+          path: Results.*.xml
+          reporter: dotnet-trx
+          fail-on-error: true
+
+  statslogparser:
+    name: StatsLogParser build and test
+    runs-on: windows-2025-vs2026
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: Install tools and run tests
+        shell: cmd
+        working-directory: python/StatsLogParser
+        run: |
+          python -m pip install --user pipx
+          set PATH=%USERPROFILE%\.local\bin;%PATH%
+          pipx install poetry
+          poetry install
+          poetry build
+          poetry run pytest tests/ --cov loginterpretation --cov-report html
+
+      - name: Upload StatsLogParser artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: StatsLogParser
+          path: python/StatsLogParser/dist
+
+  aspire:
+    name: Aspire Functional Tests
+    runs-on: windows-2025-vs2026
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Build Gallery
+        shell: pwsh
+        run: |
+          $buildNumber = "${{ github.run_number }}"
+          $branch = "${{ github.ref_name }}" -replace '[_/]', '-'
+          .\build.ps1 `
+            -Configuration $env:BuildConfiguration `
+            -BuildNumber $buildNumber `
+            -SkipArtifacts -SkipCommon -SkipJobs `
+            -CommonAssemblyVersion $env:CommonAssemblyVersion `
+            -CommonPackageVersion "$env:CommonAssemblyVersion-$branch-$buildNumber" `
+            -GalleryAssemblyVersion $env:GalleryAssemblyVersion `
+            -GalleryPackageVersion "$env:GalleryAssemblyVersion-$branch-$buildNumber" `
+            -JobsAssemblyVersion $env:JobsAssemblyVersion `
+            -JobsPackageVersion "$env:JobsAssemblyVersion-$branch-$buildNumber" `
+            -Branch "${{ github.ref_name }}" `
+            -CommitSHA "${{ github.sha }}"
+
+      - name: Setup Dev Environment
+        shell: pwsh
+        run: .\tools\Setup-DevEnvironment.ps1
+
+      - name: Run Aspire Functional Tests
+        shell: pwsh
+        env:
+          ConfigurationFilePath: ${{ github.workspace }}\tests\NuGetGallery.FunctionalTests\settings.CI.json
+        run: |
+          $repoRoot = "${{ github.workspace }}"
+          $config = "$env:BuildConfiguration"
+
+          # 1. Start Aspire Host
+          Write-Host "=== Starting Aspire Host ==="
+          $hostPid = & "$repoRoot\tools\Start-AspireHost.ps1" -Configuration $config -TrustDevCert
+          Write-Host "Aspire Host PID: $hostPid"
+
+          try {
+            # 2. Seed functional test data
+            Write-Host "=== Seeding functional test data ==="
+            & "$repoRoot\tools\Seed-FunctionalTestData.ps1" -Configuration $config
+            if ($LASTEXITCODE -ne 0) { throw "Seed failed with exit code $LASTEXITCODE" }
+
+            # 3. Build functional tests
+            Write-Host "=== Building functional tests ==="
+            & "$repoRoot\tests\Scripts\BuildGalleryFunctionalTests.ps1" -Configuration $config
+            if ($LASTEXITCODE -ne 0) { throw "Build functional tests failed with exit code $LASTEXITCODE" }
+
+            # 4. Run functional tests
+            Write-Host "=== Running P0, P1, and P2 functional tests ==="
+            $testDll = "$repoRoot\tests\NuGetGallery.FunctionalTests\bin\$config\net472\NuGetGallery.FunctionalTests.dll"
+            $resultsDir = "$repoRoot\tests\TestResults"
+            New-Item -ItemType Directory -Path $resultsDir -Force | Out-Null
+
+            dotnet test $testDll `
+              --blame-hang-timeout 600s `
+              --filter "Category=P0Tests|Category=P1Tests|Category=P2Tests" `
+              --logger "trx;LogFileName=FunctionalTests.trx" `
+              --results-directory $resultsDir
+
+            $testExit = $LASTEXITCODE
+            Write-Host "dotnet test exited with code $testExit"
+
+            if (Test-Path $resultsDir) {
+              Get-ChildItem -Recurse $resultsDir | ForEach-Object { Write-Host "  Result file: $($_.FullName) ($($_.Length) bytes)" }
+            }
+
+            if ($testExit -ne 0) { throw "Functional tests failed with exit code $testExit" }
+          }
+          finally {
+            # 5. Stop Aspire Host
+            Write-Host "=== Stopping Aspire Host ==="
+            & "$repoRoot\tools\Stop-AspireHost.ps1" -HostPid $hostPid
+          }
+
+      - name: Publish test results
+        uses: dorny/test-reporter@v1
+        if: always()
+        with:
+          name: Functional Tests (P0, P1, P2)
+          path: tests/TestResults/**/*.trx
+          reporter: dotnet-trx
+          fail-on-error: true
+
+  artifacts:
+    name: Build artifacts
+    runs-on: windows-2025-vs2026
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Build
+        shell: pwsh
+        run: |
+          $buildNumber = "${{ github.run_number }}"
+          $branch = "${{ github.ref_name }}" -replace '[_/]', '-'
+          .\build.ps1 `
+            -Configuration $env:BuildConfiguration `
+            -BuildNumber $buildNumber `
+            -CommonAssemblyVersion $env:CommonAssemblyVersion `
+            -CommonPackageVersion "$env:CommonAssemblyVersion-$branch-$buildNumber" `
+            -GalleryAssemblyVersion $env:GalleryAssemblyVersion `
+            -GalleryPackageVersion "$env:GalleryAssemblyVersion-$branch-$buildNumber" `
+            -JobsAssemblyVersion $env:JobsAssemblyVersion `
+            -JobsPackageVersion "$env:JobsAssemblyVersion-$branch-$buildNumber" `
+            -Branch "${{ github.ref_name }}" `
+            -CommitSHA "${{ github.sha }}"

--- a/tests/Scripts/BuildGalleryFunctionalTests.ps1
+++ b/tests/Scripts/BuildGalleryFunctionalTests.ps1
@@ -26,7 +26,7 @@ if ($LASTEXITCODE -ne 0) {
 
 # Build the solution
 Write-Host "Building solution"
-& $msbuild $solutionPath "/p:Configuration=$Configuration" ('/p:VSINSTALLDIR="' + $VsInstallationPath + '"')
+& $msbuild $solutionPath "/p:Configuration=$Configuration" ('/p:VSINSTALLDIR=' + $VsInstallationPath)
 if ($LASTEXITCODE -ne 0) {
     throw "Failed to build solution!"
 }

--- a/tools/Start-AspireHost.ps1
+++ b/tools/Start-AspireHost.ps1
@@ -23,7 +23,7 @@
     Default: Gallery HTTP, Aspire dashboard HTTP, Gallery HTTPS, Aspire dashboard HTTPS.
 
 .PARAMETER Timeout
-    Maximum seconds to wait for the first health URL to respond. Default: 300.
+    Maximum seconds to wait for the first health URL to respond. Default: 600.
 
 .PARAMETER TrustDevCert
     When set, exports the .NET dev certificate and imports it into the local machine trusted root store.
@@ -39,7 +39,7 @@ param(
 		"https://localhost/api/health-probe",
 		"https://localhost:17170"
 	),
-	[int]$Timeout = 300,
+	[int]$Timeout = 600,
 	[switch]$TrustDevCert
 )
 


### PR DESCRIPTION
## Summary

Adds a GitHub Actions CI workflow (`nugetgallery-ci.yml`) as an equivalent to the existing Azure DevOps dnceng pipeline. This gives us CI directly on GitHub with PR checks, post-merge validation, and scheduled builds.

## Triggers

| Trigger | Scope |
|---------|-------|
| `pull_request` | All PRs to any branch |
| `push` | Merges to `dev` and `main` |
| `schedule` | Weekdays at 8 AM Eastern (UTC 12:00) |
| `workflow_dispatch` | Manual |

## Workflow Structure

6 parallel jobs matching the ADO pipeline stages:

| Job | What it does |
|-----|-------------|
| **common** | Build + test `NuGet.Server.Common.sln` |
| **gallery** | Build + test `NuGetGallery.sln` |
| **jobs** | Build + test `NuGet.Jobs.sln` |
| **statslogparser** | Build + test Python StatsLogParser |
| **aspire** | Aspire functional tests (P0/P1/P2) |
| **artifacts** | Full build + signing + NuGet packaging |

## Test Result Artifacts

All test jobs upload their result files as downloadable artifacts via `actions/upload-artifact@v4`:

| Artifact | Format | Contents |
|----------|--------|----------|
| `test-results-common` | TRX | 17 files, ~940 tests |
| `test-results-gallery` | TRX | 8 files, ~12,100 tests |
| `test-results-jobs` | TRX | 33 files, ~10,700 tests |
| `test-results-aspire` | TRX | 1 file, ~175 tests |
| `test-results-statslogparser` | JUnit XML | 1 file, ~118 tests |

## Runner

Uses `windows-2025-vs2026` (beta) - Windows Server 2025 + VS 2026, equivalent to the ADO `windows.vs2026.amd64.open` pool.

## Key Differences from ADO

- Uses `shell: powershell` (Windows PowerShell 5.1) for the artifacts job to match ADO PowerShell@1 quoting behavior for MSBuild `/p:` properties
- Aspire job builds only the AppHost project (which transitively builds Gallery via the `BuildNet472Projects` target) instead of running the full `build.ps1` - cuts aspire from ~22m to ~11m
- Test results are uploaded as artifacts (inline test result publishing via `dorny/test-reporter` is pending org allowlisting)

## Other Changes

- `tools/Start-AspireHost.ps1`: Increased health probe timeout from 300s to 600s for slower CI runners
- `tests/Scripts/BuildGalleryFunctionalTests.ps1`: Fixed VSINSTALLDIR quoting that caused MSB3248 on GHA runners (extra double-quotes around `/p:VSINSTALLDIR=` value)

## Validation

- All 6 jobs passing on GHA: https://github.com/NuGet/NuGetGallery/actions/runs/25393975178
- DevDiv functional test pipeline also passes with this branch: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=14020598
