### PR TITLE
Added aria-label to task list checkboxes for accessibility

### DIFF
--- a/src/NuGetGallery/Services/MarkdownService.cs
+++ b/src/NuGetGallery/Services/MarkdownService.cs
@@ -11,7 +11,9 @@ using Ganss.Xss;
 using Markdig;
 using Markdig.Extensions.AutoIdentifiers;
 using Markdig.Extensions.EmphasisExtras;
+using Markdig.Extensions.TaskLists;
 using Markdig.Renderers;
+using Markdig.Renderers.Html;
 using Markdig.Syntax;
 using Markdig.Syntax.Inlines;
 
@@ -45,6 +47,7 @@ namespace NuGetGallery
             //Configure allowed tags, attributes for the sanitizer
             _htmlSanitizer.AllowedAttributes.Add("id");
             _htmlSanitizer.AllowedAttributes.Add("class");
+            _htmlSanitizer.AllowedAttributes.Add("aria-label");
         }
 
         private string SanitizeText(string input)
@@ -304,6 +307,11 @@ namespace NuGetGallery
                                     linkInline.Url = readyUriString;
                                 }
                             }
+                        }
+                        else if (node is TaskList taskList)
+                        {
+                            // Add aria-label to task list checkboxes for accessibility.
+                            taskList.GetAttributes().AddProperty("aria-label", taskList.Checked ? "Completed" : "Not completed");
                         }
                     }
                 }

--- a/tests/NuGetGallery.Facts/Services/MarkdownServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/MarkdownServiceFacts.cs
@@ -201,8 +201,8 @@ namespace NuGetGallery
 - [ ] Item3
 - Item4";
 
-                var expectedHtml = "<ul class=\"contains-task-list\">\n<li class=\"task-list-item\"><input disabled=\"disabled\" type=\"checkbox\"> Item1</li>\n<li class=\"task-list-item\">" +
-                    "<input disabled=\"disabled\" type=\"checkbox\" checked=\"checked\"> Item2</li>\n<li class=\"task-list-item\"><input disabled=\"disabled\" type=\"checkbox\"> " +
+                var expectedHtml = "<ul class=\"contains-task-list\">\n<li class=\"task-list-item\"><input aria-label=\"Not completed\" disabled=\"disabled\" type=\"checkbox\"> Item1</li>\n<li class=\"task-list-item\">" +
+                    "<input aria-label=\"Completed\" disabled=\"disabled\" type=\"checkbox\" checked=\"checked\"> Item2</li>\n<li class=\"task-list-item\"><input aria-label=\"Not completed\" disabled=\"disabled\" type=\"checkbox\"> " +
                     "Item3</li>\n<li>Item4</li>\n</ul>";
                 _featureFlagService.Setup(x => x.IsMarkdigMdRenderingEnabled()).Returns(true);
                 var readMeResult = _markdownService.GetHtmlFromMarkdown(originalMd);


### PR DESCRIPTION
* Accessibility error thrown for for no label 
<html>
<body>
<!--StartFragment-->
.task-list-item > input[type="checkbox"]
</body>
</html>

* Added aria-label for better screen reader accessibility
* Added a test case for this as well

Addresses https://github.com/NuGet/Engineering/issues/6400