### PR TITLE
Add binding redirect for Microsoft.Bcl.Memory

### DIFF
--- a/src/NuGetGallery/Web.config
+++ b/src/NuGetGallery/Web.config
@@ -727,6 +727,10 @@
         <bindingRedirect oldVersion="0.0.0.0-8.0.0.0" newVersion="8.0.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Bcl.Memory" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-9.0.0.14" newVersion="9.0.0.14"/>
+      </dependentAssembly>
+      <dependentAssembly>
         <assemblyIdentity name="Microsoft.AspNetCore.Cryptography.Internal" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
         <bindingRedirect oldVersion="0.0.0.0-8.0.10.0" newVersion="8.0.10.0"/>
       </dependentAssembly>


### PR DESCRIPTION
Adds a binding redirect for `Microsoft.Bcl.Memory` to Web.config to resolve MSB3277 assembly version conflict after bumping the package to 9.0.14.

This might be causing some runtime issues with JWT decoding. Will cherry-pick it to main as well.