### PR TITLE
Treat binding redirect warnings as errors

### DIFF
--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -18,6 +18,7 @@
     <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <UseIISExpress>true</UseIISExpress>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <MSBuildWarningsAsErrors>MSB3247</MSBuildWarningsAsErrors>
     <OldToolsVersion>12.0</OldToolsVersion>
     <TargetFrameworkProfile />
     <IISExpressSSLPort>443</IISExpressSSLPort>

--- a/src/NuGetGallery/Web.config
+++ b/src/NuGetGallery/Web.config
@@ -726,10 +726,10 @@
         <assemblyIdentity name="Microsoft.Bcl.AsyncInterfaces" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral"/>
         <bindingRedirect oldVersion="0.0.0.0-8.0.0.0" newVersion="8.0.0.0"/>
       </dependentAssembly>
-      <dependentAssembly>
+      <!--<dependentAssembly>
         <assemblyIdentity name="Microsoft.Bcl.Memory" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral"/>
         <bindingRedirect oldVersion="0.0.0.0-9.0.0.14" newVersion="9.0.0.14"/>
-      </dependentAssembly>
+      </dependentAssembly>-->
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.AspNetCore.Cryptography.Internal" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
         <bindingRedirect oldVersion="0.0.0.0-8.0.10.0" newVersion="8.0.10.0"/>

--- a/src/NuGetGallery/Web.config
+++ b/src/NuGetGallery/Web.config
@@ -726,10 +726,10 @@
         <assemblyIdentity name="Microsoft.Bcl.AsyncInterfaces" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral"/>
         <bindingRedirect oldVersion="0.0.0.0-8.0.0.0" newVersion="8.0.0.0"/>
       </dependentAssembly>
-      <!--<dependentAssembly>
+      <dependentAssembly>
         <assemblyIdentity name="Microsoft.Bcl.Memory" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral"/>
         <bindingRedirect oldVersion="0.0.0.0-9.0.0.14" newVersion="9.0.0.14"/>
-      </dependentAssembly>-->
+      </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.AspNetCore.Cryptography.Internal" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
         <bindingRedirect oldVersion="0.0.0.0-8.0.10.0" newVersion="8.0.10.0"/>


### PR DESCRIPTION
Oftentimes when we bump packages a binding redirect warning will appear in the build that isn't addressed (looking at me) which can lead to a runtime failure. This PR makes the build treat these warning as errors so that they will always be addressed before checking in.

Tested in the GitHub CI and NG release pipelines.

<img width="845" height="281" alt="image" src="https://github.com/user-attachments/assets/335fc65d-2845-4669-96c2-4d16ed0f1eb8" />

https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=14073358&view=logs&j=3dc8fd7e-4368-5a92-293e-d53cefc8c4b3&t=352c26c2-0ff9-5c2d-4ae8-5acc0e1d472e