### PR TITLE
Fix flaky UploadPackageToSelfFromUI functional test

### DIFF
--- a/tests/NuGetGallery.FunctionalTests.Core/Playwright/NuGetPageTest.cs
+++ b/tests/NuGetGallery.FunctionalTests.Core/Playwright/NuGetPageTest.cs
@@ -55,7 +55,7 @@ namespace NuGetGallery.FunctionalTests.Playwright
             }
 
             await Page.Locator("input[type='button'][value='Submit']").ClickAsync();
-            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+            await Page.WaitForURLAsync($"**/packages/{packageId}/**");
 
             return packagePath;
         }


### PR DESCRIPTION
## Problem

The `UploadNewVersionOfExistingPackageAsAdmin` test in the Aspire functional test suite is flaky. It intermittently fails with:

`
Locator expected to contain text 'NuGetFunctionalTest_...'
But was: 'Packages / Upload'
`

## Root cause

After clicking Submit, `UploadPackageAsync` waits for `LoadState.NetworkIdle`. However, the upload flow uses an AJAX POST followed by a client-side `document.location` redirect (in `async-file-upload.js`). `NetworkIdle` can fire in the gap between the AJAX response and the `document.location` navigation, causing the test to assert against the Upload page instead of the package details page.

## Fix

Replace `WaitForLoadStateAsync(LoadState.NetworkIdle)` with `WaitForURLAsync` that waits for actual navigation to the package details URL (`/packages/{packageId}/...`).

## Testing

Ran the 6 `UploadPackageToSelfFromUI` tests locally against Aspire, all passed.
