### PR TITLE
Migrate Functional test projects to .NET 8

### DIFF
--- a/.github/workflows/nugetgallery-ci.yml
+++ b/.github/workflows/nugetgallery-ci.yml
@@ -236,7 +236,7 @@ jobs:
 
             # 4. Run functional tests
             Write-Host "=== Running P0, P1, and P2 functional tests ==="
-            $testDll = "$repoRoot\tests\NuGetGallery.FunctionalTests\bin\$config\net472\NuGetGallery.FunctionalTests.dll"
+            $testDll = "$repoRoot\tests\NuGetGallery.FunctionalTests\bin\$config\net8.0\NuGetGallery.FunctionalTests.dll"
             $resultsDir = "$repoRoot\tests\TestResults"
             New-Item -ItemType Directory -Path $resultsDir -Force | Out-Null
 

--- a/.pipelines/NuGetGallery-CI-dnceng.yml
+++ b/.pipelines/NuGetGallery-CI-dnceng.yml
@@ -254,7 +254,7 @@ stages:
 
                   # 4. Run functional tests
                   Write-Host "=== Running P0, P1, and P2 functional tests ==="
-                  $testDll = "$repoRoot\tests\NuGetGallery.FunctionalTests\bin\$config\net472\NuGetGallery.FunctionalTests.dll"
+                  $testDll = "$repoRoot\tests\NuGetGallery.FunctionalTests\bin\$config\net8.0\NuGetGallery.FunctionalTests.dll"
                   $resultsDir = "$repoRoot\tests\TestResults"
                   New-Item -ItemType Directory -Path $resultsDir -Force | Out-Null
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,6 +6,7 @@
     <NuGetClientPackageVersion>6.13.2</NuGetClientPackageVersion>
   </PropertyGroup>
   <ItemGroup>
+    <PackageVersion Include="A11yInsights.PlaywrightChecker" Version="1.9.0" />
     <PackageVersion Include="Aspire.Hosting.Azure.Search" Version="13.2.1" />
     <PackageVersion Include="Aspire.Hosting.Azure.Storage" Version="13.2.1" />
     <PackageVersion Include="Autofac.Extensions.DependencyInjection" Version="4.4.0" />
@@ -138,7 +139,9 @@
     <PackageVersion Include="SerilogTraceListener" Version="3.2.0" />
     <PackageVersion Include="SharpZipLib" Version="1.3.3" />
     <PackageVersion Include="Strathweb.CacheOutput.WebApi2.StrongName" Version="0.9.0" />
+    <PackageVersion Include="System.CodeDom" Version="8.0.0" />
     <PackageVersion Include="System.ComponentModel.Annotations" Version="5.0.0" />
+    <PackageVersion Include="System.ServiceModel.Syndication" Version="8.0.0" />
     <PackageVersion Include="System.ComponentModel.EventBasedAsync" Version="4.0.11" />
     <PackageVersion Include="System.Data.SqlClient" Version="4.8.6" />
     <PackageVersion Include="System.Diagnostics.Debug" Version="4.3.0" />

--- a/NuGet.config
+++ b/NuGet.config
@@ -100,6 +100,7 @@
       <package pattern="Strathweb.CacheOutput.WebApi2.StrongName" />
     </packageSource>
     <packageSource key="nuget-server-upstreams">
+      <package pattern="A11yInsights.*" />
       <package pattern="Microsoft.Internal.*" />
     </packageSource>
   </packageSourceMapping>

--- a/tests/NuGetGallery.FunctionalTests.Core/NuGetGallery.FunctionalTests.Core.csproj
+++ b/tests/NuGetGallery.FunctionalTests.Core/NuGetGallery.FunctionalTests.Core.csproj
@@ -1,15 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\VisualStudioSearchPath.props" />
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>NuGetGallery.FunctionalTests</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="System.IO.Compression" />
-  </ItemGroup>
-  <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
     <PackageReference Include="Microsoft.Playwright.Xunit" />
+    <PackageReference Include="System.CodeDom" />
     <PackageReference Include="Microsoft.Web.Xdt" />
     <PackageReference Include="NuGet.Core" />
     <PackageReference Include="NuGet.Versioning" />

--- a/tests/NuGetGallery.FunctionalTests/NuGetGallery.FunctionalTests.csproj
+++ b/tests/NuGetGallery.FunctionalTests/NuGetGallery.FunctionalTests.csproj
@@ -1,14 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="System.ServiceModel" />
+    <PackageReference Include="System.ServiceModel.Syndication" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NuGetGallery.FunctionalTests.Core\NuGetGallery.FunctionalTests.Core.csproj" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="A11yInsights.PlaywrightChecker" />
     <PackageReference Include="FluentLinkChecker" />
     <PackageReference Include="NuGet.Packaging" />
     <PackageReference Include="xunit" />

--- a/tests/NuGetGallery.FunctionalTests/StaticAssets/StaticAssetsTests.cs
+++ b/tests/NuGetGallery.FunctionalTests/StaticAssets/StaticAssetsTests.cs
@@ -8,8 +8,6 @@ using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Reflection;
-using System.Runtime.Remoting.Contexts;
-using System.Security.Policy;
 using System.ServiceModel.Syndication;
 using System.Threading.Tasks;
 using System.Xml;

--- a/tests/Scripts/BuildGalleryFunctionalTests.ps1
+++ b/tests/Scripts/BuildGalleryFunctionalTests.ps1
@@ -33,7 +33,7 @@ if ($LASTEXITCODE -ne 0) {
 }
 
 Write-Host "Copying nuget.exe to functional tests directory"
-$functionalTestsDirectory = Join-Path $parentDir "NuGetGallery.FunctionalTests\bin\$Configuration\net472"
+$functionalTestsDirectory = Join-Path $parentDir "NuGetGallery.FunctionalTests\bin\$Configuration\net8.0"
 Copy-Item $nuget $functionalTestsDirectory
 Write-Host "##[endgroup]"
 

--- a/tests/Scripts/RunGalleryFunctionalTestCategory.ps1
+++ b/tests/Scripts/RunGalleryFunctionalTestCategory.ps1
@@ -8,7 +8,7 @@ $parentDir = Resolve-Path (Join-Path $PSScriptRoot "..")
 $repoDir = Resolve-Path (Join-Path $parentDir "..")
 
 # Required tools
-$xunit = Join-Path $repoDir "packages\xunit.runner.console\tools\net472\xunit.console.exe"
+$xunit = Join-Path $repoDir "packages\xunit.runner.console\tools\net8.0\xunit.console.exe"
 
 # Test results files
 $functionalTestsResults = Join-Path $parentDir "functionaltests.$TestCategory.xml"
@@ -16,7 +16,7 @@ $functionalTestsResults = Join-Path $parentDir "functionaltests.$TestCategory.xm
 # Clean previous test results
 Remove-Item $functionalTestsResults -ErrorAction Ignore
 
-$functionalTestsDirectory = Join-Path $parentDir "NuGetGallery.FunctionalTests\bin\$Configuration\net472"
+$functionalTestsDirectory = Join-Path $parentDir "NuGetGallery.FunctionalTests\bin\$Configuration\net8.0"
 
 # Run functional tests
 $fullTestCategory = "$($testCategory)Tests"


### PR DESCRIPTION
* Migrate functional test projects to .NET8
* Upgrade a few dependencies to compatible alternatives in .NET8
* Add A11y Agent checker package to prepare for A11y agent integration in functional tests in upcoming PR

Addresses https://github.com/NuGet/Engineering/issues/6427