### PR TITLE
Add DeepSeekV4.SDK to removed packages list

### DIFF
--- a/RemovedPackages.md
+++ b/RemovedPackages.md
@@ -199,6 +199,7 @@ Scanning is not perfect. Community partnership is a very valuable part of the ov
 |    Nova.GtkSharp 1.0.0.1-nova                |    04/10/2026    |   Malware  |
 |    WinDivertSharp 1.4.3.3                    |    05/18/2026    |   Potentially Malicious  |
 |    Aigio.WinDivertSharp 1.4.4.3              |    05/18/2026    |   Potentially Malicious  |
+|    DeepSeekV4.SDK                            |    05/26/2026    |   Untrustworthy  |
 
 Legend:
 - Copyright violation - Uses someone else's copyrighted or trademarked material without permission.


### PR DESCRIPTION
Added DeepSeekV4.SDK to the list of removed packages due to being untrustworthy.
