### PR TITLE
Fix CI test failure detection and disable ADO triggers

### DIFF
--- a/.pipelines/NuGetGallery-CI-dnceng.yml
+++ b/.pipelines/NuGetGallery-CI-dnceng.yml
@@ -1,16 +1,7 @@
 name: NuGetGallery CI $(Build.BuildId)
 
-trigger:
-  branches:
-    include:
-      - main
-      - dev
-  batch: True
-
-pr:
-  branches:
-    include:
-      - "*"
+trigger: none
+pr: none
 
 variables:
   - name: BuildConfiguration

--- a/.pipelines/NuGetGallery-CI.yml
+++ b/.pipelines/NuGetGallery-CI.yml
@@ -1,10 +1,6 @@
 name: NuGetGallery CI $(Build.BuildId)
 
-trigger:
-  branches:
-    include:
-      - "*"
-  batch: True
+trigger: none
 
 variables:
   - name: BuildConfiguration

--- a/test.ps1
+++ b/test.ps1
@@ -47,6 +47,9 @@ Invoke-BuildStep 'Running common tests' {
             $TestResultFile = Join-Path $PSScriptRoot "Results.Common.$TestCount.xml"
             Trace-Log "Testing $($_.Path)"
             dotnet test $_.Path --no-restore --no-build --configuration $Configuration "-l:trx;LogFileName=$TestResultFile"
+            if ($LASTEXITCODE -ne 0) {
+                Write-Error "Tests failed for $($_.Path) with exit code $LASTEXITCODE"
+            }
             if (-not (Test-Path $TestResultFile)) {
                 Write-Error "The test run failed to produce a result file";
                 exit 1;
@@ -66,6 +69,9 @@ Invoke-BuildStep 'Running gallery tests' {
             $TestResultFile = Join-Path $PSScriptRoot "Results.Gallery.$TestCount.xml"
             Trace-Log "Testing $($_.Path)"
             dotnet test $_.Path --no-restore --no-build --configuration $Configuration "-l:trx;LogFileName=$TestResultFile"
+            if ($LASTEXITCODE -ne 0) {
+                Write-Error "Tests failed for $($_.Path) with exit code $LASTEXITCODE"
+            }
             if (-not (Test-Path $TestResultFile)) {
                 Write-Error "The test run failed to produce a result file";
                 exit 1;
@@ -88,6 +94,9 @@ Invoke-BuildStep 'Running jobs tests' {
             $TestResultFile = Join-Path $PSScriptRoot "Results.Jobs.$TestCount.xml"
             Trace-Log "Testing $($_.Path)"
             dotnet test $_.Path --no-restore --no-build --configuration $Configuration "-l:trx;LogFileName=$TestResultFile"
+            if ($LASTEXITCODE -ne 0) {
+                Write-Error "Tests failed for $($_.Path) with exit code $LASTEXITCODE"
+            }
             if (-not (Test-Path $TestResultFile)) {
                 Write-Error "The test run failed to produce a result file";
                 exit 1;

--- a/tests/NuGetGallery.Core.Facts/CredentialTypesFacts.cs
+++ b/tests/NuGetGallery.Core.Facts/CredentialTypesFacts.cs
@@ -41,7 +41,7 @@ namespace NuGetGallery
         public void IsSupportedCredential(string credentialType)
         {
             var credential = new Credential(credentialType, "testcredential");
-            Assert.False(credential.IsSupportedCredential()); // intentionally broken
+            Assert.True(credential.IsSupportedCredential());
         }
     }
 }

--- a/tests/NuGetGallery.Core.Facts/CredentialTypesFacts.cs
+++ b/tests/NuGetGallery.Core.Facts/CredentialTypesFacts.cs
@@ -41,7 +41,7 @@ namespace NuGetGallery
         public void IsSupportedCredential(string credentialType)
         {
             var credential = new Credential(credentialType, "testcredential");
-            Assert.True(credential.IsSupportedCredential());
+            Assert.False(credential.IsSupportedCredential()); // intentionally broken
         }
     }
 }


### PR DESCRIPTION
## Summary

Two changes to improve CI reliability after moving to GitHub Actions.

### 1. Fail CI on unit test failures (`test.ps1`)

The `test.ps1` script was not checking `$LASTEXITCODE` after `dotnet test`, so unit test failures were silently ignored. Added exit code checks after each `dotnet test` call in all three test sections (common, gallery, jobs).

- Clean run: [passed ✅](https://github.com/NuGet/NuGetGallery/actions/runs/26475257193)
- Intentionally broken test: [failed with clear error ❌](https://github.com/NuGet/NuGetGallery/actions/runs/26475362671)

### 2. Disable ADO CI pipeline triggers

Removed CI and PR triggers from `NuGetGallery-CI.yml` and `NuGetGallery-CI-dnceng.yml`. These pipelines were still firing on every push/PR despite the move to GitHub Actions. They can still be run manually if needed.