### PR TITLE
Add MSBuild SDK to package search type filter UI

### DIFF
--- a/src/NuGetGallery/ViewModels/PackageListViewModel.cs
+++ b/src/NuGetGallery/ViewModels/PackageListViewModel.cs
@@ -59,6 +59,7 @@ namespace NuGetGallery
                 { "dependency", "Dependency" },
                 { "dotnettool", ".NET tool" },
                 { "template" , "Template" },
+                { "msbuildsdk", "MSBuild SDK" },
             };
 
             if (mcpFilteringEnabled)

--- a/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
@@ -1307,26 +1307,6 @@ namespace NuGetGallery
             }
 
             [Fact]
-            public async Task IncludesMsBuildSdkPackageTypeFilter()
-            {
-                var searchService = new Mock<ISearchService>();
-                searchService
-                    .Setup(s => s.Search(It.IsAny<SearchFilter>()))
-                    .Returns(Task.FromResult(new SearchResults(0, DateTime.UtcNow)));
-
-                var controller = CreateController(
-                    GetConfigurationService(),
-                    searchService: searchService);
-                controller.SetCurrentUser(TestUtility.FakeUser);
-
-                var result = (ViewResult)(await controller.ListPackages(new PackageListSearchViewModel { Q = "test" }));
-                var model = (PackageListViewModel)result.Model;
-
-                Assert.True(model.UiSupportedPackageTypes.ContainsKey("msbuildsdk"));
-                Assert.Equal("MSBuild SDK", model.UiSupportedPackageTypes["msbuildsdk"]);
-            }
-
-            [Fact]
             public async Task GetsValidationIssues()
             {
                 // Arrange

--- a/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
@@ -1307,6 +1307,26 @@ namespace NuGetGallery
             }
 
             [Fact]
+            public async Task IncludesMsBuildSdkPackageTypeFilter()
+            {
+                var searchService = new Mock<ISearchService>();
+                searchService
+                    .Setup(s => s.Search(It.IsAny<SearchFilter>()))
+                    .Returns(Task.FromResult(new SearchResults(0, DateTime.UtcNow)));
+
+                var controller = CreateController(
+                    GetConfigurationService(),
+                    searchService: searchService);
+                controller.SetCurrentUser(TestUtility.FakeUser);
+
+                var result = (ViewResult)(await controller.ListPackages(new PackageListSearchViewModel { Q = "test" }));
+                var model = (PackageListViewModel)result.Model;
+
+                Assert.True(model.UiSupportedPackageTypes.ContainsKey("msbuildsdk"));
+                Assert.Equal("MSBuild SDK", model.UiSupportedPackageTypes["msbuildsdk"]);
+            }
+
+            [Fact]
             public async Task GetsValidationIssues()
             {
                 // Arrange


### PR DESCRIPTION
## Summary

- Add **MSBuild SDK** to the advanced search **Package type** filter on `/packages`
- Aligns the UI with existing backend support for `packagetype=msbuildsdk`, which previously worked in search but showed an “unrecognized package type” warning
- Add `IncludesMsBuildSdkPackageTypeFilter` unit test to verify `ListPackages` exposes `msbuildsdk` in `UiSupportedPackageTypes`

## Screenshot

<!-- Replace with a screenshot of /packages with advanced search enabled, showing the Package type filter with MSBuild SDK selected -->

![MSBuild SDK package type filter on the packages search page](https://github.com/user-attachments/assets/029c450b-7f56-4272-893b-ac7cd8fd42f6)

## Test plan

- [x] Open `/packages` with advanced search enabled (`Gallery.SearchServiceUriPrimary` set and `NuGetGallery.AdvancedSearch` flight on)
- [x] Confirm **MSBuild SDK** appears under **Package type** (after Template)
- [x] Select **MSBuild SDK** and apply — URL includes `packagetype=msbuildsdk` and no unrecognized package type warning is shown
- [x] Run unit test: `IncludesMsBuildSdkPackageTypeFilter`