### PR TITLE
Add admin api endpoint for listing/unlisting packages

### DIFF
--- a/src/NuGetGallery.Services/PackageManagement/IPackageUpdateService.cs
+++ b/src/NuGetGallery.Services/PackageManagement/IPackageUpdateService.cs
@@ -24,7 +24,9 @@ namespace NuGetGallery
         /// </summary>
         /// <param name="packages">The packages to update.</param>
         /// <param name="listed">True to make the packages listed, false to make the packages unlisted.</param>
-        Task UpdateListedInBulkAsync(IReadOnlyList<Package> packages, bool listed);
+        /// <param name="reason">Optional reason for the listing change, recorded in the audit log.</param>
+        /// <param name="callerIdentity">Optional caller identity, recorded in the audit log.</param>
+        Task UpdateListedInBulkAsync(IReadOnlyList<Package> packages, bool listed, string reason = null, string callerIdentity = null);
 
         /// <summary>
         /// Marks <paramref name="package"/> as listed.

--- a/src/NuGetGallery.Services/PackageManagement/PackageUpdateService.cs
+++ b/src/NuGetGallery.Services/PackageManagement/PackageUpdateService.cs
@@ -32,7 +32,7 @@ namespace NuGetGallery
             _indexingService = indexingService ?? throw new ArgumentNullException(nameof(indexingService));
         }
 
-        public async Task UpdateListedInBulkAsync(IReadOnlyList<Package> packages, bool listed)
+        public async Task UpdateListedInBulkAsync(IReadOnlyList<Package> packages, bool listed, string reason = null, string callerIdentity = null)
         {
             if (packages == null || !packages.Any())
             {
@@ -80,7 +80,9 @@ namespace NuGetGallery
                 {
                     await _auditingService.SaveAuditRecordAsync(new PackageAuditRecord(
                         package,
-                        listed ? AuditedPackageAction.List : AuditedPackageAction.Unlist));
+                        listed ? AuditedPackageAction.List : AuditedPackageAction.Unlist,
+                        reason,
+                        callerIdentity));
                 }
             }
         }

--- a/src/NuGetGallery/App_Start/DefaultDependenciesModule.cs
+++ b/src/NuGetGallery/App_Start/DefaultDependenciesModule.cs
@@ -342,6 +342,10 @@ namespace NuGetGallery
                 .As<IPackageDeleteService>()
                 .InstancePerLifetimeScope();
 
+            builder.RegisterType<UpdateListedService>()
+                .As<IUpdateListedService>()
+                .InstancePerLifetimeScope();
+
             RegisterDeleteAccountService(builder, configuration);
 
             builder.RegisterType<PackageOwnerRequestService>()

--- a/src/NuGetGallery/App_Start/Routes.cs
+++ b/src/NuGetGallery/App_Start/Routes.cs
@@ -919,6 +919,12 @@ namespace NuGetGallery
                 "api/admin/soft-delete-package",
                 new { controller = "AdminApi", action = "SoftDeletePackage" },
                 new { httpMethod = new HttpMethodConstraint("POST") });
+
+            routes.MapRoute(
+                RouteName.AdminListPackage,
+                "api/admin/list-package",
+                new { controller = "AdminApi", action = "ListPackage" },
+                new { httpMethod = new HttpMethodConstraint("POST") });
         }
     }
 }

--- a/src/NuGetGallery/Areas/Admin/Controllers/AdminApiController.cs
+++ b/src/NuGetGallery/Areas/Admin/Controllers/AdminApiController.cs
@@ -25,6 +25,7 @@ namespace NuGetGallery.Areas.Admin.Controllers
         private readonly ILockUserService _lockUserService;
         private readonly IPackageDeleteService _packageDeleteService;
         private readonly IFeatureFlagService _featureFlagService;
+        private readonly IUpdateListedService _updateListedService;
 
         public AdminApiController(
             IPackageService packageService,
@@ -32,7 +33,8 @@ namespace NuGetGallery.Areas.Admin.Controllers
             ILockPackageService lockPackageService,
             ILockUserService lockUserService,
             IPackageDeleteService packageDeleteService,
-            IFeatureFlagService featureFlagService)
+            IFeatureFlagService featureFlagService,
+            IUpdateListedService updateListedService)
         {
             _packageService = packageService ?? throw new ArgumentNullException(nameof(packageService));
             _reflowPackageService = reflowPackageService ?? throw new ArgumentNullException(nameof(reflowPackageService));
@@ -40,6 +42,7 @@ namespace NuGetGallery.Areas.Admin.Controllers
             _lockUserService = lockUserService ?? throw new ArgumentNullException(nameof(lockUserService));
             _packageDeleteService = packageDeleteService ?? throw new ArgumentNullException(nameof(packageDeleteService));
             _featureFlagService = featureFlagService ?? throw new ArgumentNullException(nameof(featureFlagService));
+            _updateListedService = updateListedService ?? throw new ArgumentNullException(nameof(updateListedService));
         }
 
         [HttpPost]
@@ -318,6 +321,92 @@ namespace NuGetGallery.Areas.Admin.Controllers
             }
 
             return Json(HttpStatusCode.Accepted, new AdminSoftDeletePackageResponse
+            {
+                Results = results
+            });
+        }
+
+        [HttpPost]
+        [ActionName("ListPackage")]
+        public virtual async Task<ActionResult> UpdateListedPackageAsync(AdminUpdateListedPackageRequest request)
+        {
+            if (!ModelState.IsValid)
+            {
+                return BadRequestFromModelState();
+            }
+
+            var callerIdentity = HttpContext.Items[AdminApiAuthAttribute.CallerIdentityItemKey] as string;
+            var seen = new HashSet<PackageIdentity>();
+            var results = new List<AdminUpdateListedPackageResult>();
+            var hasAccepted = false;
+
+            var deduped = new List<UpdateListedPackageIdentity>();
+            foreach (var entry in request.Packages)
+            {
+                var nugetVersion = NuGetVersion.Parse(entry.Version.Trim());
+                var identity = new PackageIdentity(entry.Id.Trim(), nugetVersion);
+
+                if (!seen.Add(identity))
+                {
+                    continue;
+                }
+
+                deduped.Add(new UpdateListedPackageIdentity
+                {
+                    Id = identity.Id,
+                    Version = identity.Version.ToNormalizedString()
+                });
+            }
+
+            try
+            {
+                var serviceResults = await _updateListedService.UpdateListedAsync(
+                    deduped,
+                    request.Listed.Value,
+                    request.Reason,
+                    callerIdentity);
+
+                foreach (var serviceResult in serviceResults)
+                {
+                    var status = serviceResult.Result == UpdateListedServiceResult.Success
+                        ? AdminUpdateListedPackageStatus.Accepted
+                        : AdminUpdateListedPackageStatus.NotFound;
+
+                    if (serviceResult.Result == UpdateListedServiceResult.Success)
+                    {
+                        hasAccepted = true;
+                    }
+
+                    results.Add(new AdminUpdateListedPackageResult
+                    {
+                        Id = serviceResult.Id,
+                        Version = serviceResult.Version,
+                        Status = status
+                    });
+                }
+            }
+            catch (Exception ex)
+            {
+                foreach (var entry in deduped)
+                {
+                    results.Add(new AdminUpdateListedPackageResult
+                    {
+                        Id = entry.Id,
+                        Version = entry.Version,
+                        Status = AdminUpdateListedPackageStatus.Failed
+                    });
+                }
+
+                QuietLog.LogHandledException(ex);
+
+                return Json(HttpStatusCode.BadRequest, new AdminUpdateListedPackageResponse
+                {
+                    Results = results
+                });
+            }
+
+            var statusCode = hasAccepted ? HttpStatusCode.Accepted : HttpStatusCode.BadRequest;
+            return Json(statusCode, new AdminUpdateListedPackageResponse
             {
                 Results = results
             });

--- a/src/NuGetGallery/Areas/Admin/Controllers/UpdateListedController.cs
+++ b/src/NuGetGallery/Areas/Admin/Controllers/UpdateListedController.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Web.Mvc;
-using NuGet.Services.Entities;
 using NuGetGallery.Areas.Admin.ViewModels;
 
 namespace NuGetGallery.Areas.Admin.Controllers
@@ -14,14 +13,14 @@ namespace NuGetGallery.Areas.Admin.Controllers
     public class UpdateListedController : AdminControllerBase
     {
         private readonly IPackageService _packageService;
-        private readonly IPackageUpdateService _packageUpdateService;
+        private readonly IUpdateListedService _updateListedService;
 
         public UpdateListedController(
             IPackageService packageService,
-            IPackageUpdateService packageUpdateService)
+            IUpdateListedService updateListedService)
         {
             _packageService = packageService;
-            _packageUpdateService = packageUpdateService;
+            _updateListedService = updateListedService;
         }
 
         [HttpGet]
@@ -47,57 +46,30 @@ namespace NuGetGallery.Areas.Admin.Controllers
         [ValidateAntiForgeryToken]
         public async Task<ActionResult> UpdateListed(UpdateListedRequest updateListed)
         {
-            var idToVersions = updateListed
+            var packageIdentities = updateListed
                 .Packages
-                .Select(x => x.Split(new[] { '|' }, StringSplitOptions.RemoveEmptyEntries))
+                .Select(x => x.Split(['|'], StringSplitOptions.RemoveEmptyEntries))
                 .Where(x => x.Length == 2)
-                .GroupBy(x => x[0], x => x[1], StringComparer.OrdinalIgnoreCase);
-
-            var packageRegistrationCount = 0;
-            var packageCount = 0;
-            var noOpCount = 0;
-            foreach (var group in idToVersions)
-            {
-                var normalizedVersions = group
-                    .Select(x => NuGetVersionFormatter.Normalize(x))
-                    .ToHashSet(StringComparer.OrdinalIgnoreCase);
-
-                List<Package> packages;
-                if (normalizedVersions.Count == 1)
+                .Select(x => new UpdateListedPackageIdentity
                 {
-                    packages = new List<Package>();
-                    var package = _packageService.FindPackageByIdAndVersionStrict(group.Key, normalizedVersions.First());
-                    if (package != null)
-                    {
-                        packages.Add(package);
-                    }
-                }
-                else
-                {
-                    // Include the deprecation information since it is used in the auditing event.
-                    packages = _packageService.FindPackagesById(
-                            group.Key,
-                            PackageDeprecationFieldsToInclude.DeprecationAndRelationships)
-                        .Where(x => normalizedVersions.Contains(x.NormalizedVersion))
-                        .ToList();
-                }
+                    Id = x[0],
+                    Version = x[1]
+                })
+                .ToList();
 
-                packages = packages
-                    .Where(x => x.PackageStatusKey != PackageStatus.Deleted)
-                    .Where(x => x.PackageStatusKey != PackageStatus.FailedValidation)
-                    .ToList();
+            var serviceResults = await _updateListedService.UpdateListedAsync(
+                packageIdentities,
+                updateListed.Listed);
 
-                packageCount += packages.Count;
-                noOpCount += normalizedVersions.Count - packages.Count;
+            var packageCount = serviceResults.Count(r => r.Result == UpdateListedServiceResult.Success);
+            var noOpCount = serviceResults.Count(r => r.Result == UpdateListedServiceResult.PackageNotFound);
+            var registrationCount = serviceResults
+                .Where(r => r.Result == UpdateListedServiceResult.Success)
+                .Select(r => r.Id)
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .Count();
 
-                if (packages.Any())
-                {
-                    packageRegistrationCount++;
-                    await _packageUpdateService.UpdateListedInBulkAsync(packages, updateListed.Listed);
-                }
-            }
-
-            TempData["Message"] = $"{packageCount} packages across {packageRegistrationCount} package IDs have " +
+            TempData["Message"] = $"{packageCount} packages across {registrationCount} package IDs have " +
                 $"been {(updateListed.Listed ? "relisted" : "unlisted")}. {noOpCount} packages were skipped because " +
                 "they are deleted or they failed validation.";
 

--- a/src/NuGetGallery/Areas/Admin/Models/AdminUpdateListedPackageRequest.cs
+++ b/src/NuGetGallery/Areas/Admin/Models/AdminUpdateListedPackageRequest.cs
@@ -1,0 +1,64 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using NuGet.Versioning;
+
+namespace NuGetGallery.Areas.Admin.Models
+{
+    public class AdminUpdateListedPackageRequest : IValidatableObject
+    {
+        [Required]
+        public List<AdminUpdateListedPackageIdentity> Packages { get; set; }
+
+        [Required]
+        public bool? Listed { get; set; }
+
+        [Required(AllowEmptyStrings = false)]
+        public string Reason { get; set; }
+
+        public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+        {
+            if (Packages is null)
+            {
+                yield break;
+            }
+
+            if (Packages.Count == 0)
+            {
+                yield return new ValidationResult("The packages field must contain at least one entry.", [nameof(Packages)]);
+            }
+
+            if (Packages.Count > AdminRequestLimits.MaxPackageCount)
+            {
+                yield return new ValidationResult($"The packages field must contain at most {AdminRequestLimits.MaxPackageCount} entries.", [nameof(Packages)]);
+            }
+
+            for (var i = 0; i < Packages.Count; i++)
+            {
+                if (Packages[i] is null)
+                {
+                    yield return new ValidationResult("Package entry must not be null.", [$"{nameof(Packages)}[{i}]"]);
+                }
+            }
+        }
+    }
+
+    public class AdminUpdateListedPackageIdentity : IValidatableObject
+    {
+        [Required(AllowEmptyStrings = false)]
+        public string Id { get; set; }
+
+        [Required(AllowEmptyStrings = false)]
+        public string Version { get; set; }
+
+        public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+        {
+            if (!string.IsNullOrWhiteSpace(Version) && !NuGetVersion.TryParse(Version, out _))
+            {
+                yield return new ValidationResult("The version field must be a valid NuGet version.", [nameof(Version)]);
+            }
+        }
+    }
+}

--- a/src/NuGetGallery/Areas/Admin/Models/AdminUpdateListedPackageResponse.cs
+++ b/src/NuGetGallery/Areas/Admin/Models/AdminUpdateListedPackageResponse.cs
@@ -1,0 +1,28 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+
+namespace NuGetGallery.Areas.Admin.Models
+{
+    public class AdminUpdateListedPackageResponse
+    {
+        public List<AdminUpdateListedPackageResult> Results { get; set; }
+    }
+
+    public class AdminUpdateListedPackageResult
+    {
+        public string Id { get; set; }
+
+        public string Version { get; set; }
+
+        public string Status { get; set; }
+    }
+
+    public static class AdminUpdateListedPackageStatus
+    {
+        public const string Accepted = nameof(Accepted);
+        public const string Failed = nameof(Failed);
+        public const string NotFound = nameof(NotFound);
+    }
+}

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -191,6 +191,8 @@
     <Compile Include="Areas\Admin\Migrations\SupportRequestMigrationsConfiguration.cs" />
     <Compile Include="Areas\Admin\Models\AdminReflowPackageRequest.cs" />
     <Compile Include="Areas\Admin\Models\AdminReflowPackageResponse.cs" />
+    <Compile Include="Areas\Admin\Models\AdminUpdateListedPackageRequest.cs" />
+    <Compile Include="Areas\Admin\Models\AdminUpdateListedPackageResponse.cs" />
     <Compile Include="Areas\Admin\Models\RevokeApiKeysRequest.cs" />
     <Compile Include="Areas\Admin\Models\ValidateAccountResult.cs" />
     <Compile Include="Areas\Admin\Models\ValidateUsernameResult.cs" />
@@ -1500,6 +1502,8 @@
     <Compile Include="Services\ILockPackageService.cs" />
     <Compile Include="Services\ILockUserService.cs" />
     <Compile Include="Services\IReflowPackageService.cs" />
+    <Compile Include="Services\IUpdateListedService.cs" />
+    <Compile Include="Services\UpdateListedService.cs" />
     <Compile Include="Services\IPackageDeleteService.cs" />
     <Compile Include="Services\IRawSearchService.cs" />
     <Compile Include="Services\IStatusService.cs" />

--- a/src/NuGetGallery/RouteName.cs
+++ b/src/NuGetGallery/RouteName.cs
@@ -126,5 +126,6 @@ namespace NuGetGallery
         public const string AdminLockPackage = "AdminLockPackage";
         public const string AdminLockUser = "AdminLockUser";
         public const string AdminSoftDeletePackage = "AdminSoftDeletePackage";
+        public const string AdminListPackage = "AdminListPackage";
     }
 }

--- a/src/NuGetGallery/Services/IUpdateListedService.cs
+++ b/src/NuGetGallery/Services/IUpdateListedService.cs
@@ -1,0 +1,41 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using NuGet.Services.Entities;
+
+namespace NuGetGallery
+{
+    public enum UpdateListedServiceResult
+    {
+        Success,
+        PackageNotFound,
+    }
+
+    public interface IUpdateListedService
+    {
+        /// <summary>
+        /// Updates the listed status for the specified packages. Packages that are deleted or
+        /// failed validation are skipped. Returns per-package results indicating success or not-found.
+        /// </summary>
+        Task<IReadOnlyList<UpdateListedPackageResult>> UpdateListedAsync(
+            IReadOnlyList<UpdateListedPackageIdentity> packages,
+            bool listed,
+            string reason = null,
+            string callerIdentity = null);
+    }
+
+    public class UpdateListedPackageIdentity
+    {
+        public string Id { get; set; }
+        public string Version { get; set; }
+    }
+
+    public class UpdateListedPackageResult
+    {
+        public string Id { get; set; }
+        public string Version { get; set; }
+        public UpdateListedServiceResult Result { get; set; }
+    }
+}

--- a/src/NuGetGallery/Services/UpdateListedService.cs
+++ b/src/NuGetGallery/Services/UpdateListedService.cs
@@ -90,7 +90,7 @@ namespace NuGetGallery
 
                 if (eligible.Count > 0)
                 {
-                    await _packageUpdateService.UpdateListedInBulkAsync(eligible, listed);
+                    await _packageUpdateService.UpdateListedInBulkAsync(eligible, listed, reason, callerIdentity);
                 }
             }
 

--- a/src/NuGetGallery/Services/UpdateListedService.cs
+++ b/src/NuGetGallery/Services/UpdateListedService.cs
@@ -1,0 +1,100 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using NuGet.Services.Entities;
+
+namespace NuGetGallery
+{
+    public class UpdateListedService : IUpdateListedService
+    {
+        private readonly IPackageService _packageService;
+        private readonly IPackageUpdateService _packageUpdateService;
+
+        public UpdateListedService(
+            IPackageService packageService,
+            IPackageUpdateService packageUpdateService)
+        {
+            _packageService = packageService ?? throw new ArgumentNullException(nameof(packageService));
+            _packageUpdateService = packageUpdateService ?? throw new ArgumentNullException(nameof(packageUpdateService));
+        }
+
+        public async Task<IReadOnlyList<UpdateListedPackageResult>> UpdateListedAsync(
+            IReadOnlyList<UpdateListedPackageIdentity> packages,
+            bool listed,
+            string reason = null,
+            string callerIdentity = null)
+        {
+            if (packages is null)
+            {
+                throw new ArgumentNullException(nameof(packages));
+            }
+
+            var results = new List<UpdateListedPackageResult>();
+
+            // Group by package ID so we can call UpdateListedInBulkAsync per registration
+            var groups = packages
+                .Select(p => new
+                {
+                    Id = p.Id.Trim(),
+                    Version = NuGetVersionFormatter.Normalize(p.Version.Trim())
+                })
+                .GroupBy(p => p.Id, StringComparer.OrdinalIgnoreCase);
+
+            foreach (var group in groups)
+            {
+                var normalizedVersions = group
+                    .Select(p => p.Version)
+                    .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+                List<Package> foundPackages = [];
+                if (normalizedVersions.Count == 1)
+                {
+                    var package = _packageService.FindPackageByIdAndVersionStrict(group.Key, normalizedVersions.First());
+                    if (package != null)
+                    {
+                        foundPackages.Add(package);
+                    }
+                }
+                else
+                {
+                    foundPackages = _packageService.FindPackagesById(group.Key, PackageDeprecationFieldsToInclude.DeprecationAndRelationships)
+                        .Where(x => normalizedVersions.Contains(x.NormalizedVersion))
+                        .ToList();
+                }
+
+                var eligible = foundPackages
+                    .Where(x => x.PackageStatusKey != PackageStatus.Deleted)
+                    .Where(x => x.PackageStatusKey != PackageStatus.FailedValidation)
+                    .ToList();
+
+                var eligibleVersions = eligible
+                    .Select(x => x.NormalizedVersion)
+                    .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+                // Add results for each requested version
+                foreach (var entry in group)
+                {
+                    results.Add(new UpdateListedPackageResult
+                    {
+                        Id = group.Key,
+                        Version = entry.Version,
+                        Result = eligibleVersions.Contains(entry.Version)
+                            ? UpdateListedServiceResult.Success
+                            : UpdateListedServiceResult.PackageNotFound
+                    });
+                }
+
+                if (eligible.Count > 0)
+                {
+                    await _packageUpdateService.UpdateListedInBulkAsync(eligible, listed);
+                }
+            }
+
+            return results;
+        }
+    }
+}

--- a/tests/NuGetGallery.Facts/Areas/Admin/Controllers/AdminApiControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Areas/Admin/Controllers/AdminApiControllerFacts.cs
@@ -1370,9 +1370,9 @@ namespace NuGetGallery.Areas.Admin.Controllers
                 var request = new AdminUpdateListedPackageRequest
                 {
                     Packages =
-                    {
+                    [
                         new AdminUpdateListedPackageIdentity { Id = "TestPackage", Version = "not-a-version" }
-                    },
+                    ],
                     Listed = false,
                     Reason = "Test reason"
                 };
@@ -1409,9 +1409,9 @@ namespace NuGetGallery.Areas.Admin.Controllers
                 var request = new AdminUpdateListedPackageRequest
                 {
                     Packages =
-                    {
+                    [
                         new AdminUpdateListedPackageIdentity { Id = "TestPackage", Version = "1.0.0" }
-                    },
+                    ],
                     Listed = false,
                     Reason = "Test reason"
                 };
@@ -1449,10 +1449,10 @@ namespace NuGetGallery.Areas.Admin.Controllers
                 var request = new AdminUpdateListedPackageRequest
                 {
                     Packages =
-                    {
+                    [
                         new AdminUpdateListedPackageIdentity { Id = "TestPackage", Version = "1.0.0" },
                         new AdminUpdateListedPackageIdentity { Id = "TestPackage", Version = "1.0.0" }
-                    },
+                    ],
                     Listed = false,
                     Reason = "Test reason"
                 };
@@ -1494,9 +1494,9 @@ namespace NuGetGallery.Areas.Admin.Controllers
                 var request = new AdminUpdateListedPackageRequest
                 {
                     Packages =
-                    {
+                    [
                         new AdminUpdateListedPackageIdentity { Id = "NonExistent", Version = "1.0.0" }
-                    },
+                    ],
                     Listed = false,
                     Reason = "Test reason"
                 };
@@ -1536,9 +1536,9 @@ namespace NuGetGallery.Areas.Admin.Controllers
                 var request = new AdminUpdateListedPackageRequest
                 {
                     Packages =
-                    {
+                    [
                         new AdminUpdateListedPackageIdentity { Id = "TestPackage", Version = "1.0.0" }
-                    },
+                    ],
                     Listed = true,
                     Reason = "Relisting for production"
                 };

--- a/tests/NuGetGallery.Facts/Areas/Admin/Controllers/AdminApiControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Areas/Admin/Controllers/AdminApiControllerFacts.cs
@@ -29,7 +29,8 @@ namespace NuGetGallery.Areas.Admin.Controllers
             Mock<ILockPackageService> lockPackageService = null,
             Mock<ILockUserService> lockUserService = null,
             Mock<IPackageDeleteService> packageDeleteService = null,
-            Mock<IFeatureFlagService> featureFlagService = null)
+            Mock<IFeatureFlagService> featureFlagService = null,
+            Mock<IUpdateListedService> updateListedService = null)
         {
             packageService ??= new Mock<IPackageService>();
             reflowPackageService ??= new Mock<IReflowPackageService>();
@@ -37,6 +38,7 @@ namespace NuGetGallery.Areas.Admin.Controllers
             lockUserService ??= new Mock<ILockUserService>();
             packageDeleteService ??= new Mock<IPackageDeleteService>();
             featureFlagService ??= new Mock<IFeatureFlagService>();
+            updateListedService ??= new Mock<IUpdateListedService>();
 
             var controller = new AdminApiController(
                 packageService.Object,
@@ -44,7 +46,8 @@ namespace NuGetGallery.Areas.Admin.Controllers
                 lockPackageService.Object,
                 lockUserService.Object,
                 packageDeleteService.Object,
-                featureFlagService.Object);
+                featureFlagService.Object,
+                updateListedService.Object);
 
             var mockResponse = new Mock<HttpResponseBase>();
             mockResponse.SetupProperty(r => r.StatusCode);
@@ -1295,6 +1298,261 @@ namespace NuGetGallery.Areas.Admin.Controllers
                 Assert.Equal(AdminSoftDeletePackageStatus.NotFound, response.Results[0].Status);
             }
 
+        }
+
+        public class TheUpdateListedMethod : TestContainer
+        {
+            private readonly Mock<IUpdateListedService> _updateListedServiceMock;
+
+            public TheUpdateListedMethod()
+            {
+                _updateListedServiceMock = new Mock<IUpdateListedService>();
+            }
+
+            [Fact]
+            public async Task Returns400WhenModelStateIsInvalid()
+            {
+                var controller = CreateController(updateListedService: _updateListedServiceMock);
+                controller.ModelState.AddModelError("Packages", "The packages field is required.");
+
+                var result = await controller.UpdateListedPackageAsync(new AdminUpdateListedPackageRequest()) as JsonResult;
+
+                Assert.NotNull(result);
+                Assert.Equal((int)HttpStatusCode.BadRequest, controller.Response.StatusCode);
+            }
+
+            [Fact]
+            public async Task Returns400WhenListedIsNull()
+            {
+                var controller = CreateController(updateListedService: _updateListedServiceMock);
+                var request = new AdminUpdateListedPackageRequest
+                {
+                    Packages =
+                    [
+                        new AdminUpdateListedPackageIdentity { Id = "TestPackage", Version = "1.0.0" }
+                    ],
+                    Reason = "Test reason"
+                };
+
+                ValidateModel(controller, request);
+
+                var result = await controller.UpdateListedPackageAsync(request) as JsonResult;
+
+                Assert.NotNull(result);
+                Assert.Equal((int)HttpStatusCode.BadRequest, controller.Response.StatusCode);
+            }
+
+            [Fact]
+            public async Task Returns400WhenReasonIsMissing()
+            {
+                var controller = CreateController(updateListedService: _updateListedServiceMock);
+                var request = new AdminUpdateListedPackageRequest
+                {
+                    Packages =
+                    [
+                        new AdminUpdateListedPackageIdentity { Id = "TestPackage", Version = "1.0.0" }
+                    ],
+                    Listed = false
+                };
+
+                ValidateModel(controller, request);
+
+                var result = await controller.UpdateListedPackageAsync(request) as JsonResult;
+
+                Assert.NotNull(result);
+                Assert.Equal((int)HttpStatusCode.BadRequest, controller.Response.StatusCode);
+            }
+
+            [Fact]
+            public async Task Returns400WhenPackageVersionIsInvalid()
+            {
+                var controller = CreateController(updateListedService: _updateListedServiceMock);
+                var request = new AdminUpdateListedPackageRequest
+                {
+                    Packages =
+                    {
+                        new AdminUpdateListedPackageIdentity { Id = "TestPackage", Version = "not-a-version" }
+                    },
+                    Listed = false,
+                    Reason = "Test reason"
+                };
+
+                ValidateModel(controller, request);
+                ValidateModelItems(controller, request.Packages);
+
+                var result = await controller.UpdateListedPackageAsync(request) as JsonResult;
+
+                Assert.NotNull(result);
+                Assert.Equal((int)HttpStatusCode.BadRequest, controller.Response.StatusCode);
+            }
+
+            [Fact]
+            public async Task ReturnsAcceptedWhenRequestIsValid()
+            {
+                _updateListedServiceMock
+                    .Setup(s => s.UpdateListedAsync(
+                        It.IsAny<IReadOnlyList<UpdateListedPackageIdentity>>(),
+                        It.IsAny<bool>(),
+                        It.IsAny<string>(),
+                        It.IsAny<string>()))
+                    .ReturnsAsync(
+                    [
+                        new UpdateListedPackageResult
+                        {
+                            Id = "TestPackage",
+                            Version = "1.0.0",
+                            Result = UpdateListedServiceResult.Success
+                        }
+                    ]);
+
+                var controller = CreateController(updateListedService: _updateListedServiceMock);
+                var request = new AdminUpdateListedPackageRequest
+                {
+                    Packages =
+                    {
+                        new AdminUpdateListedPackageIdentity { Id = "TestPackage", Version = "1.0.0" }
+                    },
+                    Listed = false,
+                    Reason = "Test reason"
+                };
+
+                var result = await controller.UpdateListedPackageAsync(request) as JsonResult;
+
+                Assert.NotNull(result);
+                Assert.Equal((int)HttpStatusCode.Accepted, controller.Response.StatusCode);
+
+                var response = GetResponseData<AdminUpdateListedPackageResponse>(result);
+                Assert.Single(response.Results);
+                Assert.Equal(AdminUpdateListedPackageStatus.Accepted, response.Results[0].Status);
+            }
+
+            [Fact]
+            public async Task DeduplicatesPackageEntries()
+            {
+                _updateListedServiceMock
+                    .Setup(s => s.UpdateListedAsync(
+                        It.IsAny<IReadOnlyList<UpdateListedPackageIdentity>>(),
+                        It.IsAny<bool>(),
+                        It.IsAny<string>(),
+                        It.IsAny<string>()))
+                    .ReturnsAsync(
+                    [
+                        new UpdateListedPackageResult
+                        {
+                            Id = "TestPackage",
+                            Version = "1.0.0",
+                            Result = UpdateListedServiceResult.Success
+                        }
+                    ]);
+
+                var controller = CreateController(updateListedService: _updateListedServiceMock);
+                var request = new AdminUpdateListedPackageRequest
+                {
+                    Packages =
+                    {
+                        new AdminUpdateListedPackageIdentity { Id = "TestPackage", Version = "1.0.0" },
+                        new AdminUpdateListedPackageIdentity { Id = "TestPackage", Version = "1.0.0" }
+                    },
+                    Listed = false,
+                    Reason = "Test reason"
+                };
+
+                var result = await controller.UpdateListedPackageAsync(request) as JsonResult;
+
+                Assert.NotNull(result);
+                Assert.Equal((int)HttpStatusCode.Accepted, controller.Response.StatusCode);
+
+                _updateListedServiceMock.Verify(
+                    s => s.UpdateListedAsync(
+                        It.Is<IReadOnlyList<UpdateListedPackageIdentity>>(p => p.Count == 1),
+                        It.IsAny<bool>(),
+                        It.IsAny<string>(),
+                        It.IsAny<string>()),
+                    Times.Once);
+            }
+
+            [Fact]
+            public async Task Returns400WhenAllPackagesNotFound()
+            {
+                _updateListedServiceMock
+                    .Setup(s => s.UpdateListedAsync(
+                        It.IsAny<IReadOnlyList<UpdateListedPackageIdentity>>(),
+                        It.IsAny<bool>(),
+                        It.IsAny<string>(),
+                        It.IsAny<string>()))
+                    .ReturnsAsync(
+                    [
+                        new UpdateListedPackageResult
+                        {
+                            Id = "NonExistent",
+                            Version = "1.0.0",
+                            Result = UpdateListedServiceResult.PackageNotFound
+                        }
+                    ]);
+
+                var controller = CreateController(updateListedService: _updateListedServiceMock);
+                var request = new AdminUpdateListedPackageRequest
+                {
+                    Packages =
+                    {
+                        new AdminUpdateListedPackageIdentity { Id = "NonExistent", Version = "1.0.0" }
+                    },
+                    Listed = false,
+                    Reason = "Test reason"
+                };
+
+                var result = await controller.UpdateListedPackageAsync(request) as JsonResult;
+
+                Assert.NotNull(result);
+                Assert.Equal((int)HttpStatusCode.BadRequest, controller.Response.StatusCode);
+
+                var response = GetResponseData<AdminUpdateListedPackageResponse>(result);
+                Assert.Single(response.Results);
+                Assert.Equal(AdminUpdateListedPackageStatus.NotFound, response.Results[0].Status);
+            }
+
+            [Fact]
+            public async Task PassesReasonAndCallerIdentityToService()
+            {
+                _updateListedServiceMock
+                    .Setup(s => s.UpdateListedAsync(
+                        It.IsAny<IReadOnlyList<UpdateListedPackageIdentity>>(),
+                        It.IsAny<bool>(),
+                        It.IsAny<string>(),
+                        It.IsAny<string>()))
+                    .ReturnsAsync(
+                    [
+                        new UpdateListedPackageResult
+                        {
+                            Id = "TestPackage",
+                            Version = "1.0.0",
+                            Result = UpdateListedServiceResult.Success
+                        }
+                    ]);
+
+                var controller = CreateController(
+                    callerAzp: "test-client-id",
+                    updateListedService: _updateListedServiceMock);
+                var request = new AdminUpdateListedPackageRequest
+                {
+                    Packages =
+                    {
+                        new AdminUpdateListedPackageIdentity { Id = "TestPackage", Version = "1.0.0" }
+                    },
+                    Listed = true,
+                    Reason = "Relisting for production"
+                };
+
+                await controller.UpdateListedPackageAsync(request);
+
+                _updateListedServiceMock.Verify(
+                    s => s.UpdateListedAsync(
+                        It.IsAny<IReadOnlyList<UpdateListedPackageIdentity>>(),
+                        true,
+                        "Relisting for production",
+                        "test-client-id"),
+                    Times.Once);
+            }
         }
     }
 }

--- a/tests/NuGetGallery.Facts/Areas/Admin/Controllers/UpdateListedControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Areas/Admin/Controllers/UpdateListedControllerFacts.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Web;
@@ -34,134 +34,152 @@ namespace NuGetGallery.Areas.Admin.Controllers
         public class TheUpdateListedAction : FactsBase
         {
             [Fact]
-            public async Task ProcessesPackagesGroupedById()
+            public async Task CallsServiceWithParsedPackageIdentities()
             {
                 // Arrange
                 var input = new UpdateListedRequest
                 {
                     Listed = false,
-                    Packages = new List<string>
-                    {
-                        "NuGet.Versioning|9.9.9", // Does not exist
+                    Packages =
+                    [
                         "NuGet.Versioning|4.3.0",
                         "NuGet.Versioning|4.4.0",
                         "NuGet.Frameworks|5.3.0",
-                        "NuGet.Frameworks|5.4.0",
-                    }
+                    ]
                 };
-                
+
+                UpdateListedService
+                    .Setup(x => x.UpdateListedAsync(
+                        It.IsAny<IReadOnlyList<UpdateListedPackageIdentity>>(),
+                        It.IsAny<bool>(),
+                        It.IsAny<string>(),
+                        It.IsAny<string>()))
+                    .ReturnsAsync(
+                    [
+                        new UpdateListedPackageResult { Id = "NuGet.Versioning", Version = "4.3.0", Result = UpdateListedServiceResult.Success },
+                        new UpdateListedPackageResult { Id = "NuGet.Versioning", Version = "4.4.0", Result = UpdateListedServiceResult.Success },
+                        new UpdateListedPackageResult { Id = "NuGet.Frameworks", Version = "5.3.0", Result = UpdateListedServiceResult.Success },
+                    ]);
+
                 // Act
                 var result = await Target.UpdateListed(input);
 
                 // Assert
-                PackageService.Verify(
-                    x => x.FindPackagesById("NuGet.Versioning", PackageDeprecationFieldsToInclude.DeprecationAndRelationships),
-                    Times.Once);
-                PackageService.Verify(
-                    x => x.FindPackagesById("NuGet.Frameworks", PackageDeprecationFieldsToInclude.DeprecationAndRelationships),
-                    Times.Once);
-                PackageUpdateService.Verify(
-                    x => x.UpdateListedInBulkAsync(It.Is<IReadOnlyList<Package>>(l => l.All(i => i.Id == "NuGet.Versioning")), false),
-                    Times.Once);
-                PackageUpdateService.Verify(
-                    x => x.UpdateListedInBulkAsync(It.Is<IReadOnlyList<Package>>(l => l.All(i => i.Id == "NuGet.Frameworks")), false),
+                UpdateListedService.Verify(
+                    x => x.UpdateListedAsync(
+                        It.Is<IReadOnlyList<UpdateListedPackageIdentity>>(p => p.Count == 3),
+                        false,
+                        It.IsAny<string>(),
+                        It.IsAny<string>()),
                     Times.Once);
                 Assert.Equal(
-                    "4 packages across 2 package IDs have been unlisted. 1 packages were skipped because they are deleted or they failed validation.",
+                    "3 packages across 2 package IDs have been unlisted. 0 packages were skipped because they are deleted or they failed validation.",
                     Target.TempData["Message"]);
             }
 
-            [Theory]
-            [InlineData(PackageStatus.Deleted)]
-            [InlineData(PackageStatus.FailedValidation)]
-            public async Task FiltersOutWrongPackageStatus(PackageStatus packageStatus)
+            [Fact]
+            public async Task CountsNotFoundPackagesAsSkipped()
             {
                 // Arrange
                 var input = new UpdateListedRequest
                 {
                     Listed = false,
-                    Packages = new List<string>
-                    {
-                        "NuGet.Versioning|4.4.0",
+                    Packages =
+                    [
                         "NuGet.Versioning|4.3.0",
-                    }
+                        "NuGet.Versioning|9.9.9",
+                    ]
                 };
-                PackageRegistrationA.Packages.Single(x => x.NormalizedVersion == "4.3.0").PackageStatusKey = packageStatus;
+
+                UpdateListedService
+                    .Setup(x => x.UpdateListedAsync(
+                        It.IsAny<IReadOnlyList<UpdateListedPackageIdentity>>(),
+                        It.IsAny<bool>(),
+                        It.IsAny<string>(),
+                        It.IsAny<string>()))
+                    .ReturnsAsync(
+                    [
+                        new UpdateListedPackageResult { Id = "NuGet.Versioning", Version = "4.3.0", Result = UpdateListedServiceResult.Success },
+                        new UpdateListedPackageResult { Id = "NuGet.Versioning", Version = "9.9.9", Result = UpdateListedServiceResult.PackageNotFound },
+                    ]);
 
                 // Act
                 var result = await Target.UpdateListed(input);
 
                 // Assert
-                PackageService.Verify(
-                    x => x.FindPackagesById("NuGet.Versioning", PackageDeprecationFieldsToInclude.DeprecationAndRelationships),
-                    Times.Once);
-                PackageUpdateService.Verify(
-                    x => x.UpdateListedInBulkAsync(It.Is<IReadOnlyList<Package>>(l => l.Single().NormalizedVersion == "4.4.0"), false),
-                    Times.Once);
                 Assert.Equal(
                     "1 packages across 1 package IDs have been unlisted. 1 packages were skipped because they are deleted or they failed validation.",
                     Target.TempData["Message"]);
             }
 
             [Fact]
-            public async Task DoesNotFilterOutPackagesWithMatchingListed()
+            public async Task SkipsMalformedEntries()
             {
                 // Arrange
                 var input = new UpdateListedRequest
                 {
-                    Listed = false,
-                    Packages = new List<string>
-                    {
+                    Listed = true,
+                    Packages =
+                    [
                         "NuGet.Versioning|4.4.0",
-                        "NuGet.Versioning|4.3.0",
-                    }
+                        "malformed-no-pipe",
+                    ]
                 };
-                PackageRegistrationA.Packages.Single(x => x.NormalizedVersion == "4.3.0").Listed = false;
+
+                UpdateListedService
+                    .Setup(x => x.UpdateListedAsync(
+                        It.IsAny<IReadOnlyList<UpdateListedPackageIdentity>>(),
+                        It.IsAny<bool>(),
+                        It.IsAny<string>(),
+                        It.IsAny<string>()))
+                    .ReturnsAsync(
+                    [
+                        new UpdateListedPackageResult { Id = "NuGet.Versioning", Version = "4.4.0", Result = UpdateListedServiceResult.Success },
+                    ]);
 
                 // Act
                 var result = await Target.UpdateListed(input);
 
                 // Assert
-                PackageService.Verify(
-                    x => x.FindPackagesById("NuGet.Versioning", PackageDeprecationFieldsToInclude.DeprecationAndRelationships),
+                UpdateListedService.Verify(
+                    x => x.UpdateListedAsync(
+                        It.Is<IReadOnlyList<UpdateListedPackageIdentity>>(p => p.Count == 1 && p[0].Id == "NuGet.Versioning"),
+                        true,
+                        It.IsAny<string>(),
+                        It.IsAny<string>()),
                     Times.Once);
-                PackageUpdateService.Verify(
-                    x => x.UpdateListedInBulkAsync(It.Is<IReadOnlyList<Package>>(l => l.Count == 2), false),
-                    Times.Once);
-                Assert.Equal(
-                    "2 packages across 1 package IDs have been unlisted. 0 packages were skipped because they are deleted or they failed validation.",
-                    Target.TempData["Message"]);
             }
 
             [Fact]
-            public async Task UsesPointQueryForSingleVersion()
+            public async Task RedirectsToIndexAfterUpdate()
             {
                 // Arrange
                 var input = new UpdateListedRequest
                 {
                     Listed = false,
-                    Packages = new List<string>
-                    {
+                    Packages =
+                    [
                         "NuGet.Versioning|4.4.0",
-                    }
+                    ]
                 };
-                PackageService
-                    .Setup(x => x.FindPackageByIdAndVersionStrict("NuGet.Versioning", "4.4.0"))
-                    .Returns(() => PackageRegistrationA.Packages.Single(x => x.NormalizedVersion == "4.4.0"));
+
+                UpdateListedService
+                    .Setup(x => x.UpdateListedAsync(
+                        It.IsAny<IReadOnlyList<UpdateListedPackageIdentity>>(),
+                        It.IsAny<bool>(),
+                        It.IsAny<string>(),
+                        It.IsAny<string>()))
+                    .ReturnsAsync(
+                    [
+                        new UpdateListedPackageResult { Id = "NuGet.Versioning", Version = "4.4.0", Result = UpdateListedServiceResult.Success },
+                    ]);
 
                 // Act
                 var result = await Target.UpdateListed(input);
 
                 // Assert
-                PackageService.Verify(
-                    x => x.FindPackageByIdAndVersionStrict("NuGet.Versioning", "4.4.0"),
-                    Times.Once);
-                PackageUpdateService.Verify(
-                    x => x.UpdateListedInBulkAsync(It.Is<IReadOnlyList<Package>>(l => l.Single().NormalizedVersion == "4.4.0"), false),
-                    Times.Once);
-                Assert.Equal(
-                    "1 packages across 1 package IDs have been unlisted. 0 packages were skipped because they are deleted or they failed validation.",
-                    Target.TempData["Message"]);
+                var redirect = Assert.IsType<RedirectToRouteResult>(result);
+                Assert.Equal("Index", redirect.RouteValues["action"]);
             }
         }
 
@@ -170,20 +188,20 @@ namespace NuGetGallery.Areas.Admin.Controllers
             public FactsBase()
             {
                 PackageService = new Mock<IPackageService>();
-                PackageUpdateService = new Mock<IPackageUpdateService>();
+                UpdateListedService = new Mock<IUpdateListedService>();
                 HttpContextBase = new Mock<HttpContextBase>();
 
                 PackageRegistrationA = new PackageRegistration
                 {
                     Id = "NuGet.Versioning",
-                    Owners = new[]
-                    {
+                    Owners =
+                    [
                         new User { Username = "microsoft" },
                         new User { Username = "nuget" },
-                    },
+                    ],
                 };
-                PackageRegistrationA.Packages = new List<Package>
-                {
+                PackageRegistrationA.Packages =
+                [
                     new Package
                     {
                         Key = 3,
@@ -202,60 +220,20 @@ namespace NuGetGallery.Areas.Admin.Controllers
                         NormalizedVersion = "4.3.0",
                         PackageRegistration = PackageRegistrationA,
                     },
-                };
-                PackageRegistrationB = new PackageRegistration
-                {
-                    Id = "NuGet.Frameworks",
-                    Owners = new[]
-                    {
-                        new User { Username = "nuget" },
-                    },
-                };
-                PackageRegistrationB.Packages = new List<Package>
-                {
-                    new Package
-                    {
-                        Key = 6,
-                        NormalizedVersion = "5.5.0",
-                        PackageRegistration = PackageRegistrationB,
-                    },
-                    new Package
-                    {
-                        Key = 5,
-                        NormalizedVersion = "5.4.0",
-                        PackageRegistration = PackageRegistrationB,
-                    },
-                    new Package
-                    {
-                        Key = 4,
-                        NormalizedVersion = "5.3.0",
-                        PackageRegistration = PackageRegistrationB,
-                    },
-                };
+                ];
 
                 PackageService
                     .Setup(x => x.FindPackageRegistrationById(PackageRegistrationA.Id))
                     .Returns(() => PackageRegistrationA);
-                PackageService
-                    .Setup(x => x.FindPackageRegistrationById(PackageRegistrationB.Id))
-                    .Returns(() => PackageRegistrationB);
-                PackageService
-                    .Setup(x => x.FindPackagesById(PackageRegistrationA.Id, It.IsAny<PackageDeprecationFieldsToInclude>()))
-                    .Returns(() => (IReadOnlyCollection<Package>)PackageRegistrationA.Packages);
-                PackageService
-                    .Setup(x => x.FindPackagesById(PackageRegistrationB.Id, It.IsAny<PackageDeprecationFieldsToInclude>()))
-                    .Returns(() => (IReadOnlyCollection<Package>)PackageRegistrationB.Packages);
 
-                Target = new UpdateListedController(PackageService.Object, PackageUpdateService.Object);
+                Target = new UpdateListedController(PackageService.Object, UpdateListedService.Object);
                 TestUtility.SetupHttpContextMockForUrlGeneration(HttpContextBase, Target);
             }
 
             public Mock<IPackageService> PackageService { get; }
-            public Mock<IPackageUpdateService> PackageUpdateService { get; }
+            public Mock<IUpdateListedService> UpdateListedService { get; }
             public Mock<HttpContextBase> HttpContextBase { get; }
             public PackageRegistration PackageRegistrationA { get; }
-            public string Query { get; set; }
-            public PackageRegistration PackageRegistrationB { get; }
             public UpdateListedController Target { get; }
         }
     }

--- a/tests/NuGetGallery.Facts/Controllers/ControllerTests.cs
+++ b/tests/NuGetGallery.Facts/Controllers/ControllerTests.cs
@@ -81,6 +81,7 @@ namespace NuGetGallery.Controllers
                 new ControllerActionRuleException(typeof(AdminApiController), nameof(AdminApiController.LockPackageAsync)),
                 new ControllerActionRuleException(typeof(AdminApiController), nameof(AdminApiController.LockUserAsync)),
                 new ControllerActionRuleException(typeof(AdminApiController), nameof(AdminApiController.SoftDeletePackageAsync)),
+                new ControllerActionRuleException(typeof(AdminApiController), nameof(AdminApiController.UpdateListedPackageAsync)),
             };
 
             // Act

--- a/tests/NuGetGallery.Facts/Services/PackageUpdateServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/PackageUpdateServiceFacts.cs
@@ -136,7 +136,7 @@ namespace NuGetGallery.Services
                 var service = Get<PackageUpdateService>();
 
                 // Act
-                await service.UpdateListedInBulkAsync(packages, listed);
+                await service.UpdateListedInBulkAsync(packages, listed, "test reason", "test-caller");
 
                 // Assert
                 packageServiceMock.Verify();
@@ -147,7 +147,10 @@ namespace NuGetGallery.Services
 
                 Assert.Equal(listed, listedPackage.Listed);
                 Assert.Equal(listed, unlistedPackage.Listed);
-                auditingService.WroteRecord<PackageAuditRecord>(r => r.Action == action);
+                auditingService.WroteRecord<PackageAuditRecord>(r =>
+                    r.Action == action &&
+                    r.Reason == "test reason" &&
+                    r.CallerIdentity == "test-caller");
             }
         }
 

--- a/tests/NuGetGallery.Facts/Services/UpdateListedServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/UpdateListedServiceFacts.cs
@@ -1,0 +1,345 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Moq;
+using NuGet.Services.Entities;
+using Xunit;
+
+namespace NuGetGallery.Services
+{
+    public class UpdateListedServiceFacts
+    {
+        public class TheUpdateListedAsyncMethod
+        {
+            private readonly Mock<IPackageService> _packageService;
+            private readonly Mock<IPackageUpdateService> _packageUpdateService;
+            private readonly UpdateListedService _target;
+
+            private readonly PackageRegistration _registrationA;
+            private readonly PackageRegistration _registrationB;
+
+            public TheUpdateListedAsyncMethod()
+            {
+                _packageService = new Mock<IPackageService>();
+                _packageUpdateService = new Mock<IPackageUpdateService>();
+                _target = new UpdateListedService(_packageService.Object, _packageUpdateService.Object);
+
+                _registrationA = new PackageRegistration
+                {
+                    Key = 1,
+                    Id = "NuGet.Versioning",
+                };
+                _registrationA.Packages = new List<Package>
+                {
+                    new Package
+                    {
+                        Key = 1,
+                        NormalizedVersion = "4.3.0",
+                        PackageRegistration = _registrationA,
+                        PackageRegistrationKey = _registrationA.Key,
+                    },
+                    new Package
+                    {
+                        Key = 2,
+                        NormalizedVersion = "4.4.0",
+                        PackageRegistration = _registrationA,
+                        PackageRegistrationKey = _registrationA.Key,
+                    },
+                    new Package
+                    {
+                        Key = 3,
+                        NormalizedVersion = "4.5.0",
+                        PackageRegistration = _registrationA,
+                        PackageRegistrationKey = _registrationA.Key,
+                    },
+                };
+
+                _registrationB = new PackageRegistration
+                {
+                    Key = 2,
+                    Id = "NuGet.Frameworks",
+                };
+                _registrationB.Packages = new List<Package>
+                {
+                    new Package
+                    {
+                        Key = 4,
+                        NormalizedVersion = "5.3.0",
+                        PackageRegistration = _registrationB,
+                        PackageRegistrationKey = _registrationB.Key,
+                    },
+                    new Package
+                    {
+                        Key = 5,
+                        NormalizedVersion = "5.4.0",
+                        PackageRegistration = _registrationB,
+                        PackageRegistrationKey = _registrationB.Key,
+                    },
+                };
+
+                _packageService
+                    .Setup(x => x.FindPackagesById("NuGet.Versioning", It.IsAny<PackageDeprecationFieldsToInclude>()))
+                    .Returns(() => (IReadOnlyCollection<Package>)_registrationA.Packages);
+                _packageService
+                    .Setup(x => x.FindPackagesById("NuGet.Frameworks", It.IsAny<PackageDeprecationFieldsToInclude>()))
+                    .Returns(() => (IReadOnlyCollection<Package>)_registrationB.Packages);
+            }
+
+            [Fact]
+            public async Task ThrowsWhenPackagesIsNull()
+            {
+                await Assert.ThrowsAsync<ArgumentNullException>(
+                    () => _target.UpdateListedAsync(null, false));
+            }
+
+            [Fact]
+            public async Task UsesPointQueryForSingleVersion()
+            {
+                // Arrange
+                var package = _registrationA.Packages.Single(x => x.NormalizedVersion == "4.4.0");
+                _packageService
+                    .Setup(x => x.FindPackageByIdAndVersionStrict("NuGet.Versioning", "4.4.0"))
+                    .Returns(package);
+
+                var input = new List<UpdateListedPackageIdentity>
+                {
+                    new UpdateListedPackageIdentity { Id = "NuGet.Versioning", Version = "4.4.0" }
+                };
+
+                // Act
+                var results = await _target.UpdateListedAsync(input, false);
+
+                // Assert
+                _packageService.Verify(
+                    x => x.FindPackageByIdAndVersionStrict("NuGet.Versioning", "4.4.0"),
+                    Times.Once);
+                _packageService.Verify(
+                    x => x.FindPackagesById(It.IsAny<string>(), It.IsAny<PackageDeprecationFieldsToInclude>()),
+                    Times.Never);
+                Assert.Single(results);
+                Assert.Equal(UpdateListedServiceResult.Success, results[0].Result);
+            }
+
+            [Fact]
+            public async Task UsesBulkQueryForMultipleVersions()
+            {
+                // Arrange
+                var input = new List<UpdateListedPackageIdentity>
+                {
+                    new UpdateListedPackageIdentity { Id = "NuGet.Versioning", Version = "4.3.0" },
+                    new UpdateListedPackageIdentity { Id = "NuGet.Versioning", Version = "4.4.0" },
+                };
+
+                // Act
+                var results = await _target.UpdateListedAsync(input, false);
+
+                // Assert
+                _packageService.Verify(
+                    x => x.FindPackagesById("NuGet.Versioning", PackageDeprecationFieldsToInclude.DeprecationAndRelationships),
+                    Times.Once);
+                _packageService.Verify(
+                    x => x.FindPackageByIdAndVersionStrict(It.IsAny<string>(), It.IsAny<string>()),
+                    Times.Never);
+                Assert.Equal(2, results.Count);
+                Assert.All(results, r => Assert.Equal(UpdateListedServiceResult.Success, r.Result));
+            }
+
+            [Fact]
+            public async Task GroupsByPackageIdAndCallsUpdatePerGroup()
+            {
+                // Arrange
+                _packageService
+                    .Setup(x => x.FindPackageByIdAndVersionStrict("NuGet.Versioning", "4.3.0"))
+                    .Returns(_registrationA.Packages.Single(x => x.NormalizedVersion == "4.3.0"));
+                _packageService
+                    .Setup(x => x.FindPackageByIdAndVersionStrict("NuGet.Frameworks", "5.3.0"))
+                    .Returns(_registrationB.Packages.Single(x => x.NormalizedVersion == "5.3.0"));
+
+                var input = new List<UpdateListedPackageIdentity>
+                {
+                    new UpdateListedPackageIdentity { Id = "NuGet.Versioning", Version = "4.3.0" },
+                    new UpdateListedPackageIdentity { Id = "NuGet.Frameworks", Version = "5.3.0" },
+                };
+
+                // Act
+                var results = await _target.UpdateListedAsync(input, false);
+
+                // Assert
+                _packageUpdateService.Verify(
+                    x => x.UpdateListedInBulkAsync(
+                        It.Is<IReadOnlyList<Package>>(l => l.All(p => p.PackageRegistration.Id == "NuGet.Versioning")),
+                        false, null, null),
+                    Times.Once);
+                _packageUpdateService.Verify(
+                    x => x.UpdateListedInBulkAsync(
+                        It.Is<IReadOnlyList<Package>>(l => l.All(p => p.PackageRegistration.Id == "NuGet.Frameworks")),
+                        false, null, null),
+                    Times.Once);
+                Assert.Equal(2, results.Count);
+                Assert.All(results, r => Assert.Equal(UpdateListedServiceResult.Success, r.Result));
+            }
+
+            [Theory]
+            [InlineData(PackageStatus.Deleted)]
+            [InlineData(PackageStatus.FailedValidation)]
+            public async Task FiltersOutIneligiblePackageStatuses(PackageStatus status)
+            {
+                // Arrange
+                _registrationA.Packages.Single(x => x.NormalizedVersion == "4.3.0").PackageStatusKey = status;
+
+                var input = new List<UpdateListedPackageIdentity>
+                {
+                    new UpdateListedPackageIdentity { Id = "NuGet.Versioning", Version = "4.3.0" },
+                    new UpdateListedPackageIdentity { Id = "NuGet.Versioning", Version = "4.4.0" },
+                };
+
+                // Act
+                var results = await _target.UpdateListedAsync(input, false);
+
+                // Assert
+                Assert.Equal(2, results.Count);
+                Assert.Equal(UpdateListedServiceResult.PackageNotFound, results.Single(r => r.Version == "4.3.0").Result);
+                Assert.Equal(UpdateListedServiceResult.Success, results.Single(r => r.Version == "4.4.0").Result);
+
+                _packageUpdateService.Verify(
+                    x => x.UpdateListedInBulkAsync(
+                        It.Is<IReadOnlyList<Package>>(l => l.Count == 1 && l[0].NormalizedVersion == "4.4.0"),
+                        false, null, null),
+                    Times.Once);
+            }
+
+            [Fact]
+            public async Task ReturnsNotFoundForMissingPackages()
+            {
+                // Arrange
+                _packageService
+                    .Setup(x => x.FindPackageByIdAndVersionStrict("NuGet.Versioning", "9.9.9"))
+                    .Returns((Package)null);
+
+                var input = new List<UpdateListedPackageIdentity>
+                {
+                    new UpdateListedPackageIdentity { Id = "NuGet.Versioning", Version = "9.9.9" },
+                };
+
+                // Act
+                var results = await _target.UpdateListedAsync(input, false);
+
+                // Assert
+                Assert.Single(results);
+                Assert.Equal(UpdateListedServiceResult.PackageNotFound, results[0].Result);
+
+                _packageUpdateService.Verify(
+                    x => x.UpdateListedInBulkAsync(
+                        It.IsAny<IReadOnlyList<Package>>(),
+                        It.IsAny<bool>(),
+                        It.IsAny<string>(),
+                        It.IsAny<string>()),
+                    Times.Never);
+            }
+
+            [Fact]
+            public async Task DoesNotSkipPackagesAlreadyMatchingListedState()
+            {
+                // Arrange
+                _registrationA.Packages.Single(x => x.NormalizedVersion == "4.3.0").Listed = false;
+
+                var input = new List<UpdateListedPackageIdentity>
+                {
+                    new UpdateListedPackageIdentity { Id = "NuGet.Versioning", Version = "4.3.0" },
+                    new UpdateListedPackageIdentity { Id = "NuGet.Versioning", Version = "4.4.0" },
+                };
+
+                // Act
+                var results = await _target.UpdateListedAsync(input, false);
+
+                // Assert
+                Assert.Equal(2, results.Count);
+                Assert.All(results, r => Assert.Equal(UpdateListedServiceResult.Success, r.Result));
+
+                _packageUpdateService.Verify(
+                    x => x.UpdateListedInBulkAsync(
+                        It.Is<IReadOnlyList<Package>>(l => l.Count == 2),
+                        false, null, null),
+                    Times.Once);
+            }
+
+            [Fact]
+            public async Task PassesReasonAndCallerIdentityToUpdateService()
+            {
+                // Arrange
+                _packageService
+                    .Setup(x => x.FindPackageByIdAndVersionStrict("NuGet.Versioning", "4.4.0"))
+                    .Returns(_registrationA.Packages.Single(x => x.NormalizedVersion == "4.4.0"));
+
+                var input = new List<UpdateListedPackageIdentity>
+                {
+                    new UpdateListedPackageIdentity { Id = "NuGet.Versioning", Version = "4.4.0" },
+                };
+
+                // Act
+                await _target.UpdateListedAsync(input, false, "test reason", "test-caller");
+
+                // Assert
+                _packageUpdateService.Verify(
+                    x => x.UpdateListedInBulkAsync(
+                        It.IsAny<IReadOnlyList<Package>>(),
+                        false,
+                        "test reason",
+                        "test-caller"),
+                    Times.Once);
+            }
+
+            [Fact]
+            public async Task NormalizesVersions()
+            {
+                // Arrange
+                _packageService
+                    .Setup(x => x.FindPackageByIdAndVersionStrict("NuGet.Versioning", "4.4.0"))
+                    .Returns(_registrationA.Packages.Single(x => x.NormalizedVersion == "4.4.0"));
+
+                var input = new List<UpdateListedPackageIdentity>
+                {
+                    new UpdateListedPackageIdentity { Id = "NuGet.Versioning", Version = "4.4.0.0" },
+                };
+
+                // Act
+                var results = await _target.UpdateListedAsync(input, false);
+
+                // Assert
+                _packageService.Verify(
+                    x => x.FindPackageByIdAndVersionStrict("NuGet.Versioning", "4.4.0"),
+                    Times.Once);
+                Assert.Single(results);
+                Assert.Equal("4.4.0", results[0].Version);
+            }
+
+            [Fact]
+            public async Task TrimsWhitespaceFromIdAndVersion()
+            {
+                // Arrange
+                _packageService
+                    .Setup(x => x.FindPackageByIdAndVersionStrict("NuGet.Versioning", "4.4.0"))
+                    .Returns(_registrationA.Packages.Single(x => x.NormalizedVersion == "4.4.0"));
+
+                var input = new List<UpdateListedPackageIdentity>
+                {
+                    new UpdateListedPackageIdentity { Id = "  NuGet.Versioning  ", Version = "  4.4.0  " },
+                };
+
+                // Act
+                var results = await _target.UpdateListedAsync(input, false);
+
+                // Assert
+                _packageService.Verify(
+                    x => x.FindPackageByIdAndVersionStrict("NuGet.Versioning", "4.4.0"),
+                    Times.Once);
+                Assert.Single(results);
+                Assert.Equal(UpdateListedServiceResult.Success, results[0].Result);
+            }
+        }
+    }
+}

--- a/tests/NuGetGallery.FunctionalTests/AdminApi/AdminApiTests.cs
+++ b/tests/NuGetGallery.FunctionalTests/AdminApi/AdminApiTests.cs
@@ -43,6 +43,7 @@ namespace NuGetGallery.FunctionalTests.AdminApi
             [InlineData("/api/admin/lock-package")]
             [InlineData("/api/admin/lock-user")]
             [InlineData("/api/admin/soft-delete-package")]
+            [InlineData("/api/admin/list-package")]
             public async Task Returns401WhenNoAuthorizationHeader(string endpoint)
             {
                 var response = await PostJsonAsync(endpoint, "{}");
@@ -58,6 +59,7 @@ namespace NuGetGallery.FunctionalTests.AdminApi
             [InlineData("/api/admin/lock-package")]
             [InlineData("/api/admin/lock-user")]
             [InlineData("/api/admin/soft-delete-package")]
+            [InlineData("/api/admin/list-package")]
             public async Task Returns401WhenWrongScheme(string endpoint)
             {
                 var request = CreatePostRequest(endpoint, "{}");
@@ -75,6 +77,7 @@ namespace NuGetGallery.FunctionalTests.AdminApi
             [InlineData("/api/admin/lock-package")]
             [InlineData("/api/admin/lock-user")]
             [InlineData("/api/admin/soft-delete-package")]
+            [InlineData("/api/admin/list-package")]
             public async Task Returns401WhenGarbageBearerToken(string endpoint)
             {
                 var request = CreatePostRequest(endpoint, "{}");
@@ -92,6 +95,7 @@ namespace NuGetGallery.FunctionalTests.AdminApi
             [InlineData("/api/admin/lock-package")]
             [InlineData("/api/admin/lock-user")]
             [InlineData("/api/admin/soft-delete-package")]
+            [InlineData("/api/admin/list-package")]
             public async Task Returns403WhenWrongTenant(string endpoint)
             {
                 var token = CreateFakeJwt("wrong-tenant-id", GetAllowedClientId());
@@ -110,6 +114,7 @@ namespace NuGetGallery.FunctionalTests.AdminApi
             [InlineData("/api/admin/lock-package")]
             [InlineData("/api/admin/lock-user")]
             [InlineData("/api/admin/soft-delete-package")]
+            [InlineData("/api/admin/list-package")]
             public async Task Returns403WhenWrongClientId(string endpoint)
             {
                 var token = CreateFakeJwt(GetAllowedTenantId(), "wrong-client-id");
@@ -139,6 +144,7 @@ namespace NuGetGallery.FunctionalTests.AdminApi
             [InlineData("/api/admin/lock-package")]
             [InlineData("/api/admin/lock-user")]
             [InlineData("/api/admin/soft-delete-package")]
+            [InlineData("/api/admin/list-package")]
             public async Task Returns400ForMalformedJson(string endpoint)
             {
                 var response = await PostAuthenticatedJsonAsync(endpoint, "{not valid json");
@@ -285,6 +291,51 @@ namespace NuGetGallery.FunctionalTests.AdminApi
                 Assert.NotNull(unlockResults);
                 Assert.Single(unlockResults);
                 Assert.Equal("Accepted", unlockResults[0]["Status"]?.ToString());
+            }
+
+            [Fact]
+            [Priority(2)]
+            [Category("AdminApiTests")]
+            public async Task UnlistsAndRelistsExistingPackage()
+            {
+                const string packageId = "BaseTestPackage";
+                const string packageVersion = "1.0.0";
+
+                // Unlist the package
+                var unlistBody = JsonConvert.SerializeObject(new
+                {
+                    packages = new[] { new { id = packageId, version = packageVersion } },
+                    listed = false,
+                    reason = "Functional test unlist"
+                });
+
+                var unlistResponse = await PostAuthenticatedJsonAsync("/api/admin/list-package", unlistBody);
+
+                var unlistJson = await ReadJsonAsync(unlistResponse);
+                TestOutputHelper.WriteLine($"Unlist response: {unlistJson}");
+                Assert.Equal(HttpStatusCode.Accepted, unlistResponse.StatusCode);
+                var unlistResults = unlistJson["Results"] as JArray;
+                Assert.NotNull(unlistResults);
+                Assert.Single(unlistResults);
+                Assert.Equal("Accepted", unlistResults[0]["Status"]?.ToString());
+
+                // Relist the package (verifies round-trip and cleans up)
+                var relistBody = JsonConvert.SerializeObject(new
+                {
+                    packages = new[] { new { id = packageId, version = packageVersion } },
+                    listed = true,
+                    reason = "Functional test relist"
+                });
+
+                var relistResponse = await PostAuthenticatedJsonAsync("/api/admin/list-package", relistBody);
+
+                var relistJson = await ReadJsonAsync(relistResponse);
+                TestOutputHelper.WriteLine($"Relist response: {relistJson}");
+                Assert.Equal(HttpStatusCode.Accepted, relistResponse.StatusCode);
+                var relistResults = relistJson["Results"] as JArray;
+                Assert.NotNull(relistResults);
+                Assert.Single(relistResults);
+                Assert.Equal("Accepted", relistResults[0]["Status"]?.ToString());
             }
 
             [Fact]


### PR DESCRIPTION
- Add new admin api endpoint for listing and unlisting packages.
- Create new `UpdateListedService` which is shared between the new endpoint and existing admin controller.
- Unit and functional tests.

```
POST /api/admin/list-package
 
Auth: Bearer token (Entra ID, same as other admin API endpoints)
 
Request:
 
{
   "packages": [
     { "id": "NuGet.Versioning", "version": "4.3.0" },
     { "id": "NuGet.Versioning", "version": "4.4.0" }
   ],
   "listed": false,
   "reason": "Unlisting due to critical vulnerability"
}
 
- packages — required, 1-100 entries, valid NuGet version strings
- listed — required, true to relist, false to unlist
- reason — required, non-empty string
 
Response (202 if any succeeded, 400 if all failed/not found):
 
{
   "Results": [
     { "Id": "NuGet.Versioning", "Version": "4.3.0", "Status": "Accepted" },
     { "Id": "NuGet.Versioning", "Version": "4.4.0", "Status": "NotFound" }
   ]
}
 
Status values: Accepted, NotFound, Failed
 
Deleted and failed-validation packages are skipped (returned as NotFound). Duplicates are deduped.
```