### PR TITLE
Update framework docs links to Learn

### DIFF
--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -877,7 +877,7 @@
                         else
                         {
                             <span tabindex="0">There are no supported framework assets in this package.</span><br/>
-                            <p class="frameworktableinfo-text"><i>Learn more about <a href='https://docs.microsoft.com/dotnet/standard/frameworks' aria-label="Learn more about Target Frameworks">Target Frameworks</a> and <a href='https://docs.microsoft.com/dotnet/standard/net-standard' aria-label="Learn more about .NET Standard">.NET Standard</a>.</i></p>
+                            <p class="frameworktableinfo-text"><i>Learn more about <a href='https://learn.microsoft.com/dotnet/standard/frameworks' aria-label="Learn more about Target Frameworks">Target Frameworks</a> and <a href='https://learn.microsoft.com/dotnet/standard/net-standard' aria-label="Learn more about .NET Standard">.NET Standard</a>.</i></p>
                         }
                     </div>
                     }

--- a/src/NuGetGallery/Views/Packages/_SupportedFrameworksTable.cshtml
+++ b/src/NuGetGallery/Views/Packages/_SupportedFrameworksTable.cshtml
@@ -48,5 +48,5 @@
         <i class="frameworktableinfo-asset-icon"></i>
         <span class="frameworktableinfo-text">Included target framework(s) (in package)</span>
     </div>
-    <span class="frameworktableinfo-text"><i>Learn more about <a href='https://docs.microsoft.com/dotnet/standard/frameworks' aria-label="Learn more about Target Frameworks">Target Frameworks</a> and <a href='https://docs.microsoft.com/dotnet/standard/net-standard' aria-label="Learn more about .NET Standard">.NET Standard</a>.</i></span>
+    <span class="frameworktableinfo-text"><i>Learn more about <a href='https://learn.microsoft.com/dotnet/standard/frameworks' aria-label="Learn more about Target Frameworks">Target Frameworks</a> and <a href='https://learn.microsoft.com/dotnet/standard/net-standard' aria-label="Learn more about .NET Standard">.NET Standard</a>.</i></span>
 </div>


### PR DESCRIPTION
Summary of the changes (in less than 80 characters):

Update supported frameworks docs links to use learn.microsoft.com.

* Replaces the Target Frameworks help link in the supported frameworks table and fallback UI.
* Replaces the .NET Standard help link in the same package page UI while preserving paths, link text, and aria labels.

Addresses N/A