### PR TITLE
Fixes semantic ordering for FilterLatestPackageHelper fallback

### DIFF
--- a/src/NuGetGallery.Services/PackageManagement/PackageService.cs
+++ b/src/NuGetGallery.Services/PackageManagement/PackageService.cs
@@ -497,9 +497,15 @@ namespace NuGetGallery
 
             // If we couldn't find a package marked as latest, then return the most recent one.
             // Prereleases were already filtered out if appropriate.
+            // Uses normalized package version for semantic ordering.
             if (package == null)
             {
-                package = packages.OrderByDescending(p => p.Version).FirstOrDefault();
+                package = packages
+                    .OrderByDescending(p => {
+                        NuGetVersion.TryParse(NuGetVersionFormatter.GetNormalizedPackageVersion(p), out var v);
+                        return v;
+                    })
+                    .FirstOrDefault();
             }
 
             return package;

--- a/tests/NuGetGallery.Facts/Services/PackageServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/PackageServiceFacts.cs
@@ -1389,6 +1389,24 @@ namespace NuGetGallery
             }
 
             [Fact]
+            public void ReturnsHighestSemanticVersionIfNoLatestVersionIsAvailable()
+            {
+                // Arrange
+                var packageRegistration = new PackageRegistration { Id = Id };
+                var package1 = new Package { Version = "1.0.11", PackageRegistration = packageRegistration, IsLatest = false, Listed = false };
+                var package2 = new Package { Version = "1.0.10", PackageRegistration = packageRegistration, IsLatest = false, Listed = false };
+                var package3 = new Package { Version = "1.0.9", PackageRegistration = packageRegistration, IsLatest = false, Listed = false };
+
+                // Act
+                var result = InvokeMethod(new[] { package1, package2, package3 });
+
+                // Assert
+                Assert.NotNull(result);
+                Assert.Equal("1.0.11", result.Version);
+            }
+
+
+            [Fact]
             public void ThrowsIfPackagesNull()
             {
                 Assert.Throws<ArgumentNullException>(() => InvokeMethod(null));


### PR DESCRIPTION
Ensures semantic ordering in FilterLatestPackageHelper

* Use NuGetVersion.TryParse and NuGetVersionFormatter.GetNormalizedPackageVersion for semantic ordering in fallback path
* Add test ReturnsHighestSemanticVersionIfNoLatestVersionIsAvailable

Addresses https://github.com/NuGet/NuGetGallery/issues/10796