### PR TITLE
Fixes semantic ordering for FilterLatestPackageHelper fallback

### DIFF
--- a/src/NuGetGallery.Services/PackageManagement/PackageService.cs
+++ b/src/NuGetGallery.Services/PackageManagement/PackageService.cs
@@ -522,9 +522,15 @@ namespace NuGetGallery
 
             // If we couldn't find a package marked as latest, then return the most recent one.
             // Prereleases were already filtered out if appropriate.
+            // Uses normalized package version for semantic ordering.
             if (package == null)
             {
-                package = packages.OrderByDescending(p => p.Version).FirstOrDefault();
+                package = packages
+                    .OrderByDescending(p => {
+                        NuGetVersion.TryParse(NuGetVersionFormatter.GetNormalizedPackageVersion(p), out var v);
+                        return v;
+                    })
+                    .FirstOrDefault();
             }
 
             return package;

--- a/src/NuGetGallery.Services/PackageManagement/PackageService.cs
+++ b/src/NuGetGallery.Services/PackageManagement/PackageService.cs
@@ -527,9 +527,10 @@ namespace NuGetGallery
             {
                 package = packages
                     .OrderByDescending(p => {
-                        NuGetVersion.TryParse(NuGetVersionFormatter.GetNormalizedPackageVersion(p), out var v);
+                        _ = NuGetVersion.TryParse(NuGetVersionFormatter.GetNormalizedPackageVersion(p), out var v);
                         return v;
                     })
+                        .ThenByDescending(p => p.Key)
                     .FirstOrDefault();
             }
 

--- a/tests/NuGetGallery.Facts/Services/PackageServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/PackageServiceFacts.cs
@@ -1405,6 +1405,41 @@ namespace NuGetGallery
                 Assert.Equal("1.0.11", result.Version);
             }
 
+            [Fact]
+            public void ReturnsHighestKeyWhenAllVersionsFailToParseAndNoLatestVersionIsAvailable()
+            {
+                // Arrange
+                var packageRegistration = new PackageRegistration { Id = Id };
+                var package1 = new Package { Key = 1, Version = "not-an-accepted-version", PackageRegistration = packageRegistration, IsLatest = false, Listed = false };
+                var package2 = new Package { Key = 2, Version = "fails-2-parse-2", PackageRegistration = packageRegistration, IsLatest = false, Listed = false };
+                var package3 = new Package { Key = 3, Version = "fails-2-parse", PackageRegistration = packageRegistration, IsLatest = false, Listed = false };
+
+                // Act
+                var result = InvokeMethod(new[] { package1, package2, package3 });
+
+                // Assert
+                Assert.NotNull(result);
+                Assert.Equal(3, result.Key);
+            }
+
+            [Fact]
+            public void ReturnsHighestSemanticVersionIfSomeVersionsFailToParseAndNoLatestVersionIsAvailable()
+            {
+                // Arrange
+                var packageRegistration = new PackageRegistration { Id = Id };
+                var package1 = new Package { Key = 1, Version = "1.10.11", PackageRegistration = packageRegistration, IsLatest = false, Listed = false };
+                var package2 = new Package { Key = 2, Version = "fails-2-parse-2", PackageRegistration = packageRegistration, IsLatest = false, Listed = false };
+                var package3 = new Package { Key = 3, Version = "fails-2-parse", PackageRegistration = packageRegistration, IsLatest = false, Listed = false };
+                var package4 = new Package { Key = 4, Version = "1.10.9", PackageRegistration = packageRegistration, IsLatest = false, Listed = false };
+
+                // Act
+                var result = InvokeMethod(new[] { package1, package2, package3, package4 });
+
+                // Assert
+                Assert.NotNull(result);
+                Assert.Equal("1.10.11", result.Version);
+            }
+
 
             [Fact]
             public void ThrowsIfPackagesNull()

--- a/tests/NuGetGallery.Facts/Services/PackageServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/PackageServiceFacts.cs
@@ -1389,6 +1389,24 @@ namespace NuGetGallery
             }
 
             [Fact]
+            public void ReturnsHighestSemanticVersionIfNoLatestVersionIsAvailable()
+            {
+                // Arrange
+                var packageRegistration = new PackageRegistration { Id = Id };
+                var package1 = new Package { Version = "1.0.11", PackageRegistration = packageRegistration, IsLatest = false, Listed = false };
+                var package2 = new Package { Version = "1.0.10", PackageRegistration = packageRegistration, IsLatest = false, Listed = false };
+                var package3 = new Package { Version = "1.0.9", PackageRegistration = packageRegistration, IsLatest = false, Listed = false };
+
+                // Act
+                var result = InvokeMethod(new[] { package1, package2, package3 });
+
+                // Assert
+                Assert.NotNull(result);
+                Assert.Equal("1.0.11", result.Version);
+            }
+
+
+            [Fact]
             public void ThrowsIfPackagesNull()
             {
                 Assert.Throws<ArgumentNullException>(() => InvokeMethod(null));


### PR DESCRIPTION
Ensures semantic ordering in FilterLatestPackageHelper

* Use NuGetVersion.TryParse and NuGetVersionFormatter.GetNormalizedPackageVersion for semantic ordering in fallback path
* Add test ReturnsHighestSemanticVersionIfNoLatestVersionIsAvailable

Addresses https://github.com/NuGet/NuGetGallery/issues/10796