### PR TITLE
Fixed accessibilty bugs found in May E2E testing

### DIFF
--- a/src/NuGetGallery/Views/Packages/_ManageOwners.cshtml
+++ b/src/NuGetGallery/Views/Packages/_ManageOwners.cshtml
@@ -81,7 +81,7 @@
 
                     <div class="form-group">
                         <label for="newOwnerMessage">Message</label>
-                        <textarea id="newOwnerMessage" name="newOwnerMessage" data-bind="value: newOwnerMessage" aria-required="true" class="form-control textarea-brand" cols="50" rows="2"></textarea>
+                        <textarea id="newOwnerMessage" name="newOwnerMessage" data-bind="value: newOwnerMessage" class="form-control textarea-brand" cols="50" rows="2"></textarea>
                     </div>
 
                     <div class="form-group">

--- a/src/NuGetGallery/Views/Pages/Contact.cshtml
+++ b/src/NuGetGallery/Views/Pages/Contact.cshtml
@@ -23,9 +23,9 @@
             <h2 class="ms-fontSize-xl ms-fontWeight-semibold">Found a bug in NuGet or the website nuget.org?</h2>
             <p>
                 If you're having trouble with the <strong>nuget.org website</strong>,
-                file a bug on the NuGet Gallery <a href="https://github.com/NuGet/NuGetGallery/issues">Issue Tracker</a>.
+                file a bug on the <a href="https://github.com/NuGet/NuGetGallery/issues">NuGet Gallery Issue Tracker</a>.
                 If you're having trouble with the <strong>NuGet client tools</strong> (the Visual Studio extension, NuGet.exe command line tool, .NET CLI restore etc.),
-                file a bug on the NuGet Client <a href="https://github.com/NuGet/Home/issues">Issue Tracker</a>.
+                file a bug on the <a href="https://github.com/NuGet/Home/issues">NuGet Client Issue Tracker</a>.
             </p>
 
             <h2 class="ms-fontSize-xl ms-fontWeight-semibold">Is a package violating a license or otherwise abusive?</h2>


### PR DESCRIPTION
Fixed two accessibility bugs found in May E2E testing:
* On the Manage Package page, when navigating to the Message input field under "Add owner", the screen reader announces the field as "required", even though the field is optional and no visual indication of it being required is provided.
* There are multiple links labeled "Issue tracker" on the Contacts page.

Addresses https://github.com/NuGet/Engineering/issues/6435