### PR TITLE
Bump Microsoft.Extensions.* and System.Text.Json to 10.0.3 and enable central transitive pinning

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -153,10 +153,10 @@
     <PackageVersion Include="System.Security.Cryptography.Pkcs" Version="8.0.1" />
     <PackageVersion Include="System.Security.Cryptography.X509Certificates" Version="4.3.2" />
     <PackageVersion Include="System.ServiceModel.Syndication" Version="8.0.0" />
-    <PackageVersion Include="System.Text.Encodings.Web" Version="8.0.0" />
-    <PackageVersion Include="System.Text.Json" Version="8.0.6" />
-    <PackageVersion Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
-    <PackageVersion Include="System.ValueTuple" Version="4.5.0" />
+    <PackageVersion Include="System.Text.Encodings.Web" Version="10.0.3" />
+    <PackageVersion Include="System.Text.Json" Version="10.0.3" />
+    <PackageVersion Include="System.Threading.Tasks.Extensions" Version="4.6.3" />
+    <PackageVersion Include="System.ValueTuple" Version="4.6.1" />
     <PackageVersion Include="UAParser" Version="3.1.44" />
     <PackageVersion Include="WebActivatorEx" Version="2.0.6" />
     <PackageVersion Include="WebGrease" Version="1.6.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -86,6 +86,14 @@
     <PackageVersion Include="Microsoft.Extensions.Primitives" Version="10.0.3" />
     <PackageVersion Include="Microsoft.Identity.Client" Version="4.80.0" />
     <PackageVersion Include="Microsoft.Identity.Web" Version="3.8.2" />
+    <PackageVersion Include="Microsoft.IdentityModel.Abstractions" Version="8.18.0" />
+    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.18.0" />
+    <PackageVersion Include="Microsoft.IdentityModel.Logging" Version="8.18.0" />
+    <PackageVersion Include="Microsoft.IdentityModel.LoggingExtensions" Version="8.18.0" />
+    <PackageVersion Include="Microsoft.IdentityModel.Protocols" Version="8.18.0" />
+    <PackageVersion Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="8.18.0" />
+    <PackageVersion Include="Microsoft.IdentityModel.Tokens" Version="8.18.0" />
+    <PackageVersion Include="Microsoft.IdentityModel.Validators" Version="8.18.0" />
     <PackageVersion Include="Microsoft.Internal.NuGet.Testing.SignedPackages" Version="6.13.2-rc.1" />
     <PackageVersion Include="Microsoft.Net.Http" Version="2.2.29" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-    <CentralPackageTransitivePinningEnabled>false</CentralPackageTransitivePinningEnabled>
+    <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
     <EnablePackageVersionOverride>true</EnablePackageVersionOverride>
     <NuGetClientPackageVersion>6.13.2</NuGetClientPackageVersion>
   </PropertyGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -38,10 +38,10 @@
     <PackageVersion Include="Lucene.Net" Version="3.0.3" />
     <PackageVersion Include="Markdig.Signed" Version="0.37.0" />
     <PackageVersion Include="MicroBuild.Core" Version="0.3.0" />
-    <PackageVersion Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.21.0" />
-    <PackageVersion Include="Microsoft.ApplicationInsights.TraceListener" Version="2.21.0" />
-    <PackageVersion Include="Microsoft.ApplicationInsights.Web" Version="2.21.0" />
-    <PackageVersion Include="Microsoft.ApplicationInsights" Version="2.21.0" />
+    <PackageVersion Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.23.0" />
+    <PackageVersion Include="Microsoft.ApplicationInsights.TraceListener" Version="2.23.0" />
+    <PackageVersion Include="Microsoft.ApplicationInsights.Web" Version="2.23.0" />
+    <PackageVersion Include="Microsoft.ApplicationInsights" Version="2.23.0" />
     <PackageVersion Include="Microsoft.AspNet.DynamicData.EFProvider" Version="6.0.0" />
     <PackageVersion Include="Microsoft.AspNet.Identity.Core" Version="1.0.0" />
     <PackageVersion Include="Microsoft.AspNet.Mvc" Version="5.2.9" />
@@ -67,23 +67,23 @@
     <PackageVersion Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" Version="4.1.0" />
     <PackageVersion Include="Microsoft.Data.Services.Client" Version="5.8.4" />
     <PackageVersion Include="Microsoft.Data.Services" Version="5.8.4" />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="10.0.3" />
     <PackageVersion Include="Microsoft.Extensions.CommandLineUtils" Version="1.1.1" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.FileExtensions" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.3" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.3" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.3" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.3" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.FileExtensions" Version="10.0.3" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.3" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.3" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.3" />
     <PackageVersion Include="Microsoft.Extensions.Http.Polly" Version="8.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Primitives" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.3" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.3" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.3" />
+    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.3" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.3" />
+    <PackageVersion Include="Microsoft.Extensions.Primitives" Version="10.0.3" />
     <PackageVersion Include="Microsoft.Identity.Client" Version="4.80.0" />
     <PackageVersion Include="Microsoft.Identity.Web" Version="3.8.2" />
     <PackageVersion Include="Microsoft.Internal.NuGet.Testing.SignedPackages" Version="6.13.2-rc.1" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -20,7 +20,7 @@
     <PackageVersion Include="Azure.Messaging.ServiceBus" Version="7.16.1" />
     <PackageVersion Include="Azure.Search.Documents" Version="11.4.0-beta.6" />
     <PackageVersion Include="Azure.Security.KeyVault.Keys" Version="4.4.0" />
-    <PackageVersion Include="Azure.Security.KeyVault.Secrets" Version="4.4.0" />
+    <PackageVersion Include="Azure.Security.KeyVault.Secrets" Version="4.6.0" />
     <PackageVersion Include="Azure.Storage.Blobs" Version="12.22.2" />
     <PackageVersion Include="Azure.Storage.Queues" Version="12.18.0" />
     <PackageVersion Include="CommonMark.NET" Version="0.15.1" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -67,23 +67,23 @@
     <PackageVersion Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" Version="4.1.0" />
     <PackageVersion Include="Microsoft.Data.Services.Client" Version="5.8.4" />
     <PackageVersion Include="Microsoft.Data.Services" Version="5.8.4" />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="10.0.0" />
     <PackageVersion Include="Microsoft.Extensions.CommandLineUtils" Version="1.1.1" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.2" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.FileExtensions" Version="8.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="8.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.FileExtensions" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Http.Polly" Version="8.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.Http" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.3" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="8.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Options" Version="8.0.2" />
-    <PackageVersion Include="Microsoft.Extensions.Primitives" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Primitives" Version="10.0.0" />
     <PackageVersion Include="Microsoft.Identity.Client" Version="4.80.0" />
     <PackageVersion Include="Microsoft.Identity.Web" Version="3.8.2" />
     <PackageVersion Include="Microsoft.Internal.NuGet.Testing.SignedPackages" Version="6.13.2-rc.1" />

--- a/src/NuGetGallery.AppHost/NuGetGallery.AppHost.csproj
+++ b/src/NuGetGallery.AppHost/NuGetGallery.AppHost.csproj
@@ -12,6 +12,13 @@
     <GenerateAssemblyFileVersionAttribute>true</GenerateAssemblyFileVersionAttribute>
     <GenerateAssemblyInformationalVersionAttribute>true</GenerateAssemblyInformationalVersionAttribute>
     <GenerateAssemblyVersionAttribute>true</GenerateAssemblyVersionAttribute>
+
+    <!-- This dev-only Aspire host is not built or deployed by ev2. Its Aspire.Hosting.*
+         packages floor several transitive dependencies (Azure.*, Microsoft.Extensions.*)
+         higher than the solution's central versions, so solution-wide transitive pinning
+         would report those as NU1109 downgrades. Opt this project out and let Aspire
+         resolve its own transitive graph. -->
+    <CentralPackageTransitivePinningEnabled>false</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -2267,6 +2267,16 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <!-- net472 ships System.ValueTuple 4.0.3.0 in-box, so NuGet won't copy the 4.6.1
+         package assembly (4.0.5.0) that Extensions/STJ 10.0.3 require and that the
+         binding redirect targets. Force the package copy into bin so the redirect resolves. -->
+    <PackageReference Include="System.ValueTuple" GeneratePathProperty="true" ExcludeAssets="all" />
+    <Reference Include="System.ValueTuple">
+      <HintPath>$(PkgSystem_ValueTuple)\lib\net47\System.ValueTuple.dll</HintPath>
+      <Private>true</Private>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
     <PackageReference Include="Autofac.Extensions.DependencyInjection" />
     <PackageReference Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />

--- a/src/NuGetGallery/Web.config
+++ b/src/NuGetGallery/Web.config
@@ -659,6 +659,10 @@
         <bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
+        <assemblyIdentity name="Microsoft.IdentityModel.LoggingExtensions" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
         <assemblyIdentity name="Microsoft.Identity.Client" publicKeyToken="0A613F4DD989E8AE" culture="neutral"/>
         <bindingRedirect oldVersion="0.0.0.0-4.80.0.0" newVersion="4.80.0.0"/>
       </dependentAssembly>

--- a/src/NuGetGallery/Web.config
+++ b/src/NuGetGallery/Web.config
@@ -600,7 +600,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.IdentityModel.Tokens.Jwt" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-8.7.0.0" newVersion="8.7.0.0"/>
+        <bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Formats.Asn1" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral"/>
@@ -636,19 +636,27 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.IdentityModel.Tokens" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-8.7.0.0" newVersion="8.7.0.0"/>
+        <bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.IdentityModel.Protocols.OpenIdConnect" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-8.7.0.0" newVersion="8.7.0.0"/>
+        <bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.IdentityModel.Protocols" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-8.7.0.0" newVersion="8.7.0.0"/>
+        <bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.IdentityModel.Abstractions" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-8.14.0.0" newVersion="8.14.0.0"/>
+        <bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.IdentityModel.JsonWebTokens" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.IdentityModel.Logging" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-8.18.0.0" newVersion="8.18.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Identity.Client" publicKeyToken="0A613F4DD989E8AE" culture="neutral"/>
@@ -660,6 +668,10 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Extensions.Options" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.3" newVersion="10.0.0.3"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Extensions.Options.ConfigurationExtensions" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.3" newVersion="10.0.0.3"/>
       </dependentAssembly>
       <dependentAssembly>

--- a/src/NuGetGallery/Web.config
+++ b/src/NuGetGallery/Web.config
@@ -556,15 +556,19 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-4.2.1.0" newVersion="4.2.1.0"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.2.4.0" newVersion="4.2.4.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.ValueTuple" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.0.5.0" newVersion="4.0.5.0"/>
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Text.Json" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-8.0.0.6" newVersion="8.0.0.6"/>
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.3" newVersion="10.0.0.3"/>
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Text.Encodings.Web" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-8.0.0.0" newVersion="8.0.0.0"/>
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.3" newVersion="10.0.0.3"/>
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Spatial" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
@@ -604,7 +608,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-8.0.0.1" newVersion="8.0.0.1"/>
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.3" newVersion="10.0.0.3"/>
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
@@ -652,71 +656,71 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Extensions.Primitives" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-8.0.0.0" newVersion="8.0.0.0"/>
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.3" newVersion="10.0.0.3"/>
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Extensions.Options" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-8.0.0.2" newVersion="8.0.0.2"/>
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.3" newVersion="10.0.0.3"/>
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Extensions.Logging.Abstractions" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-8.0.0.3" newVersion="8.0.0.3"/>
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.3" newVersion="10.0.0.3"/>
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Extensions.Logging" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-8.0.0.1" newVersion="8.0.0.1"/>
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.3" newVersion="10.0.0.3"/>
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Extensions.Http" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-8.0.0.0" newVersion="8.0.0.0"/>
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.3" newVersion="10.0.0.3"/>
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Extensions.FileProviders.Physical" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-8.0.0.0" newVersion="8.0.0.0"/>
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.3" newVersion="10.0.0.3"/>
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Extensions.FileProviders.Abstractions" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-8.0.0.0" newVersion="8.0.0.0"/>
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.3" newVersion="10.0.0.3"/>
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Extensions.DependencyInjection.Abstractions" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-8.0.0.2" newVersion="8.0.0.2"/>
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.3" newVersion="10.0.0.3"/>
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Extensions.DependencyInjection" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-8.0.0.1" newVersion="8.0.0.1"/>
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.3" newVersion="10.0.0.3"/>
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Extensions.Configuration.Json" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-8.0.0.1" newVersion="8.0.0.1"/>
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.3" newVersion="10.0.0.3"/>
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Extensions.Configuration.FileExtensions" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-8.0.0.1" newVersion="8.0.0.1"/>
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.3" newVersion="10.0.0.3"/>
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Extensions.Configuration.EnvironmentVariables" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-8.0.0.0" newVersion="8.0.0.0"/>
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.3" newVersion="10.0.0.3"/>
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Extensions.Configuration.Binder" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-8.0.0.2" newVersion="8.0.0.2"/>
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.3" newVersion="10.0.0.3"/>
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Extensions.Configuration.Abstractions" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-8.0.0.0" newVersion="8.0.0.0"/>
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.3" newVersion="10.0.0.3"/>
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Extensions.Configuration" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-8.0.0.0" newVersion="8.0.0.0"/>
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.3" newVersion="10.0.0.3"/>
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Extensions.Caching.Memory" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-8.0.0.1" newVersion="8.0.0.1"/>
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.3" newVersion="10.0.0.3"/>
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Extensions.Caching.Abstractions" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-8.0.0.0" newVersion="8.0.0.0"/>
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.3" newVersion="10.0.0.3"/>
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Data.OData" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
@@ -728,7 +732,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Bcl.AsyncInterfaces" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-8.0.0.0" newVersion="8.0.0.0"/>
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.3" newVersion="10.0.0.3"/>
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Bcl.Memory" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral"/>
@@ -752,7 +756,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.ApplicationInsights" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-2.21.0.429" newVersion="2.21.0.429"/>
+        <bindingRedirect oldVersion="0.0.0.0-2.23.0.29" newVersion="2.23.0.29"/>
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="EntityFramework" publicKeyToken="B77A5C561934E089" culture="neutral"/>


### PR DESCRIPTION
## Summary

Aligns NuGetGallery's `Microsoft.Extensions.*`, `System.Text.Json`, and related packages to 10.0.3 to match the NuGet.Services monorepo, and turns on central transitive pinning so the whole dependency graph resolves to a single, consistent set of versions.

The monorepo now ships `NuGet.Services.Internal` built against `Microsoft.Extensions.Options` 10, which the ev2 pipelines inject into the gallery web/exe projects. Before this change those builds failed with CS1705/CS1503 (Options 8 vs 10) and MSB3247 assembly conflicts. Enabling transitive pinning resolves the version split globally, and the follow-up commits fix the runtime fallout that pinning surfaced.

## Package changes

| Package(s) | From | To |
| --- | --- | --- |
| Microsoft.Extensions.* (Options, Configuration, Logging, DI, Http, Caching.Memory, Primitives) | 8.x | 10.0.3 |
| System.Text.Json / System.Text.Encodings.Web | 8.0.6 / 8.0.0 | 10.0.3 |
| System.Threading.Tasks.Extensions | 4.5.4 | 4.6.3 |
| System.ValueTuple | 4.5.0 | 4.6.1 |
| Microsoft.ApplicationInsights.* | 2.21.0 | 2.23.0 |
| Azure.Security.KeyVault.Secrets | 4.4.0 | 4.6.0 |
| Microsoft.IdentityModel.* (Abstractions, JsonWebTokens, Logging, LoggingExtensions, Protocols, Protocols.OpenIdConnect, Tokens, Validators) | transitive (8.7/8.14) | 8.18.0 (pinned) |

Config/settings:
- `CentralPackageTransitivePinningEnabled` set to `true`.
- New central pins for the `Microsoft.IdentityModel.*` family so the whole family resolves uniformly to 8.18.0 (previously split across 8.7/8.14/8.18 as transitive-only).

## Runtime fixes that pinning surfaced

Transitive pinning bumped several assembly versions that a net472 web app resolves at runtime, so `Web.config` binding redirects and one project reference needed updating:

- `Web.config`: updated redirects for `Microsoft.Extensions.Options`/`Options.ConfigurationExtensions` (10.0.0.3), the full `Microsoft.IdentityModel.*` family (8.18.0.0, including newly added JsonWebTokens/Logging/LoggingExtensions), and Application Insights (2.23.0.29).
- `NuGetGallery.csproj`: force the `System.ValueTuple` 4.6.1 assembly (4.0.5.0) to be copied into `bin`. On net472 the framework provides an in-box `System.ValueTuple` facade (4.0.3.0), so NuGet does not copy the package assembly. The 10.0.3 packages require 4.6.1 and the redirect targets 4.0.5.0, so without forcing the copy the app started up and threw `FileNotFoundException` for `System.ValueTuple, Version=4.0.0.0` during Key Vault/Azure.Identity init.

## How this was tested

Validated through the DevDiv NuGet.Services build and test pipelines, running this branch as the `NuGetGallery` resource, plus a deploy to DEV staging.

- **Restore**: all five gallery solutions restore clean with pinning on (one NU1109 surfaced for `Azure.Security.KeyVault.Secrets` and was resolved by the 4.6.0 bump).
- **Package graph diff**: aggregated every `project.assets.json` before and after. 0 packages added, 0 removed, 62 upward version consolidations. No downgrades.
- **API surface check**: ran ApiCompat (net462) on the largest jumps, `System.Text.Json` 8.0.x to 10.0.3 and `System.Security.Cryptography.Pkcs` 7.0.2 to 8.0.1. No breaking public API changes.
- **Build pipelines**: all 17 component/ev2 build pipelines green against this branch, including the two that build the gallery as a submodule (AzureSearchService, CDNRedirect) and the gallery build/package pipelines that previously failed with MSB3247.
- **Deploy**: deployed to DEV staging. The app now starts (the `System.ValueTuple` startup crash is gone). Confirmed the copy-local fix locally too: `ResolveReferences` shows `System.ValueTuple.dll` 4.0.5.0 in the copy-local set.
- **Functional/E2E**: the end-to-end suite is 94/94 green against DEV staging, and the gallery and search functional test pipelines pass. One fixture unit test (`CanPushUnnamedPackageType`) is intermittently failing, but it is a known-flaky push-counting test in the E2E repo (same class of flakiness as the already-skipped `PushesAllPackagesOnFirstPush`, NuGetGallery#8260) and is unrelated to these changes.
