### PR TITLE
Group vulnerability ranges case-insensitively in metadata verification

### DIFF
--- a/src/VerifyGitHubVulnerabilities/Verify/PackageVulnerabilitiesVerifier.cs
+++ b/src/VerifyGitHubVulnerabilities/Verify/PackageVulnerabilitiesVerifier.cs
@@ -194,8 +194,13 @@ namespace VerifyGitHubVulnerabilities.Verify
                 return Task.CompletedTask;
             }
 
-            // Group ranges by id -- this makes testing metadata collections cleaner
-            var rangesById = new Dictionary<string, IList<string>>();
+            // Group ranges by id -- this makes testing metadata collections cleaner.
+            // Use a case-insensitive comparer because NuGet package IDs are case-insensitive and a single advisory can
+            // list the same package under different casings for different version ranges (e.g. "Microsoft.OpenApi" for
+            // the 2.x range and "Microsoft.OpenAPI" for the 3.x range). Registration metadata is served case-insensitively,
+            // so splitting these into separate groups causes each group to check every version against only its own subset
+            // of ranges, producing false "marked vulnerable and is not in a vulnerable range" mismatches.
+            var rangesById = new Dictionary<string, IList<string>>(StringComparer.OrdinalIgnoreCase);
             foreach (var range in gitHubAdvisory.AffectedRanges)
             {
                 var id = range.PackageId.Trim(' '); // some incoming data needs cleaning


### PR DESCRIPTION
## Summary

`VerifyGitHubVulnerabilities` grouped an advisory's affected ranges by **case-sensitive** package ID in `PackageVulnerabilitiesVerifier.VerifyVulnerabilityInMetadataAsync`. When a single advisory lists the same package under different casings for different version ranges, the ranges were split into separate groups. Because registration metadata is served case-insensitively (nuget.org normalizes package IDs), each group then checked *every* version of the package against only its own subset of ranges, producing false `is marked vulnerable and is not in a vulnerable range` mismatches.

The fix groups ranges with `StringComparer.OrdinalIgnoreCase`, matching NuGet's case-insensitive package ID semantics, so every version is checked against the union of all ranges for that package.

## Real-world example (advisory GHSA-v5pm-xwqc-g5wc, key 367749)

The advisory lists the same package under two casings:

| Package ID (as listed) | Affected range |
| --- | --- |
| `Microsoft.OpenApi` | `>= 2.0.0-preview.11, <= 2.7.4` |
| `Microsoft.OpenAPI` | `>= 3.0.0, <= 3.5.3` |

Before the fix, this produced two buckets:

- Bucket `Microsoft.OpenApi` (2.x range only) sees version `3.5.3` marked vulnerable, `3.5.3` is not in `2.x` &rarr; **false mismatch**.
- Bucket `Microsoft.OpenAPI` (3.x range only) sees version `2.0.0-preview.11` marked vulnerable, `2.0.0-preview.11` is not in `3.x` &rarr; **false mismatch**.

Observed in App Insights:

```
[Metadata] Vulnerability advisory 367749, version "2.0.0-preview.11" of package "Microsoft.OpenAPI" is marked vulnerable and is not in a vulnerable range!
[Metadata] Vulnerability advisory 367749, version "3.5.3" of package "Microsoft.OpenApi" is marked vulnerable and is not in a vulnerable range!
```

After the fix both casings share one bucket that knows both ranges, so `2.0.0-preview.11` matches the 2.x range and `3.5.3` matches the 3.x range. No false mismatch.

## Scope / what this is not

- The gallery database and the registration metadata were both **correct**; only the verifier was miscomputing. These were false positives, not real data corruption.
- The writer job (`GitHubVulnerabilities2Db`) was unaffected: it wrote advisory 367749 successfully (no duplicate-key/unique-index exceptions) and continued processing new advisories, so advisory ingestion was never blocked.
- Operational impact was a persistently red verifier signal, which can mask a genuine mismatch later.

## Testing

There is no `VerifyGitHubVulnerabilities.Facts` project, and the metadata path constructs its own `PackageMetadataResource` internally, so it is not unit-testable without a refactor to inject that dependency. The change is a one-line, low-risk fix and the project compiles cleanly. Adding coverage would require scaffolding a new test project plus a small refactor for injectability; happy to do that as a follow-up if desired.
