### PR TITLE
Allow existence of multiple deprecation records in audit step (#10899)

### DIFF
--- a/src/GitHubVulnerabilities2Db/Gallery/ThrowingTelemetryService.cs
+++ b/src/GitHubVulnerabilities2Db/Gallery/ThrowingTelemetryService.cs
@@ -206,6 +206,11 @@ namespace GitHubVulnerabilities2Db.Gallery
             throw new NotImplementedException();
         }
 
+        public void TrackDuplicatePackageDeprecations(string packageId, string packageVersion, int deprecationCount)
+        {
+            throw new NotImplementedException();
+        }
+
         public void TrackPackageDeprecate(IReadOnlyList<Package> packages, PackageDeprecationStatus status, PackageRegistration alternateRegistration, Package alternatePackage, bool hasCustomMessage, bool hasChanges)
         {
             throw new NotImplementedException();

--- a/src/NuGetGallery.Core/Auditing/PackageAuditRecord.cs
+++ b/src/NuGetGallery.Core/Auditing/PackageAuditRecord.cs
@@ -66,7 +66,7 @@ namespace NuGetGallery.Auditing
             RegistrationRecord = AuditedPackageRegistration.CreateFrom(package.PackageRegistration);
             DeprecationRecord = package.Deprecations
                 .Select(d => AuditedPackageDeprecation.CreateFrom(d))
-                .SingleOrDefault();
+                .FirstOrDefault();
         }
 
         public PackageAuditRecord(Package package, AuditedPackageAction action)
@@ -83,7 +83,7 @@ namespace NuGetGallery.Auditing
             RegistrationRecord = AuditedPackageRegistration.CreateFrom(package.PackageRegistration);
             DeprecationRecord = package.Deprecations
                 .Select(d => AuditedPackageDeprecation.CreateFrom(d))
-                .SingleOrDefault();
+                .FirstOrDefault();
         }
 
         public override string GetPath()

--- a/src/NuGetGallery.Services/Telemetry/ITelemetryService.cs
+++ b/src/NuGetGallery.Services/Telemetry/ITelemetryService.cs
@@ -46,6 +46,10 @@ namespace NuGetGallery
 
         void TrackPackageDelete(Package package, bool isHardDelete);
 
+        // Temporary telemetry to detect packages that have more than one deprecation record.
+        // Can be removed once the unique index on PackageDeprecations is restored.
+        void TrackDuplicatePackageDeprecations(string packageId, string packageVersion, int deprecationCount);
+
         void TrackPackageReupload(Package package);
 
         void TrackPackageReflow(Package package);

--- a/src/NuGetGallery.Services/Telemetry/TelemetryService.cs
+++ b/src/NuGetGallery.Services/Telemetry/TelemetryService.cs
@@ -49,6 +49,7 @@ namespace NuGetGallery
             public const string PackageListed = "PackageListed";
             public const string PackagesUpdateListed = "PackagesUpdateListed";
             public const string PackageDelete = "PackageDelete";
+            public const string DuplicatePackageDeprecations = "DuplicatePackageDeprecations";
             public const string PackageDeprecate = "PackageDeprecate";
             public const string PackageReupload = "PackageReupload";
             public const string PackageHardDeleteReflow = "PackageHardDeleteReflow";
@@ -176,6 +177,7 @@ namespace NuGetGallery
 
         // Package delete properties
         public const string IsHardDelete = "IsHardDelete";
+        public const string DeprecationCount = "DeprecationCount";
 
         // Organization properties
         public const string OrganizationAccountKey = "OrganizationAccountKey";
@@ -521,6 +523,16 @@ namespace NuGetGallery
             TrackMetricForPackage(Events.PackageDelete, package, properties =>
             {
                 properties.Add(IsHardDelete, isHardDelete.ToString());
+            });
+        }
+
+        // Temporary telemetry to detect packages that have more than one deprecation record while soft deleting.
+        // Can be removed once the unique index on PackageDeprecations is restored.
+        public void TrackDuplicatePackageDeprecations(string packageId, string packageVersion, int deprecationCount)
+        {
+            TrackMetricForPackage(Events.DuplicatePackageDeprecations, packageId, packageVersion, properties =>
+            {
+                properties.Add(DeprecationCount, deprecationCount.ToString());
             });
         }
 

--- a/src/NuGetGallery/Services/PackageDeprecationService.cs
+++ b/src/NuGetGallery/Services/PackageDeprecationService.cs
@@ -71,7 +71,18 @@ namespace NuGetGallery
                 // the low number of properties here, we'll track the changes ourselves. To use the change tracker to
                 // check if an individual entity has changed would require non-trivial changes to our DB abstractions.
                 var changed = false;
-                var deprecation = package.Deprecations.SingleOrDefault();
+
+                // Temporary telemetry to detect packages that already have more than one deprecation record.
+                // Can be removed once the unique index on PackageDeprecations is restored.
+                if (package.Deprecations.Count > 1)
+                {
+                    _telemetryService.TrackDuplicatePackageDeprecations(
+                        package.PackageRegistration.Id,
+                        package.NormalizedVersion,
+                        package.Deprecations.Count);
+                }
+
+                var deprecation = package.Deprecations.FirstOrDefault();
                 if (shouldDelete)
                 {
                     if (deprecation != null)

--- a/src/VerifyMicrosoftPackage/Fakes/FakeTelemetryService.cs
+++ b/src/VerifyMicrosoftPackage/Fakes/FakeTelemetryService.cs
@@ -203,6 +203,11 @@ namespace NuGet.VerifyMicrosoftPackage.Fakes
             throw new NotImplementedException();
         }
 
+        public void TrackDuplicatePackageDeprecations(string packageId, string packageVersion, int deprecationCount)
+        {
+            throw new NotImplementedException();
+        }
+
         public void TrackPackageDeprecate(IReadOnlyList<Package> packages, PackageDeprecationStatus status, PackageRegistration alternateRegistration, Package alternatePackage, bool hasCustomMessage, bool hasChanges)
         {
             throw new NotImplementedException();

--- a/tests/NuGetGallery.Core.Facts/Auditing/PackageAuditRecordTests.cs
+++ b/tests/NuGetGallery.Core.Facts/Auditing/PackageAuditRecordTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Collections.Generic;
 using NuGet.Services.Entities;
 using Xunit;
 
@@ -49,6 +50,26 @@ namespace NuGetGallery.Auditing
             var actualResult = record.GetPath();
 
             Assert.Equal("b/1.0.0", actualResult);
+        }
+
+        [Fact]
+        public void Constructor_WithMultipleDeprecations_DoesNotThrow()
+        {
+            var package = new Package()
+            {
+                Hash = "a",
+                PackageRegistration = new PackageRegistration() { Id = "b" },
+                Version = "1.0.0",
+                Deprecations = new List<PackageDeprecation>
+                {
+                    new PackageDeprecation(),
+                    new PackageDeprecation(),
+                },
+            };
+
+            var record = new PackageAuditRecord(package, AuditedPackageAction.Delete, reason: "c");
+
+            Assert.NotNull(record.DeprecationRecord);
         }
     }
 }


### PR DESCRIPTION
* Allow existence of multiple deprecation records in audit step for soft delete packages
* Added telemetry for duplicate deprecation record creation
* Cherry pick commit from main to dev

Addresses https://github.com/NuGet/Engineering/issues/6482