### PR TITLE
Case-insensitive version comparison for the short version lists

### DIFF
--- a/src/NuGetGallery.Services/PackageManagement/PackageService.cs
+++ b/src/NuGetGallery.Services/PackageManagement/PackageService.cs
@@ -338,14 +338,14 @@ namespace NuGetGallery
             {
                 // if we have list longer than requested, trim it, making sure we don't trim includeVersion if it happens to be last
                 var removeAt = packages.Count - 1;
-                if (!string.IsNullOrWhiteSpace(includeVersion) && packages[removeAt].NormalizedVersion == includeVersion)
+                if (!string.IsNullOrWhiteSpace(includeVersion) && string.Equals(packages[removeAt].NormalizedVersion, includeVersion, StringComparison.OrdinalIgnoreCase))
                 {
                     --removeAt;
                 }
                 packages.RemoveAt(removeAt);
             }
 
-            if (!string.IsNullOrWhiteSpace(includeVersion) && !packages.Any(p => p.NormalizedVersion == includeVersion))
+            if (!string.IsNullOrWhiteSpace(includeVersion) && !packages.Any(p => string.Equals(p.NormalizedVersion, includeVersion, StringComparison.OrdinalIgnoreCase)))
             {
                 var requiredPackage = GetPackagesByIdQueryable(
                     id,
@@ -356,7 +356,7 @@ namespace NuGetGallery
                     includeDeprecations: includeDeprecations,
                     includeDeprecationRelationships: false,
                     includeSupportedFrameworks: includeSupportedFrameworks)
-                    .Where(p => p.NormalizedVersion == includeVersion)
+                    .Where(p => p.NormalizedVersion == includeVersion) // string comparisons on DB side are case-insensitive due to collation used
                     .SingleOrDefault();
 
                 if (requiredPackage is not null)


### PR DESCRIPTION
Version comparisons outside SQL have to be case-insensitive to match what happens in SQL.

This fixes some 500 errors that one might see if constructing package details URL manually.