### PR TITLE
Optional jobs dependency tracking

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -39,6 +39,7 @@
     <PackageVersion Include="Markdig.Signed" Version="0.37.0" />
     <PackageVersion Include="MicroBuild.Core" Version="0.3.0" />
     <PackageVersion Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.21.0" />
+    <PackageVersion Include="Microsoft.ApplicationInsights.DependencyCollector" Version="2.21.0" />
     <PackageVersion Include="Microsoft.ApplicationInsights.TraceListener" Version="2.21.0" />
     <PackageVersion Include="Microsoft.ApplicationInsights.Web" Version="2.21.0" />
     <PackageVersion Include="Microsoft.ApplicationInsights" Version="2.21.0" />

--- a/src/Ng/Arguments.cs
+++ b/src/Ng/Arguments.cs
@@ -14,6 +14,7 @@ namespace Ng
         public const string Gallery = "gallery";
         public const string InstrumentationKey = "instrumentationkey";
         public const string HeartbeatIntervalSeconds = "HeartbeatIntervalSeconds";
+        public const string EnableDependencyTracking = "EnableDependencyTracking";
         public const string Path = "path";
         public const string Source = "source";
         public const string Verbose = "verbose";

--- a/src/Ng/Program.cs
+++ b/src/Ng/Program.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -66,12 +66,14 @@ namespace Ng
                 var instanceName = arguments.GetOrDefault(Arguments.InstanceName, jobName);
                 var instrumentationKey = arguments.GetOrDefault<string>(Arguments.InstrumentationKey);
                 var heartbeatIntervalSeconds = arguments.GetOrDefault<int>(Arguments.HeartbeatIntervalSeconds);
+                var enableDependencyTracking = arguments.GetOrDefault<bool>(Arguments.EnableDependencyTracking);
 
                 applicationInsightsConfiguration = ConfigureApplicationInsights(
                     instrumentationKey,
                     heartbeatIntervalSeconds,
                     jobName,
                     instanceName,
+                    enableDependencyTracking,
                     out var telemetryClient,
                     out var telemetryGlobalDimensions);
 
@@ -182,19 +184,21 @@ namespace Ng
             int heartbeatIntervalSeconds,
             string jobName,
             string instanceName,
+            bool enableDependencyTracking,
             out ITelemetryClient telemetryClient,
             out IDictionary<string, string> telemetryGlobalDimensions)
         {
             ApplicationInsightsConfiguration applicationInsightsConfiguration;
             if (heartbeatIntervalSeconds == 0)
             {
-                applicationInsightsConfiguration = ApplicationInsights.Initialize(instrumentationKey);
+                applicationInsightsConfiguration = ApplicationInsights.Initialize(instrumentationKey, enableDependencyTracking);
             }
             else
             {
                 applicationInsightsConfiguration = ApplicationInsights.Initialize(
                     instrumentationKey,
-                    TimeSpan.FromSeconds(heartbeatIntervalSeconds));
+                    TimeSpan.FromSeconds(heartbeatIntervalSeconds),
+                    enableDependencyTracking);
             }
 
             telemetryClient = new TelemetryClientWrapper(

--- a/src/NuGet.Jobs.Common/Configuration/JobArgumentNames.cs
+++ b/src/NuGet.Jobs.Common/Configuration/JobArgumentNames.cs
@@ -94,6 +94,7 @@ namespace NuGet.Jobs
         // Application Insights
         public const string InstrumentationKey = "InstrumentationKey";
         public const string HeartbeatIntervalSeconds = "HeartbeatIntervalSeconds";
+        public const string EnableDependencyTracking = "EnableDependencyTracking";
 
         // Arguments specific to validation tasks
         public const string RunValidationTasks = "RunValidationTasks";

--- a/src/NuGet.Jobs.Common/JobRunner.cs
+++ b/src/NuGet.Jobs.Common/JobRunner.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -175,15 +175,20 @@ namespace NuGet.Jobs
                 jobArgsDictionary,
                 JobArgumentNames.HeartbeatIntervalSeconds);
 
+            var enableDependencyTracking = JobConfigurationManager.TryGetBoolArgument(
+                jobArgsDictionary,
+                JobArgumentNames.EnableDependencyTracking);
+
             if (heartbeatIntervalSeconds.HasValue)
             {
                 applicationInsightsConfiguration = ApplicationInsights.Initialize(
                     instrumentationKey,
-                    TimeSpan.FromSeconds(heartbeatIntervalSeconds.Value));
+                    TimeSpan.FromSeconds(heartbeatIntervalSeconds.Value),
+                    enableDependencyTracking);
             }
             else
             {
-                applicationInsightsConfiguration = ApplicationInsights.Initialize(instrumentationKey);
+                applicationInsightsConfiguration = ApplicationInsights.Initialize(instrumentationKey, enableDependencyTracking);
             }
 
             // Determine job and instance name, for logging.

--- a/src/NuGet.Services.Logging/ApplicationInsights.cs
+++ b/src/NuGet.Services.Logging/ApplicationInsights.cs
@@ -1,9 +1,10 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using Microsoft.ApplicationInsights;
 using Microsoft.ApplicationInsights.DataContracts;
+using Microsoft.ApplicationInsights.DependencyCollector;
 using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.ApplicationInsights.Extensibility.Implementation;
 using Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing;
@@ -30,9 +31,15 @@ namespace NuGet.Services.Logging
         /// <paramref name="instrumentationKey"/>, taking into account the <c>ApplicationInsights.config</c> file if present.
         /// </summary>
         /// <param name="instrumentationKey">The instrumentation key to use.</param>
-        public static ApplicationInsightsConfiguration Initialize(string instrumentationKey)
+        /// <param name="enableDependencyTracking">
+        /// When <c>true</c>, a <see cref="DependencyTrackingTelemetryModule"/> is initialized so outbound
+        /// dependency calls are collected into the <c>dependencies</c> table. Defaults to <c>false</c>.
+        /// </param>
+        public static ApplicationInsightsConfiguration Initialize(
+            string instrumentationKey,
+            bool enableDependencyTracking = false)
         {
-            return InitializeApplicationInsightsConfiguration(instrumentationKey, heartbeatInterval: null);
+            return InitializeApplicationInsightsConfiguration(instrumentationKey, heartbeatInterval: null, enableDependencyTracking);
         }
 
         /// <summary>
@@ -42,16 +49,22 @@ namespace NuGet.Services.Logging
         /// </summary>
         /// <param name="instrumentationKey">The instrumentation key to use.</param>
         /// <param name="heartbeatInterval">The heartbeat interval to use.</param>
+        /// <param name="enableDependencyTracking">
+        /// When <c>true</c>, a <see cref="DependencyTrackingTelemetryModule"/> is initialized so outbound
+        /// dependency calls are collected into the <c>dependencies</c> table. Defaults to <c>false</c>.
+        /// </param>
         public static ApplicationInsightsConfiguration Initialize(
             string instrumentationKey,
-            TimeSpan heartbeatInterval)
+            TimeSpan heartbeatInterval,
+            bool enableDependencyTracking = false)
         {
-            return InitializeApplicationInsightsConfiguration(instrumentationKey, heartbeatInterval);
+            return InitializeApplicationInsightsConfiguration(instrumentationKey, heartbeatInterval, enableDependencyTracking);
         }
 
         private static ApplicationInsightsConfiguration InitializeApplicationInsightsConfiguration(
             string instrumentationKey,
-            TimeSpan? heartbeatInterval)
+            TimeSpan? heartbeatInterval,
+            bool enableDependencyTracking = false)
         {
             // Note: TelemetryConfiguration.Active is being deprecated
             // https://github.com/microsoft/ApplicationInsights-dotnet/issues/1152
@@ -95,7 +108,22 @@ namespace NuGet.Services.Logging
 
             telemetryClient.TrackTrace(traceMessage, SeverityLevel.Information);
 
-            return new ApplicationInsightsConfiguration(telemetryConfiguration, diagnosticsTelemetryModule);
+            // Optionally enable collection of outbound dependency telemetry (HTTP, SQL, etc.).
+            DependencyTrackingTelemetryModule dependencyTrackingTelemetryModule = null;
+            if (enableDependencyTracking)
+            {
+                dependencyTrackingTelemetryModule = new DependencyTrackingTelemetryModule();
+                dependencyTrackingTelemetryModule.Initialize(telemetryConfiguration);
+
+                telemetryClient.TrackTrace(
+                    "DependencyTrackingTelemetryModule initialized; outbound dependency collection is enabled.",
+                    SeverityLevel.Information);
+            }
+
+            return new ApplicationInsightsConfiguration(
+                telemetryConfiguration,
+                diagnosticsTelemetryModule,
+                dependencyTrackingTelemetryModule);
         }
     }
 }

--- a/src/NuGet.Services.Logging/ApplicationInsightsConfiguration.cs
+++ b/src/NuGet.Services.Logging/ApplicationInsightsConfiguration.cs
@@ -1,7 +1,8 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using Microsoft.ApplicationInsights.DependencyCollector;
 using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing;
 
@@ -12,10 +13,12 @@ namespace NuGet.Services.Logging
     {
         internal ApplicationInsightsConfiguration(
             TelemetryConfiguration telemetryConfiguration,
-            DiagnosticsTelemetryModule diagnosticsTelemetryModule)
+            DiagnosticsTelemetryModule diagnosticsTelemetryModule,
+            DependencyTrackingTelemetryModule dependencyTrackingTelemetryModule = null)
         {
             TelemetryConfiguration = telemetryConfiguration ?? throw new ArgumentNullException(nameof(telemetryConfiguration));
             DiagnosticsTelemetryModule = diagnosticsTelemetryModule ?? throw new ArgumentNullException(nameof(diagnosticsTelemetryModule));
+            DependencyTrackingTelemetryModule = dependencyTrackingTelemetryModule;
         }
 
         /// <summary>
@@ -34,8 +37,16 @@ namespace NuGet.Services.Logging
         /// </summary>
         public DiagnosticsTelemetryModule DiagnosticsTelemetryModule { get; }
 
+        /// <summary>
+        /// Contains the initialized <see cref="Microsoft.ApplicationInsights.DependencyCollector.DependencyTrackingTelemetryModule"/>,
+        /// or <c>null</c> when dependency tracking was not enabled during initialization.
+        /// When set, outbound dependency calls (HTTP, SQL, etc.) are collected into the Application Insights <c>dependencies</c> table.
+        /// </summary>
+        public DependencyTrackingTelemetryModule DependencyTrackingTelemetryModule { get; }
+
         public void Dispose()
         {
+            DependencyTrackingTelemetryModule?.Dispose();
             DiagnosticsTelemetryModule.Dispose();
             TelemetryConfiguration.Dispose();
         }

--- a/src/NuGet.Services.Logging/NuGet.Services.Logging.csproj
+++ b/src/NuGet.Services.Logging/NuGet.Services.Logging.csproj
@@ -12,6 +12,7 @@
   
   <ItemGroup>
     <PackageReference Include="Microsoft.ApplicationInsights" />
+    <PackageReference Include="Microsoft.ApplicationInsights.DependencyCollector" />
     <PackageReference Include="Microsoft.Extensions.Logging" />
     <PackageReference Include="Newtonsoft.Json" />
     <PackageReference Include="Serilog.Enrichers.Environment" />


### PR DESCRIPTION
Web services log dependency calls, but jobs don't, which complicates incident investigations.

Added an argument to `ApplicationInsights.Initialize` to use dependency tracking with app insights, turned off by default for now, so we don't introduce any extra load. We'll enable it gradually, starting with monitoring jobs (due to recent incidents with those).