### PR TITLE
[Staging] Unit 1.1 - Refactor to GetArchiveValidationError

### DIFF
--- a/src/NuGetGallery/Controllers/ApiController.cs
+++ b/src/NuGetGallery/Controllers/ApiController.cs
@@ -8,7 +8,6 @@ using System.Data;
 using System.Data.SqlClient;
 using System.Globalization;
 using System.IO;
-using System.IO.Compression;
 using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
@@ -551,47 +550,10 @@ namespace NuGetGallery
 
                 using (var packageStream = ReadPackageFromRequest())
                 {
-                    try
+                    var archiveValidationError = ZipArchiveHelpers.GetArchiveValidationError(packageStream);
+                    if (archiveValidationError != null)
                     {
-                        InvalidZipEntry anyInvalidZipEntry = ZipArchiveHelpers.ValidateArchiveEntries(packageStream, out ZipArchiveEntry invalidZipEntry);
-
-                        switch (anyInvalidZipEntry)
-                        {
-                            case InvalidZipEntry.None:
-                                break;
-                            case InvalidZipEntry.InFuture:
-                                return new HttpStatusCodeWithBodyResult(HttpStatusCode.BadRequest, string.Format(
-                                    CultureInfo.CurrentCulture,
-                                    Strings.PackageEntryFromTheFuture,
-                                    invalidZipEntry.Name));
-                            case InvalidZipEntry.DoubleForwardSlashesInPath:
-                                return new HttpStatusCodeWithBodyResult(HttpStatusCode.BadRequest, string.Format(
-                                    CultureInfo.CurrentCulture,
-                                    Strings.PackageEntryWithDoubleForwardSlash,
-                                    invalidZipEntry.Name));
-                            case InvalidZipEntry.DoubleBackwardSlashesInPath:
-                                return new HttpStatusCodeWithBodyResult(HttpStatusCode.BadRequest, string.Format(
-                                    CultureInfo.CurrentCulture,
-                                    Strings.PackageEntryWithDoubleBackSlash,
-                                    invalidZipEntry.Name));
-                            default:
-                                // Generic error message for unknown invalid zip entry
-                                return new HttpStatusCodeWithBodyResult(HttpStatusCode.BadRequest, string.Format(
-                                    CultureInfo.CurrentCulture,
-                                    Strings.InvalidPackageEntry,
-                                    invalidZipEntry.Name));
-                        }
-                    }
-                    catch (Exception ex)
-                    {
-                        // This is not very elegant to catch every Exception type here. However, the types of exceptions
-                        // that could be thrown when reading a garbage ZIP is undocumented. We've seen ArgumentOutOfRangeException
-                        // get thrown from HttpInputStream and InvalidDataException thrown from ZipArchive.
-                        ex.Log();
-
-                        return new HttpStatusCodeWithBodyResult(HttpStatusCode.BadRequest, string.Format(
-                            CultureInfo.CurrentCulture,
-                            Strings.FailedToReadUploadFile));
+                        return new HttpStatusCodeWithBodyResult(HttpStatusCode.BadRequest, archiveValidationError);
                     }
 
                     try

--- a/src/NuGetGallery/Services/SymbolPackageUploadService.cs
+++ b/src/NuGetGallery/Services/SymbolPackageUploadService.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Globalization;
 using System.IO;
-using System.IO.Compression;
 using System.Linq;
 using System.Threading.Tasks;
 using NuGet.Frameworks;
@@ -63,33 +62,10 @@ namespace NuGetGallery
 
             try
             {
-                InvalidZipEntry anyInvalidZipEntry = ZipArchiveHelpers.ValidateArchiveEntries(symbolPackageStream, out ZipArchiveEntry invalidZipEntry);
-
-                switch (anyInvalidZipEntry)
+                var archiveValidationError = ZipArchiveHelpers.GetArchiveValidationError(symbolPackageStream);
+                if (archiveValidationError != null)
                 {
-                    case InvalidZipEntry.None:
-                        break;
-                    case InvalidZipEntry.InFuture:
-                        return SymbolPackageValidationResult.Invalid(string.Format(
-                            CultureInfo.CurrentCulture,
-                            Strings.PackageEntryFromTheFuture,
-                            invalidZipEntry.Name));
-                    case InvalidZipEntry.DoubleForwardSlashesInPath:
-                        return SymbolPackageValidationResult.Invalid(string.Format(
-                            CultureInfo.CurrentCulture,
-                            Strings.PackageEntryWithDoubleForwardSlash,
-                            invalidZipEntry.Name));
-                    case InvalidZipEntry.DoubleBackwardSlashesInPath:
-                        return SymbolPackageValidationResult.Invalid(string.Format(
-                            CultureInfo.CurrentCulture,
-                            Strings.PackageEntryWithDoubleBackSlash,
-                            invalidZipEntry.Name));
-                    default:
-                        // Generic error message for unknown invalid zip entry
-                        return SymbolPackageValidationResult.Invalid(string.Format(
-                            CultureInfo.CurrentCulture,
-                            Strings.InvalidPackageEntry,
-                            invalidZipEntry.Name));
+                    return SymbolPackageValidationResult.Invalid(archiveValidationError);
                 }
 
                 using (var packageToPush = new PackageArchiveReader(symbolPackageStream, leaveStreamOpen: true))


### PR DESCRIPTION
## Summary

This is **Unit 1.1**, a follow-up to [Unit 1](https://github.com/NuGet/NuGetGallery/pull/10946).

This PR:

- Reuses `ZipArchiveHelpers.GetArchiveValidationError` for API package pushes.
- Reuses the same helper for symbol package uploads.
- Removes duplicated archive-validation and error-handling logic.
- Preserves the existing caller-specific response types and behavior.

## Delivery roadmap

| Unit | Scope | PR |
| --- | --- | --- |
| 1 | Package staging | [#10946](https://github.com/NuGet/NuGetGallery/pull/10946) |
| 1.1 | Archive validation deduplication | This PR |
| 2 | Package staging UI | — |
| 3 | Package validation | — |
| 4 | Package management | — |
| 5 | Package promotion | — |
| 6 | Promotion history | — |
| 7 | Package groups | — |
| 8 | Group promotion | — |
| 9 | Symbol staging | — |
| 10 | Symbol promotion | — |
| 11 | Symbol groups | — |
| 12 | Blob cleanup | — |
| 13 | Expiration and quotas | — |
| 14 | Notifications and ownership | — |
| 15 | External contracts | — |
| 16 | Launch readiness | — |

## Review scope

This is a mechanical follow-up to Unit 1. Please review the replacement of duplicated archive-validation logic in `ApiController` and `SymbolPackageUploadService`.