### PR TITLE
Fix expired API key cleanup row count

### DIFF
--- a/src/Gallery.Maintenance/DeleteExpiredApiKeysTask.cs
+++ b/src/Gallery.Maintenance/DeleteExpiredApiKeysTask.cs
@@ -39,27 +39,33 @@ DELETE FROM [dbo].[Credentials] WHERE [Key] IN ({0})";
 
         public override async Task RunAsync(Job job)
         {
-            IEnumerable<ApiKey> expiredApiKeys;
+            IEnumerable<ApiKey> expiredApiKeyScopeRows;
 
             using (var connection = await job.OpenSqlConnectionAsync<GalleryDbConfiguration>())
             {
-                expiredApiKeys = await connection.QueryWithRetryAsync<ApiKey>(
+                expiredApiKeyScopeRows = await connection.QueryWithRetryAsync<ApiKey>(
                     SelectQuery,
                     commandTimeout: _commandTimeout,
                     maxRetries: 3);
             }
 
-            var credentialKeys = expiredApiKeys.Select(expiredApiKey =>
+            var credentialKeys = expiredApiKeyScopeRows.Select(expiredApiKeyScopeRow =>
             {
                 _logger.LogInformation(
                     "Found expired ApiKey: CredentialKey='{credentialKey}' CredentialType='{credentialType}' UserKey='{userKey}', User='{userName}', Subject='{scopeSubject}', Expires={expires}",
-                    expiredApiKey.CredentialKey, expiredApiKey.CredentialType, expiredApiKey.UserKey, expiredApiKey.Username, expiredApiKey.ScopeSubject, expiredApiKey.Expires);
+                    expiredApiKeyScopeRow.CredentialKey,
+                    expiredApiKeyScopeRow.CredentialType,
+                    expiredApiKeyScopeRow.UserKey,
+                    expiredApiKeyScopeRow.Username,
+                    expiredApiKeyScopeRow.ScopeSubject,
+                    expiredApiKeyScopeRow.Expires);
 
-                return expiredApiKey.CredentialKey;
-            });
+                return expiredApiKeyScopeRow.CredentialKey;
+            }).Distinct().ToList();
 
             var rowCount = 0;
-            var expectedRowCount = expiredApiKeys.Count() * 2; // credential and scope.
+            var scopeRowCount = expiredApiKeyScopeRows.Count();
+            var expectedRowCount = credentialKeys.Count + scopeRowCount;
 
             if (expectedRowCount > 0)
             {

--- a/src/Gallery.Maintenance/DeleteExpiredApiKeysTask.cs
+++ b/src/Gallery.Maintenance/DeleteExpiredApiKeysTask.cs
@@ -39,33 +39,32 @@ DELETE FROM [dbo].[Credentials] WHERE [Key] IN ({0})";
 
         public override async Task RunAsync(Job job)
         {
-            IEnumerable<ApiKey> expiredApiKeyScopeRows;
+            IEnumerable<ApiKey> expiredApiKeyScopes;
 
             using (var connection = await job.OpenSqlConnectionAsync<GalleryDbConfiguration>())
             {
-                expiredApiKeyScopeRows = await connection.QueryWithRetryAsync<ApiKey>(
+                expiredApiKeyScopes = await connection.QueryWithRetryAsync<ApiKey>(
                     SelectQuery,
                     commandTimeout: _commandTimeout,
                     maxRetries: 3);
             }
 
-            var credentialKeys = expiredApiKeyScopeRows.Select(expiredApiKeyScopeRow =>
+            var expiredCredentialKeys = expiredApiKeyScopes.Select(expiredApiKeyScope =>
             {
                 _logger.LogInformation(
                     "Found expired ApiKey: CredentialKey='{credentialKey}' CredentialType='{credentialType}' UserKey='{userKey}', User='{userName}', Subject='{scopeSubject}', Expires={expires}",
-                    expiredApiKeyScopeRow.CredentialKey,
-                    expiredApiKeyScopeRow.CredentialType,
-                    expiredApiKeyScopeRow.UserKey,
-                    expiredApiKeyScopeRow.Username,
-                    expiredApiKeyScopeRow.ScopeSubject,
-                    expiredApiKeyScopeRow.Expires);
+                    expiredApiKeyScope.CredentialKey,
+                    expiredApiKeyScope.CredentialType,
+                    expiredApiKeyScope.UserKey,
+                    expiredApiKeyScope.Username,
+                    expiredApiKeyScope.ScopeSubject,
+                    expiredApiKeyScope.Expires);
 
-                return expiredApiKeyScopeRow.CredentialKey;
+                return expiredApiKeyScope.CredentialKey;
             }).Distinct().ToList();
 
             var rowCount = 0;
-            var scopeRowCount = expiredApiKeyScopeRows.Count();
-            var expectedRowCount = credentialKeys.Count + scopeRowCount;
+            var expectedRowCount = expiredCredentialKeys.Count + expiredApiKeyScopes.Count();
 
             if (expectedRowCount > 0)
             {
@@ -74,7 +73,7 @@ DELETE FROM [dbo].[Credentials] WHERE [Key] IN ({0})";
                 using (var command = connection.CreateCommand())
                 {
                     var numKeys = 0;
-                    var parameters = credentialKeys.Select(c => new SqlParameter("@Key" + numKeys++, SqlDbType.Int) { Value = c }).ToArray();
+                    var parameters = expiredCredentialKeys.Select(c => new SqlParameter("@Key" + numKeys++, SqlDbType.Int) { Value = c }).ToArray();
                     command.Parameters.AddRange(parameters);
 
 #pragma warning disable CA2100 // Review SQL queries for security vulnerabilities


### PR DESCRIPTION
Fix expired API key cleanup row count for multi-scope credentials.

Context: https://portal.microsofticm.com/imp/v5/incidents/details/853796517/summary

- Gallery.Maintenance job missed heartbeats. This job runs a task that deletes expired API keys by querying the SQL DB for keys past expiry, and then deleting the Key from the [Credentials] table and the linked subject/scopes from [Scopes]. After deleting, it does some validation to check that it deleted the correct amount, but it gets that math wrong. The deletes themselves still go through fine.
- It tries to count the expected number of deletes (expired Keys + expired Scopes), but just assumes that this number would be the same as NumScopes x 2. It expects that every key has exactly one scope, but the reality is that a key can have multiple scopes defined, so you could have 1 key with 2 different scope row. The current code expects the number of deletes here to be 4, but it should be 3 (1 key + 2 scopes). This needs a small fix to the code.
- SRE agent diagnosed the error and root cause perfectly 🤖👑

This is the fix:
- Count distinct credential keys separately from scope query rows.
- Avoid duplicate credential keys in the deletion query.
- Clarify that each query result represents an API key scope row.

I wasn't sure how to add tests cheaply, since the task uses a direct SQL query, so we'd have to do SQL setup/cleanup to test this, or we'd need to refactor the main loop to make it more testable. I skipped that for now.