### PR TITLE
[Staging] Unit 2.1 - Use staged package repository

### DIFF
--- a/src/NuGetGallery/App_Start/DefaultDependenciesModule.cs
+++ b/src/NuGetGallery/App_Start/DefaultDependenciesModule.cs
@@ -228,6 +228,11 @@ namespace NuGetGallery
                 .As<IEntityRepository<Package>>()
                 .InstancePerLifetimeScope();
 
+            builder.RegisterType<EntityRepository<StagedPackage>>()
+                .AsSelf()
+                .As<IEntityRepository<StagedPackage>>()
+                .InstancePerLifetimeScope();
+
             builder.RegisterType<EntityRepository<PackageDependency>>()
                 .AsSelf()
                 .As<IEntityRepository<PackageDependency>>()

--- a/src/NuGetGallery/Services/PackageStagingManagementService.cs
+++ b/src/NuGetGallery/Services/PackageStagingManagementService.cs
@@ -12,21 +12,21 @@ namespace NuGetGallery
 {
     public class PackageStagingManagementService : IPackageStagingManagementService
     {
-        private readonly IEntitiesContext _entitiesContext;
         private readonly IApiScopeEvaluator _apiScopeEvaluator;
         private readonly IFeatureFlagService _featureFlagService;
         private readonly IPackageService _packageService;
+        private readonly IEntityRepository<StagedPackage> _stagedPackageRepository;
 
         public PackageStagingManagementService(
-            IEntitiesContext entitiesContext,
             IApiScopeEvaluator apiScopeEvaluator,
             IFeatureFlagService featureFlagService,
-            IPackageService packageService)
+            IPackageService packageService,
+            IEntityRepository<StagedPackage> stagedPackageRepository)
         {
-            _entitiesContext = entitiesContext ?? throw new ArgumentNullException(nameof(entitiesContext));
             _apiScopeEvaluator = apiScopeEvaluator ?? throw new ArgumentNullException(nameof(apiScopeEvaluator));
             _featureFlagService = featureFlagService ?? throw new ArgumentNullException(nameof(featureFlagService));
             _packageService = packageService ?? throw new ArgumentNullException(nameof(packageService));
+            _stagedPackageRepository = stagedPackageRepository ?? throw new ArgumentNullException(nameof(stagedPackageRepository));
         }
 
         public PackageStagingStatus GetPackage(User currentUser, IEnumerable<Scope> scopes, string id, string version)
@@ -57,7 +57,9 @@ namespace NuGetGallery
                 return null;
             }
 
-            var stagedPackage = _entitiesContext.StagedPackages.Find(package.Key);
+            var stagedPackage = _stagedPackageRepository
+                .GetAll()
+                .SingleOrDefault(candidate => candidate.PackageKey == package.Key);
             if (stagedPackage == null)
             {
                 return null;
@@ -105,7 +107,7 @@ namespace NuGetGallery
                 .Select(owner => owner.Key)
                 .ToArray();
 
-            var stagedPackages = _entitiesContext.StagedPackages;
+            var stagedPackages = _stagedPackageRepository.GetAll();
 
             return stagedPackages
                 .Include(stagedPackage => stagedPackage.Package.PackageRegistration)

--- a/src/NuGetGallery/Services/PackageStagingUploadService.cs
+++ b/src/NuGetGallery/Services/PackageStagingUploadService.cs
@@ -22,8 +22,6 @@ namespace NuGetGallery
 {
     public class PackageStagingUploadService : IPackageStagingUploadService
     {
-        private readonly IEntitiesContext _entitiesContext;
-
         private readonly IApiScopeEvaluator _apiScopeEvaluator;
 
         private readonly IFeatureFlagService _featureFlagService;
@@ -38,17 +36,18 @@ namespace NuGetGallery
 
         private readonly IStagingBlobService _stagingBlobService;
 
+        private readonly IEntityRepository<StagedPackage> _stagedPackageRepository;
+
         public PackageStagingUploadService(
-            IEntitiesContext entitiesContext,
             IApiScopeEvaluator apiScopeEvaluator,
             IFeatureFlagService featureFlagService,
             IPackageService packageService,
             IPackageUploadService packageUploadService,
             IReservedNamespaceService reservedNamespaceService,
             ISecurityPolicyService securityPolicyService,
-            IStagingBlobService stagingBlobService)
+            IStagingBlobService stagingBlobService,
+            IEntityRepository<StagedPackage> stagedPackageRepository)
         {
-            _entitiesContext = entitiesContext ?? throw new ArgumentNullException(nameof(entitiesContext));
             _apiScopeEvaluator = apiScopeEvaluator ?? throw new ArgumentNullException(nameof(apiScopeEvaluator));
             _featureFlagService = featureFlagService ?? throw new ArgumentNullException(nameof(featureFlagService));
             _packageService = packageService ?? throw new ArgumentNullException(nameof(packageService));
@@ -56,6 +55,7 @@ namespace NuGetGallery
             _reservedNamespaceService = reservedNamespaceService ?? throw new ArgumentNullException(nameof(reservedNamespaceService));
             _securityPolicyService = securityPolicyService ?? throw new ArgumentNullException(nameof(securityPolicyService));
             _stagingBlobService = stagingBlobService ?? throw new ArgumentNullException(nameof(stagingBlobService));
+            _stagedPackageRepository = stagedPackageRepository ?? throw new ArgumentNullException(nameof(stagedPackageRepository));
         }
 
         public async Task<PackageStagingResult> StagePackageAsync(User currentUser, IEnumerable<Scope> scopes, HttpContextBase httpContext, Stream packageFile)
@@ -294,7 +294,7 @@ namespace NuGetGallery
             var blobPath = await _stagingBlobService.SavePackageFileAsync(package.PackageRegistration.Id, package.NormalizedVersion, packageFile);
 
             await _packageService.UpdatePackageStatusAsync(package, PackageStatus.Staged, commitChanges: false);
-            _entitiesContext.StagedPackages.Add(new StagedPackage
+            _stagedPackageRepository.InsertOnCommit(new StagedPackage
             {
                 Package = package,
                 OwnerKey = owner.Key,
@@ -304,7 +304,7 @@ namespace NuGetGallery
 
             try
             {
-                await _entitiesContext.SaveChangesAsync();
+                await _stagedPackageRepository.CommitChangesAsync();
             }
             catch (Exception exception) when (IsConflict(exception))
             {

--- a/tests/NuGetGallery.Facts/Services/PackageStagingManagementServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/PackageStagingManagementServiceFacts.cs
@@ -56,9 +56,9 @@ namespace NuGetGallery
                 stagedPackagesSet.As<IQueryable<StagedPackage>>().Setup(x => x.GetEnumerator()).Returns(() => stagedPackagesQuery.GetEnumerator());
                 stagedPackagesSet.Setup(x => x.Include("Package.PackageRegistration")).Returns(stagedPackagesSet.Object);
                 stagedPackagesSet.Setup(x => x.Include("Owner")).Returns(stagedPackagesSet.Object);
-                var entitiesContext = new Mock<IEntitiesContext>();
-                entitiesContext
-                    .SetupGet(x => x.StagedPackages)
+                var stagedPackageRepository = new Mock<IEntityRepository<StagedPackage>>();
+                stagedPackageRepository
+                    .Setup(x => x.GetAll())
                     .Returns(stagedPackagesSet.Object);
 
                 var featureFlagService = new Mock<IFeatureFlagService>();
@@ -67,10 +67,10 @@ namespace NuGetGallery
                     .Returns((User owner) => isEnabled(owner));
 
                 return new PackageStagingManagementService(
-                    entitiesContext.Object,
                     Mock.Of<IApiScopeEvaluator>(),
                     featureFlagService.Object,
-                    Mock.Of<IPackageService>());
+                    Mock.Of<IPackageService>(),
+                    stagedPackageRepository.Object);
             }
 
             private static StagedPackage CreateStagedPackage(int packageKey, string id, string version, User owner)

--- a/tests/NuGetGallery.Facts/Services/PackageStagingUploadServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/PackageStagingUploadServiceFacts.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
-using System.Data.Entity;
 using System.IO;
 using System.Net;
 using System.Threading.Tasks;
@@ -99,14 +98,13 @@ namespace NuGetGallery
                     .ReturnsAsync(blobPath);
 
                 StagedPackage stagedPackage = null;
-                var stagedPackages = new Mock<DbSet<StagedPackage>>();
-                stagedPackages
-                    .Setup(x => x.Add(It.IsAny<StagedPackage>()))
+                var stagedPackageRepository = new Mock<IEntityRepository<StagedPackage>>();
+                stagedPackageRepository
+                    .Setup(x => x.InsertOnCommit(It.IsAny<StagedPackage>()))
                     .Callback<StagedPackage>(value => stagedPackage = value);
-
-                var entitiesContext = new Mock<IEntitiesContext>();
-                entitiesContext.SetupGet(x => x.StagedPackages).Returns(stagedPackages.Object);
-                entitiesContext.Setup(x => x.SaveChangesAsync()).ReturnsAsync(1);
+                stagedPackageRepository
+                    .Setup(x => x.CommitChangesAsync())
+                    .Returns(Task.CompletedTask);
 
                 var featureFlagService = new Mock<IFeatureFlagService>();
                 featureFlagService
@@ -114,14 +112,14 @@ namespace NuGetGallery
                     .Returns(true);
 
                 var target = new PackageStagingUploadService(
-                    entitiesContext.Object,
                     apiScopeEvaluator.Object,
                     featureFlagService.Object,
                     packageService.Object,
                     packageUploadService.Object,
                     Mock.Of<IReservedNamespaceService>(),
                     securityPolicyService.Object,
-                    stagingFiles.Object);
+                    stagingFiles.Object,
+                    stagedPackageRepository.Object);
 
                 using (var packageFile = TestPackage.CreateTestPackageStream("PackageA", "1.0.0"))
                 {
@@ -138,7 +136,8 @@ namespace NuGetGallery
                 Assert.Equal(PackageStatus.Staged, package.PackageStatusKey);
                 Assert.Equal(owner.Key, stagedPackage.OwnerKey);
                 Assert.Equal(blobPath, stagedPackage.BlobPath);
-                entitiesContext.Verify(x => x.SaveChangesAsync(), Times.Once);
+                stagedPackageRepository.Verify(x => x.InsertOnCommit(stagedPackage), Times.Once);
+                stagedPackageRepository.Verify(x => x.CommitChangesAsync(), Times.Once);
             }
         }
 


### PR DESCRIPTION
## Summary

This is **Unit 2.1**, a follow-up to [Unit 2](https://github.com/NuGet/NuGetGallery/pull/10950).

This PR:

- Adds an `IEntityRepository<StagedPackage>` registration.
- Uses the repository abstraction for staged-package queries.
- Uses the repository abstraction when inserting and committing staged packages.
- Removes direct `IEntitiesContext` access from the staging upload and management services.
- Updates the corresponding service tests to mock the repository boundary.

Behavior remains unchanged.

## Delivery roadmap

| Unit | Scope | PR |
| --- | --- | --- |
| 1 | Package staging | [#10946](https://github.com/NuGet/NuGetGallery/pull/10946) |
| 1.1 | Archive validation deduplication | [#10948](https://github.com/NuGet/NuGetGallery/pull/10948) |
| 2 | Package staging UI | [#10950](https://github.com/NuGet/NuGetGallery/pull/10950) |
| 2.1 | Staged package repository | This PR |
| 3 | Package validation | — |
| 4 | Package management | — |
| 5 | Package promotion | — |
| 6 | Promotion history | — |
| 7 | Package groups | — |
| 8 | Group promotion | — |
| 9 | Symbol staging | — |
| 10 | Symbol promotion | — |
| 11 | Symbol groups | — |
| 12 | Blob cleanup | — |
| 13 | Expiration and quotas | — |
| 14 | Notifications and ownership | — |
| 15 | External contracts | — |
| 16 | Launch readiness | — |

## Review scope

This is a data-access refactor following Unit 2 review feedback. Please review the replacement of direct `IEntitiesContext` access with `IEntityRepository<StagedPackage>` in the staging upload and management services.