### PR TITLE
Re-enable FailValidation Audit

### DIFF
--- a/src/NuGetGallery/Areas/Admin/Services/ValidationAdminService.cs
+++ b/src/NuGetGallery/Areas/Admin/Services/ValidationAdminService.cs
@@ -146,11 +146,8 @@ namespace NuGetGallery.Areas.Admin.Services
                 }
 
                 await _validationService.FailValidationAsync(package);
-                // TODO #6488: Need to update the shim before adding validatei
-                // await _auditingService.SaveAuditRecordAsync(
-                // new PackageAuditRecord(package, AuditedPackageAction.FailValidation, ForceFailValidationReason));
-                await _packages.CommitChangesAsync();
-
+                await _auditingService.SaveAuditRecordAsync(
+                new PackageAuditRecord(package, AuditedPackageAction.FailValidation, ForceFailValidationReason));
                 return true;
             }
             else if (validatingType == ValidatingType.SymbolPackage)
@@ -167,11 +164,8 @@ namespace NuGetGallery.Areas.Admin.Services
                 }
 
                 await _validationService.FailValidationAsync(symbolPackage);
-                // TODO #6488: Need to update the shim before adding validatei
-                // await _auditingService.SaveAuditRecordAsync(
-                // new PackageAuditRecord(symbolPackage.Package, AuditedPackageAction.SymbolsFailValidation, ForceFailValidationReason));
-                await _symbolPackages.CommitChangesAsync();
-
+                await _auditingService.SaveAuditRecordAsync(
+                new PackageAuditRecord(symbolPackage.Package, AuditedPackageAction.SymbolsFailValidation, ForceFailValidationReason));
                 return true;
             }
             else

--- a/src/NuGetGallery/Areas/Admin/Services/ValidationAdminService.cs
+++ b/src/NuGetGallery/Areas/Admin/Services/ValidationAdminService.cs
@@ -146,6 +146,7 @@ namespace NuGetGallery.Areas.Admin.Services
                 }
 
                 await _validationService.FailValidationAsync(package);
+                await _packages.CommitChangesAsync();
                 await _auditingService.SaveAuditRecordAsync(
                 new PackageAuditRecord(package, AuditedPackageAction.FailValidation, ForceFailValidationReason));
                 return true;
@@ -164,6 +165,7 @@ namespace NuGetGallery.Areas.Admin.Services
                 }
 
                 await _validationService.FailValidationAsync(symbolPackage);
+                await _symbolPackages.CommitChangesAsync();
                 await _auditingService.SaveAuditRecordAsync(
                 new PackageAuditRecord(symbolPackage.Package, AuditedPackageAction.SymbolsFailValidation, ForceFailValidationReason));
                 return true;


### PR DESCRIPTION
Re-enabled FaileValidation Audit now that the Shim is updated. 
Also removed "CommitChangesAsync();" as this is not necessary as no change has been made to the package and/or sympbols