### PR TITLE
Base "Per day average" on trailing 6-week download stats (#10931)

### DIFF
--- a/src/AccountDeleter/EmptyFeatureFlagService.cs
+++ b/src/AccountDeleter/EmptyFeatureFlagService.cs
@@ -71,6 +71,11 @@ namespace NuGetGallery.AccountDeleter
             throw new NotImplementedException();
         }
 
+        public bool IsRecentDownloadsPerDayEnabled()
+        {
+            throw new NotImplementedException();
+        }
+
         public bool IsDisplayNuGetPackageExplorerLinkEnabled()
         {
             throw new NotImplementedException();

--- a/src/GitHubVulnerabilities2Db/Fakes/FakeFeatureFlagService.cs
+++ b/src/GitHubVulnerabilities2Db/Fakes/FakeFeatureFlagService.cs
@@ -70,6 +70,11 @@ namespace GitHubVulnerabilities2Db.Fakes
             throw new NotImplementedException();
         }
 
+        public bool IsRecentDownloadsPerDayEnabled()
+        {
+            throw new NotImplementedException();
+        }
+
         public bool IsDisplayNuGetTrendsLinksEnabled()
         {
             throw new NotImplementedException();

--- a/src/NuGetGallery.Services/Configuration/FeatureFlagService.cs
+++ b/src/NuGetGallery.Services/Configuration/FeatureFlagService.cs
@@ -29,6 +29,7 @@ namespace NuGetGallery
         private const string DisplayVulnerabilitiesFeatureName = GalleryPrefix + "DisplayVulnerabilities";
         private const string ManagePackagesVulnerabilitiesFeatureName = GalleryPrefix + "ManagePackagesVulnerabilities";
         private const string DisplayFuGetLinksFeatureName = GalleryPrefix + "DisplayFuGetLinks";
+        private const string RecentDownloadsPerDayFeatureName = GalleryPrefix + "RecentDownloadsPerDay";
         private const string DisplayNuGetPackageExplorerLinkFeatureName = GalleryPrefix + "DisplayNuGetPackageExplorerLink";
         private const string DisplayNuGetTrendsLinkFeatureName = GalleryPrefix + "DisplayNuGetTrendsLink";
         private const string ODataReadOnlyDatabaseFeatureName = GalleryPrefix + "ODataReadOnlyDatabase";
@@ -184,6 +185,11 @@ namespace NuGetGallery
         public bool IsDisplayFuGetLinksEnabled()
         {
             return _client.IsEnabled(DisplayFuGetLinksFeatureName, defaultValue: false);
+        }
+
+        public bool IsRecentDownloadsPerDayEnabled()
+        {
+            return _client.IsEnabled(RecentDownloadsPerDayFeatureName, defaultValue: false);
         }
 
         public bool IsDisplayNuGetPackageExplorerLinkEnabled()

--- a/src/NuGetGallery.Services/Configuration/IFeatureFlagService.cs
+++ b/src/NuGetGallery.Services/Configuration/IFeatureFlagService.cs
@@ -84,6 +84,13 @@ namespace NuGetGallery
         bool IsDisplayFuGetLinksEnabled();
 
         /// <summary>
+        /// Whether the "Per day average" download metric on a package's details page is computed from
+        /// the trailing 6-week download statistics rather than dividing lifetime downloads by the age
+        /// of the oldest available version. See https://github.com/NuGet/NuGetGallery/issues/10931.
+        /// </summary>
+        bool IsRecentDownloadsPerDayEnabled();
+
+        /// <summary>
         /// Whether or not a nugettrends.com link is visible on a package's details page.
         /// </summary>
         bool IsDisplayNuGetTrendsLinksEnabled();

--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -63,6 +63,21 @@ namespace NuGetGallery
         /// </summary>
         private static readonly TimeSpan IsIndexedCheckUntil = TimeSpan.FromDays(1);
 
+        /// <summary>
+        /// The trailing window, in days, over which the "Per day average" download metric is computed when
+        /// recent download statistics are available. This MUST match the window in the report stored proc
+        /// dbo.DownloadReportRecentPopularityDetailByPackage (DATEADD(day, -42, ...)). That date filter is
+        /// inclusive of both ends (43 calendar dates), but the most recent date is a partial, ETL-lagged
+        /// bucket, so ~42 full days of data are captured; 42 also matches the report's documented 6-week
+        /// window. The per-package report carries no date dimension, so the window can't be read back here.
+        /// </summary>
+        private const int RecentDownloadWindowInDays = 42;
+
+        /// <summary>
+        /// How long a package's recent download total is cached before the statistics report is re-read.
+        /// </summary>
+        private static readonly TimeSpan RecentDownloadStatisticsCacheDuration = TimeSpan.FromHours(1);
+
         private static readonly IReadOnlyList<ReportPackageReason> ReportAbuseReasons = new[]
         {
             ReportPackageReason.ViolatesALicenseIOwn,
@@ -152,6 +167,7 @@ namespace NuGetGallery
         private readonly IPackageFrameworkCompatibilityFactory _compatibilityFactory;
         private readonly IReflowPackageService _reflowPackageService;
         private readonly DisplayPackageViewModelFactory _displayPackageViewModelFactory;
+        private readonly IStatisticsService _statisticsService;
         private readonly DisplayLicenseViewModelFactory _displayLicenseViewModelFactory;
         private readonly ListPackageItemViewModelFactory _listPackageItemViewModelFactory;
         private readonly ManagePackageViewModelFactory _managePackageViewModelFactory;
@@ -194,7 +210,8 @@ namespace NuGetGallery
             IMarkdownService markdownService,
             IPackageFrameworkCompatibilityFactory compatibilityFactory,
             ISponsorshipUrlService sponsorshipUrlService,
-            IReflowPackageService reflowPackageService)
+            IReflowPackageService reflowPackageService,
+            IStatisticsService statisticsService)
         {
             _packageFilter = packageFilter;
             _packageService = packageService;
@@ -233,6 +250,7 @@ namespace NuGetGallery
             _abTestService = abTestService ?? throw new ArgumentNullException(nameof(abTestService));
             _iconUrlProvider = iconUrlProvider ?? throw new ArgumentNullException(nameof(iconUrlProvider));
             _reflowPackageService = reflowPackageService ?? throw new ArgumentNullException(nameof(reflowPackageService));
+            _statisticsService = statisticsService ?? throw new ArgumentNullException(nameof(statisticsService));
 
             _displayPackageViewModelFactory = new DisplayPackageViewModelFactory(_iconUrlProvider, _compatibilityFactory, featureFlagService, sponsorshipUrlService);
             _displayLicenseViewModelFactory = new DisplayLicenseViewModelFactory(_iconUrlProvider, _markdownService, _featureFlagService);
@@ -1033,6 +1051,11 @@ namespace NuGetGallery
                 model.PackageDependents = GetPackageDependents(id);
             }
 
+            if (_featureFlagService.IsRecentDownloadsPerDayEnabled())
+            {
+                await SetRecentDownloadsPerDayAsync(model, id, hasCompleteVersionHistory: !hasMoreVersions);
+            }
+
             if (model.IsGitHubUsageEnabled = _featureFlagService.IsGitHubUsageEnabled(currentUser))
             {
                 var gitHubUsage = _contentObjectService.GitHubUsageConfiguration.GetPackageInformation(id);
@@ -1176,6 +1199,89 @@ namespace NuGetGallery
                 // https://github.com/NuGet/NuGetGallery/issues/4718
             }
             return dependents;
+        }
+
+        /// <summary>
+        /// Overrides the model's "Per day average" download metric with one computed from the trailing
+        /// <see cref="RecentDownloadWindowInDays"/>-day download statistics, when those are available.
+        /// This reflects a package's current popularity, unlike the factory's lifetime figure which divides
+        /// total downloads by the age of the oldest available version and over-states packages that release
+        /// frequently or unlist/delete old versions. See https://github.com/NuGet/NuGetGallery/issues/10931.
+        /// When recent statistics are unavailable the model keeps the lifetime figure as a fallback.
+        /// </summary>
+        /// <param name="hasCompleteVersionHistory">
+        /// True when <see cref="DisplayPackageViewModel.TotalDaysSinceCreated"/> was computed from the package's
+        /// full version history and can be trusted as its true age. When only a capped subset of versions was
+        /// loaded (reduced version lists), the age is unreliable, so the full window is used instead.
+        /// </param>
+        private async Task SetRecentDownloadsPerDayAsync(DisplayPackageViewModel model, string id, bool hasCompleteVersionHistory)
+        {
+            // No statistics source configured (e.g. NullStatisticsService); keep the lifetime fallback.
+            if (_statisticsService == NullStatisticsService.Instance)
+            {
+                return;
+            }
+
+            try
+            {
+                var recentDownloads = await GetRecentDownloadCountAsync(id);
+                if (recentDownloads.HasValue)
+                {
+                    // For a package younger than the window, divide only by the days it has existed; otherwise a
+                    // brand-new package's average is understated, since the report only contains downloads from
+                    // the days the package existed. Only trust the age when the full version history was loaded:
+                    // with a capped list (reduced version lists) the computed age can be far too small, which
+                    // would instead over-state a frequently-releasing package, so fall back to the full window.
+                    var windowDays = hasCompleteVersionHistory
+                        ? Math.Max(1, Math.Min(RecentDownloadWindowInDays, model.TotalDaysSinceCreated))
+                        : RecentDownloadWindowInDays;
+                    var downloadsPerDay = recentDownloads.Value / windowDays;
+                    model.DownloadsPerDay = downloadsPerDay;
+                    model.DownloadsPerDayLabel = downloadsPerDay < 1 ? "<1" : downloadsPerDay.ToNuGetNumberString();
+                }
+            }
+            catch (Exception ex)
+            {
+                // A statistics hiccup must never break the package details page; fall back to the
+                // lifetime average already set on the model.
+                _telemetryService.TraceException(ex);
+            }
+        }
+
+        /// <summary>
+        /// Returns the total number of downloads for the package over the trailing statistics window,
+        /// or null when no recent statistics report is available. The result is cached per web instance
+        /// for <see cref="RecentDownloadStatisticsCacheDuration"/> to avoid a report read on every request.
+        /// </summary>
+        private async Task<long?> GetRecentDownloadCountAsync(string id)
+        {
+            var cacheKey = "RecentDownloads_" + id.ToLowerInvariant();
+            var cached = HttpContext.Cache.Get(cacheKey);
+            if (cached != null)
+            {
+                var cachedValue = (long)cached;
+                return cachedValue < 0 ? (long?)null : cachedValue;
+            }
+
+            // -1 is a sentinel meaning "no recent statistics available" so that packages without a
+            // recent-popularity report are cached too and don't trigger a report read on every request.
+            var recentDownloads = -1L;
+            var report = await _statisticsService.GetPackageDownloadsByVersion(id);
+            if (report?.Facts != null && report.Facts.Count > 0)
+            {
+                recentDownloads = report.Facts.Sum(fact => fact.Amount);
+            }
+
+            // note: this is a per instance cache
+            HttpContext.Cache.Add(
+                cacheKey,
+                recentDownloads,
+                null,
+                DateTime.UtcNow.Add(RecentDownloadStatisticsCacheDuration),
+                Cache.NoSlidingExpiration,
+                CacheItemPriority.Default, null);
+
+            return recentDownloads < 0 ? (long?)null : recentDownloads;
         }
 
         [HttpGet]

--- a/src/VerifyMicrosoftPackage/Fakes/FakeFeatureFlagService.cs
+++ b/src/VerifyMicrosoftPackage/Fakes/FakeFeatureFlagService.cs
@@ -36,6 +36,8 @@ namespace NuGet.VerifyMicrosoftPackage.Fakes
 
         public bool IsDisplayFuGetLinksEnabled() => throw new NotImplementedException();
 
+        public bool IsRecentDownloadsPerDayEnabled() => throw new NotImplementedException();
+
         public bool AreEmbeddedIconsEnabled(User user) => throw new NotImplementedException();
 
         public bool IsForceFlatContainerIconsEnabled() => throw new NotImplementedException();

--- a/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
@@ -92,7 +92,8 @@ namespace NuGetGallery
             Mock<IIconUrlProvider> iconUrlProvider = null,
             Mock<IMarkdownService> markdownService = null,
             Mock<IPackageFrameworkCompatibilityFactory> compatibilityFactory = null,
-            Mock<ISponsorshipUrlService> sponsorshipUrlService = null)
+            Mock<ISponsorshipUrlService> sponsorshipUrlService = null,
+            Mock<IStatisticsService> statisticsService = null)
         {
             packageService = packageService ?? new Mock<IPackageService>();
             PackageDependents packageDependents = new PackageDependents();
@@ -280,6 +281,14 @@ namespace NuGetGallery
 
             iconUrlProvider = iconUrlProvider ?? new Mock<IIconUrlProvider>();
 
+            if (statisticsService == null)
+            {
+                statisticsService = new Mock<IStatisticsService>();
+                statisticsService
+                    .Setup(x => x.GetPackageDownloadsByVersion(It.IsAny<string>()))
+                    .ReturnsAsync((StatisticsPackagesReport)null);
+            }
+
             abTestService = abTestService ?? new Mock<IABTestService>();
 
             var diagnosticsService = new Mock<IDiagnosticsService>();
@@ -323,7 +332,8 @@ namespace NuGetGallery
                 markdownService.Object,
                 compatibilityFactory.Object,
                 sponsorshipUrlService.Object,
-                reflowPackageService.Object);
+                reflowPackageService.Object,
+                statisticsService.Object);
 
             controller.CallBase = true;
             controller.Object.SetOwinContextOverride(Fakes.CreateOwinContext());
@@ -1088,6 +1098,202 @@ namespace NuGetGallery
                 Assert.Equal("Foo", model.Id);
                 Assert.Equal("1.1.1", model.Version);
                 Assert.Null(model.ReadMeHtml);
+            }
+
+            [Fact]
+            public async Task WhenRecentDownloadsPerDayEnabledUsesTrailingWindowStatistics()
+            {
+                // Arrange
+                var packageService = new Mock<IPackageService>();
+                var statisticsService = new Mock<IStatisticsService>();
+                var controller = CreateController(
+                    GetConfigurationService(),
+                    packageService: packageService,
+                    statisticsService: statisticsService);
+                controller.SetCurrentUser(TestUtility.FakeUser);
+
+                var package = new Package()
+                {
+                    PackageRegistration = new PackageRegistration() { Id = "Foo", Owners = new List<User>() },
+                    Version = "1.0.0",
+                    NormalizedVersion = "1.0.0",
+                    PackageStatusKey = PackageStatus.Available,
+                    Created = DateTime.UtcNow.AddYears(-5),
+                };
+
+                var packages = new[] { package };
+                packageService
+                    .Setup(p => p.FindPackagesById("Foo", true, true, true))
+                    .Returns(packages);
+                packageService
+                    .Setup(p => p.FilterLatestPackage(packages, SemVerLevelKey.SemVer2, true))
+                    .Returns(package);
+
+                // 8,400 downloads over the trailing 42-day window => 200 per day.
+                var report = new StatisticsPackagesReport
+                {
+                    Facts = new List<StatisticsFact>
+                    {
+                        new StatisticsFact(new Dictionary<string, string>(), 8000),
+                        new StatisticsFact(new Dictionary<string, string>(), 400),
+                    },
+                };
+                statisticsService
+                    .Setup(s => s.GetPackageDownloadsByVersion("Foo"))
+                    .ReturnsAsync(report);
+
+                // Act
+                var result = await controller.DisplayPackage("Foo", null);
+
+                // Assert
+                var model = ResultAssert.IsView<DisplayPackageViewModel>(result);
+                Assert.Equal(200L, model.DownloadsPerDay);
+                Assert.Equal("200", model.DownloadsPerDayLabel);
+            }
+
+            [Fact]
+            public async Task WhenPackageYoungerThanWindowDividesByPackageAgeNotFullWindow()
+            {
+                // Arrange
+                var packageService = new Mock<IPackageService>();
+                var statisticsService = new Mock<IStatisticsService>();
+                var controller = CreateController(
+                    GetConfigurationService(),
+                    packageService: packageService,
+                    statisticsService: statisticsService);
+                controller.SetCurrentUser(TestUtility.FakeUser);
+
+                var package = new Package()
+                {
+                    PackageRegistration = new PackageRegistration() { Id = "Foo", Owners = new List<User>() },
+                    Version = "1.0.0",
+                    NormalizedVersion = "1.0.0",
+                    PackageStatusKey = PackageStatus.Available,
+                    Created = DateTime.UtcNow.AddDays(-10),
+                };
+
+                var packages = new[] { package };
+                packageService
+                    .Setup(p => p.FindPackagesById("Foo", true, true, true))
+                    .Returns(packages);
+                packageService
+                    .Setup(p => p.FilterLatestPackage(packages, SemVerLevelKey.SemVer2, true))
+                    .Returns(package);
+
+                // 1,000 downloads for a package only ~10 days old => 100 per day, not 1000/42 (23).
+                var report = new StatisticsPackagesReport
+                {
+                    Facts = new List<StatisticsFact>
+                    {
+                        new StatisticsFact(new Dictionary<string, string>(), 1000),
+                    },
+                };
+                statisticsService
+                    .Setup(s => s.GetPackageDownloadsByVersion("Foo"))
+                    .ReturnsAsync(report);
+
+                // Act
+                var result = await controller.DisplayPackage("Foo", null);
+
+                // Assert
+                var model = ResultAssert.IsView<DisplayPackageViewModel>(result);
+                Assert.Equal(100L, model.DownloadsPerDay);
+            }
+
+            [Fact]
+            public async Task WhenVersionListIsCappedUsesFullWindowNotApparentAge()
+            {
+                // Arrange: reduced version lists means only the latest versions are loaded, so the apparent
+                // age is unreliable. A frequently-releasing but old package must not be divided by that age.
+                var featureFlagService = new Mock<IFeatureFlagService>();
+                featureFlagService.SetReturnsDefault<bool>(true);
+                featureFlagService.Setup(ff => ff.IsReducedVersionListsEnabled()).Returns(true);
+
+                var packageService = new Mock<IPackageService>();
+                var statisticsService = new Mock<IStatisticsService>();
+
+                var package = new Package()
+                {
+                    PackageRegistration = new PackageRegistration() { Id = "Foo", Owners = new List<User>() },
+                    Version = "1.0.0",
+                    NormalizedVersion = "1.0.0",
+                    PackageStatusKey = PackageStatus.Available,
+                    // The loaded (capped) versions span only ~5 days, but the package is actually old.
+                    Created = DateTime.UtcNow.AddDays(-5),
+                };
+                var packages = new List<Package> { package };
+
+                packageService
+                    .Setup(ps => ps.FindLatestVersionsById(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<int>()))
+                    .Returns(new LatestPackageVersionsResult { Packages = packages, HasMoreResults = true });
+                packageService
+                    .Setup(p => p.FilterLatestPackage(It.IsAny<IReadOnlyCollection<Package>>(), SemVerLevelKey.SemVer2, true))
+                    .Returns(package);
+
+                var report = new StatisticsPackagesReport
+                {
+                    Facts = new List<StatisticsFact> { new StatisticsFact(new Dictionary<string, string>(), 4200) },
+                };
+                statisticsService
+                    .Setup(s => s.GetPackageDownloadsByVersion("Foo"))
+                    .ReturnsAsync(report);
+
+                var controller = CreateController(
+                    GetConfigurationService(),
+                    packageService: packageService,
+                    statisticsService: statisticsService,
+                    featureFlagService: featureFlagService);
+                controller.SetCurrentUser(TestUtility.FakeUser);
+
+                // Act
+                var result = await controller.DisplayPackage("Foo", null);
+
+                // Assert: full 42-day window used (4200/42 = 100), not the misleading 5-day apparent age (840).
+                var model = ResultAssert.IsView<DisplayPackageViewModel>(result);
+                Assert.Equal(100L, model.DownloadsPerDay);
+            }
+
+            [Fact]
+            public async Task WhenRecentDownloadsPerDayDisabledDoesNotReadStatistics()
+            {
+                // Arrange
+                var packageService = new Mock<IPackageService>();
+                var statisticsService = new Mock<IStatisticsService>();
+                var featureFlagService = new Mock<IFeatureFlagService>();
+                featureFlagService.SetReturnsDefault<bool>(true);
+                featureFlagService.Setup(ff => ff.IsReducedVersionListsEnabled()).Returns(false);
+                featureFlagService.Setup(ff => ff.IsRecentDownloadsPerDayEnabled()).Returns(false);
+
+                var controller = CreateController(
+                    GetConfigurationService(),
+                    packageService: packageService,
+                    statisticsService: statisticsService,
+                    featureFlagService: featureFlagService);
+                controller.SetCurrentUser(TestUtility.FakeUser);
+
+                var package = new Package()
+                {
+                    PackageRegistration = new PackageRegistration() { Id = "Foo", Owners = new List<User>() },
+                    Version = "1.0.0",
+                    NormalizedVersion = "1.0.0",
+                    PackageStatusKey = PackageStatus.Available,
+                    Created = DateTime.UtcNow.AddYears(-5),
+                };
+
+                var packages = new[] { package };
+                packageService
+                    .Setup(p => p.FindPackagesById("Foo", true, true, true))
+                    .Returns(packages);
+                packageService
+                    .Setup(p => p.FilterLatestPackage(packages, SemVerLevelKey.SemVer2, true))
+                    .Returns(package);
+
+                // Act
+                var result = await controller.DisplayPackage("Foo", null);
+
+                // Assert
+                ResultAssert.IsView<DisplayPackageViewModel>(result);
+                statisticsService.Verify(s => s.GetPackageDownloadsByVersion(It.IsAny<string>()), Times.Never);
             }
 
             [Fact]


### PR DESCRIPTION
The package details page computed "Per day average" as lifetime downloads divided by the age of the oldest *available* version. For packages that release frequently or unlist/delete old versions, that denominator is far smaller than the package's real age, massively over-stating the average (e.g. an ~8-year-old package showing a 58-day denominator).

When recent statistics are available, compute the metric from the trailing 42-day per-package download report (the same data behind the "Full stats" page) instead. Divide by min(42, package age) so packages younger than the window are not under-stated, but only trust the age when the full version history was loaded (with reduced version lists the loaded subset can span far fewer days than the package's real age). Gated behind a feature flag (off by default); falls back to the existing lifetime figure when recent statistics are unavailable, so the page never breaks.


Addresses https://github.com/NuGet/NuGetGallery/issues/10931