### PR TITLE
OIDC: Enrich telemetry to include API key types

### DIFF
--- a/src/NuGetGallery.Core/Authentication/NuGetClaims.cs
+++ b/src/NuGetGallery.Core/Authentication/NuGetClaims.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 namespace NuGetGallery.Authentication
@@ -56,6 +56,12 @@ namespace NuGetGallery.Authentication
         /// The claim url for the claim that stores the type of credential used for authentication for the current session.
         /// </summary>
         public const string ExternalLoginCredentialType = ClaimsDomain + "externallogincredentialtype";
+
+        /// <summary>
+        /// The claim url for the claim that stores the specific <see cref="Credential.Type"/>
+        /// (e.g. apikey.v2, apikey.v4) used to authenticate the request.
+        /// </summary>
+        public const string CredentialType = ClaimsDomain + "credentialtype";
 
         /// <summary>
         /// The class for all possible values for <see cref="ExternalLoginCredentialType"/> claim.

--- a/src/NuGetGallery.Services/Authentication/Providers/ApiKey/ApiKeyAuthenticationHandler.cs
+++ b/src/NuGetGallery.Services/Authentication/Providers/ApiKey/ApiKeyAuthenticationHandler.cs
@@ -119,7 +119,8 @@ namespace NuGetGallery.Authentication.Providers.ApiKey
                                 AuthenticationTypes.ApiKey,
                                 // In cases where the apikey in the DB differs from the user provided
                                 // value (like apikey.v4) this will hold the hashed value
-                                new Claim(NuGetClaims.ApiKey, credential.Value), 
+                                new Claim(NuGetClaims.ApiKey, credential.Value),
+                                new Claim(NuGetClaims.CredentialType, credential.Type ?? string.Empty),
                                 new Claim(NuGetClaims.Scope, scopes),
                                 new Claim(NuGetClaims.CredentialKey, credential.Key.ToString())),
                             new AuthenticationProperties());

--- a/src/NuGetGallery.Services/Extensions/PrincipalExtensions.cs
+++ b/src/NuGetGallery.Services/Extensions/PrincipalExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -247,6 +247,22 @@ namespace NuGetGallery
             }
 
             return false;
+        }
+
+        /// <summary>
+        /// Get the specific credential type (e.g. apikey.v2, apikey.v4) used to authenticate.
+        /// </summary>
+        /// <param name="self">Current user principal identity.</param>
+        /// <returns>The credential type, or null if not present.</returns>
+        public static string GetCredentialType(this IIdentity self)
+        {
+            if (self == null)
+            {
+                throw new ArgumentNullException(nameof(self));
+            }
+
+            var identity = self as ClaimsIdentity;
+            return identity?.GetClaimOrDefault(NuGetClaims.CredentialType);
         }
 
         private static string GetScopeClaim(IIdentity self)

--- a/src/NuGetGallery.Services/Telemetry/TelemetryService.cs
+++ b/src/NuGetGallery.Services/Telemetry/TelemetryService.cs
@@ -452,8 +452,7 @@ namespace NuGetGallery
             TrackMetricForAccountActivity(enabledMultiFactorAuth ? Events.UserMultiFactorAuthenticationEnabled : Events.UserMultiFactorAuthenticationDisabled,
                 user,
                 credential: null,
-                addProperties: addProperties =>
-                {
+                addProperties: addProperties => {
                     addProperties.Add("Referrer", referrer);
                 });
         }
@@ -465,8 +464,7 @@ namespace NuGetGallery
 
         public void TrackUserLogin(User user, Credential credential, bool wasMultiFactorAuthenticated)
         {
-            TrackMetricForAccountActivity(Events.CredentialUsed, user, credential, addProperties =>
-            {
+            TrackMetricForAccountActivity(Events.CredentialUsed, user, credential, addProperties => {
                 addProperties.Add(WasMultiFactorAuthenticated, wasMultiFactorAuthenticated.ToString());
             });
         }
@@ -1243,7 +1241,7 @@ namespace NuGetGallery
 
         private IDisposable TrackSqlConnectionCreationDuration(string kind)
         {
-            return new DurationTracker(duration =>
+            return new DurationTracker(duration => 
                 _telemetryClient.TrackAggregatedMetric(Events.CreateSqlConnectionDurationMs, duration.TotalMilliseconds, Kind, kind));
         }
 

--- a/src/NuGetGallery.Services/Telemetry/TelemetryService.cs
+++ b/src/NuGetGallery.Services/Telemetry/TelemetryService.cs
@@ -128,6 +128,7 @@ namespace NuGetGallery
 
         // Package event properties
         public const string AuthenticationMethod = "AuthenticationMethod";
+        public const string CredentialType = "CredentialType";
         public const string ClientVersion = "ClientVersion";
         public const string ProtocolVersion = "ProtocolVersion";
         public const string ClientInformation = "ClientInformation";
@@ -451,7 +452,8 @@ namespace NuGetGallery
             TrackMetricForAccountActivity(enabledMultiFactorAuth ? Events.UserMultiFactorAuthenticationEnabled : Events.UserMultiFactorAuthenticationDisabled,
                 user,
                 credential: null,
-                addProperties: addProperties => {
+                addProperties: addProperties =>
+                {
                     addProperties.Add("Referrer", referrer);
                 });
         }
@@ -463,7 +465,8 @@ namespace NuGetGallery
 
         public void TrackUserLogin(User user, Credential credential, bool wasMultiFactorAuthenticated)
         {
-            TrackMetricForAccountActivity(Events.CredentialUsed, user, credential, addProperties => {
+            TrackMetricForAccountActivity(Events.CredentialUsed, user, credential, addProperties =>
+            {
                 addProperties.Add(WasMultiFactorAuthenticated, wasMultiFactorAuthenticated.ToString());
             });
         }
@@ -803,6 +806,7 @@ namespace NuGetGallery
                 properties.Add(PackageVersion, packageVersion);
                 properties.Add(AccountCreationDate, GetAccountCreationDate(user));
                 properties.Add(AuthenticationMethod, identity.GetAuthenticationType());
+                properties.Add(CredentialType, identity.GetCredentialType());
                 properties.Add(KeyCreationDate, GetApiKeyCreationDate(user, identity));
                 properties.Add(IsScoped, identity.IsScopedAuthentication().ToString());
                 addProperties?.Invoke(properties);
@@ -1239,7 +1243,7 @@ namespace NuGetGallery
 
         private IDisposable TrackSqlConnectionCreationDuration(string kind)
         {
-            return new DurationTracker(duration => 
+            return new DurationTracker(duration =>
                 _telemetryClient.TrackAggregatedMetric(Events.CreateSqlConnectionDurationMs, duration.TotalMilliseconds, Kind, kind));
         }
 

--- a/tests/NuGetGallery.Facts/Services/TelemetryServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/TelemetryServiceFacts.cs
@@ -1,13 +1,16 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Security.Claims;
+using System.Security.Principal;
 using Microsoft.Extensions.Logging;
 using Moq;
 using NuGet.Services.Entities;
 using NuGet.Versioning;
+using NuGetGallery.Authentication;
 using NuGetGallery.Diagnostics;
 using NuGetGallery.Framework;
 using Xunit;
@@ -1004,6 +1007,113 @@ namespace NuGetGallery
                         It.IsAny<int>()),
                     Times.Once);
                 Assert.Contains("InvalidOperationException", service.LastTraceMessage);
+            }
+        }
+
+        public class TheCredentialTypeDimension : BaseFacts
+        {
+            private static readonly Fakes fakes = new Fakes();
+
+            private static IIdentity CreateApiKeyIdentity(string credentialType)
+            {
+                var claims = new List<Claim>
+                {
+                    new Claim(ClaimsIdentity.DefaultNameClaimType, fakes.User.Username),
+                    new Claim(ClaimTypes.AuthenticationMethod, Authentication.AuthenticationTypes.ApiKey),
+                };
+
+                if (credentialType != null)
+                {
+                    claims.Add(new Claim(NuGetClaims.CredentialType, credentialType));
+                }
+
+                return new ClaimsIdentity(claims, Authentication.AuthenticationTypes.ApiKey);
+            }
+
+            private static IDictionary<string, string> Track(TrackAction track)
+            {
+                var service = CreateService();
+                var allProperties = new List<IDictionary<string, string>>();
+                service.TelemetryClient
+                    .Setup(x => x.TrackMetric(It.IsAny<string>(), It.IsAny<double>(), It.IsAny<IDictionary<string, string>>()))
+                    .Callback<string, double, IDictionary<string, string>>((_, __, p) => allProperties.Add(p));
+
+                track(service);
+
+                return Assert.Single(allProperties);
+            }
+
+            [Theory]
+            [InlineData("apikey.v1")]
+            [InlineData("apikey.v2")]
+            [InlineData("apikey.v4")]
+            [InlineData("apikey.v5")]
+            public void TrackPackagePushEventIncludesSpecificCredentialType(string credentialType)
+            {
+                // Arrange
+                var package = fakes.Package.Packages.First();
+                var identity = CreateApiKeyIdentity(credentialType);
+
+                // Act
+                var properties = Track(s => s.TrackPackagePushEvent(package, fakes.User, identity));
+
+                // Assert
+                Assert.Contains(
+                    new KeyValuePair<string, string>(TelemetryService.CredentialType, credentialType),
+                    properties);
+
+                // The coarse authentication bucket is still emitted alongside it.
+                Assert.Contains(
+                    new KeyValuePair<string, string>(TelemetryService.AuthenticationMethod, Authentication.AuthenticationTypes.ApiKey),
+                    properties);
+            }
+
+            [Fact]
+            public void TrackCreatePackageVerificationKeyEventIncludesCredentialType()
+            {
+                // Arrange
+                var package = fakes.Package.Packages.First();
+                var identity = CreateApiKeyIdentity(CredentialTypes.ApiKey.VerifyV1);
+
+                // Act
+                var properties = Track(s => s.TrackCreatePackageVerificationKeyEvent(
+                    package.PackageRegistration.Id, package.NormalizedVersion, fakes.User, identity));
+
+                // Assert
+                Assert.Contains(
+                    new KeyValuePair<string, string>(TelemetryService.CredentialType, CredentialTypes.ApiKey.VerifyV1),
+                    properties);
+            }
+
+            [Fact]
+            public void TrackPackagePushNamespaceConflictEventIncludesCredentialType()
+            {
+                // Arrange
+                var package = fakes.Package.Packages.First();
+                var identity = CreateApiKeyIdentity(CredentialTypes.ApiKey.V2);
+
+                // Act
+                var properties = Track(s => s.TrackPackagePushNamespaceConflictEvent(
+                    package.PackageRegistration.Id, package.NormalizedVersion, fakes.User, identity));
+
+                // Assert
+                Assert.Contains(
+                    new KeyValuePair<string, string>(TelemetryService.CredentialType, CredentialTypes.ApiKey.V2),
+                    properties);
+            }
+
+            [Fact]
+            public void TrackPackagePushEventWithoutCredentialTypeClaimDoesNotThrow()
+            {
+                // Arrange - GenericIdentity has no claims, so no CredentialType is present.
+                var package = fakes.Package.Packages.First();
+                var identity = Fakes.ToIdentity(fakes.User);
+
+                // Act
+                var properties = Track(s => s.TrackPackagePushEvent(package, fakes.User, identity));
+
+                // Assert - the dimension key is present; value reflects "no specific type".
+                Assert.True(properties.ContainsKey(TelemetryService.CredentialType));
             }
         }
 


### PR DESCRIPTION
We have a data gap, where we can't see what type of API key customers are using to publish a package. This fixes it. 

Tested on DEV:
<img width="367" height="70" alt="image" src="https://github.com/user-attachments/assets/a2d09729-6a2b-42f9-9801-39acfbc6c6b3" />


Addresses https://github.com/orgs/NuGet/projects/21/views/1?filterQuery=assignee%3A%40me+milestone%3A%22Sprint+2026-08%22&pane=issue&itemId=210443365&issue=NuGet%7CEngineering%7C6476