### PR TITLE
Reject non-canonical author signed attributes before repository signing

### DIFF
--- a/src/NuGet.Services.Contracts/Validation/ValidationIssueCode.cs
+++ b/src/NuGet.Services.Contracts/Validation/ValidationIssueCode.cs
@@ -62,6 +62,11 @@ namespace NuGet.Services.Validation
         /// </summary>
         PackageIsSignedWithUnauthorizedCertificate = 9,
 
+        /// <summary>
+        /// The author signature's signed attributes are not in canonical DER order.
+        /// </summary>
+        AuthorSignedAttributesNotCanonical = 10,
+
         #region SymbolErrorCodes - reserved 200 - 299 segment
         /// <summary>
         /// Symbol checksum does not match with the binary assembly.

--- a/src/NuGet.Services.Validation.Issues/ValidationIssue.cs
+++ b/src/NuGet.Services.Validation.Issues/ValidationIssue.cs
@@ -17,6 +17,7 @@ namespace NuGet.Services.Validation.Issues
         public static ValidationIssue OnlySignatureFormatVersion1Supported { get; } = new NoDataValidationIssue(ValidationIssueCode.OnlySignatureFormatVersion1Supported);
         public static ValidationIssue AuthorCounterSignaturesNotSupported { get; } = new NoDataValidationIssue(ValidationIssueCode.AuthorCounterSignaturesNotSupported);
         public static ValidationIssue PackageIsNotSigned { get; } = new NoDataValidationIssue(ValidationIssueCode.PackageIsNotSigned);
+        public static ValidationIssue AuthorSignedAttributesNotCanonical { get; } = new NoDataValidationIssue(ValidationIssueCode.AuthorSignedAttributesNotCanonical);
         public static ValidationIssue SymbolErrorCode_ChecksumDoesNotMatch { get; } = new NoDataValidationIssue(ValidationIssueCode.SymbolErrorCode_ChecksumDoesNotMatch);
         public static ValidationIssue SymbolErrorCode_MatchingAssemblyNotFound { get; } = new NoDataValidationIssue(ValidationIssueCode.SymbolErrorCode_MatchingAssemblyNotFound);
         public static ValidationIssue SymbolErrorCode_PdbIsNotPortable { get; } = new NoDataValidationIssue(ValidationIssueCode.SymbolErrorCode_PdbIsNotPortable);
@@ -48,6 +49,7 @@ namespace NuGet.Services.Validation.Issues
             ValidationIssueCode.OnlySignatureFormatVersion1Supported,
             ValidationIssueCode.AuthorCounterSignaturesNotSupported,
             ValidationIssueCode.PackageIsNotSigned,
+            ValidationIssueCode.AuthorSignedAttributesNotCanonical,
             ValidationIssueCode.SymbolErrorCode_ChecksumDoesNotMatch,
             ValidationIssueCode.SymbolErrorCode_MatchingAssemblyNotFound,
             ValidationIssueCode.SymbolErrorCode_PdbIsNotPortable,

--- a/src/NuGetGallery.Core/Extensions/ValidationIssueExtensions.cs
+++ b/src/NuGetGallery.Core/Extensions/ValidationIssueExtensions.cs
@@ -53,6 +53,8 @@ namespace NuGetGallery
                 case ValidationIssueCode.PackageIsSignedWithUnauthorizedCertificate:
                     var certIssue = (UnauthorizedCertificateFailure)validationIssue;
                     return $"The package was signed, but the signing certificate {(certIssue != null ? $"(SHA-256 thumbprint {certIssue.Sha256Thumbprint})" : "")} is not associated with your account. You must register this certificate to publish signed packages. [Read more...](https://aka.ms/nuget-signed-ref)";
+                case ValidationIssueCode.AuthorSignedAttributesNotCanonical:
+                    return "The author signature's signed attributes are not in canonical DER order. The package must be signed again with a compliant signing tool.";
                 case ValidationIssueCode.SymbolErrorCode_ChecksumDoesNotMatch:
                     return "The checksum does not match for the dll(s) and corresponding pdb(s).";
                 case ValidationIssueCode.SymbolErrorCode_MatchingAssemblyNotFound:

--- a/src/NuGetGallery/Views/Packages/_ValidationIssue.cshtml
+++ b/src/NuGetGallery/Views/Packages/_ValidationIssue.cshtml
@@ -58,6 +58,11 @@
             </text>
             break;
         }
+    case ValidationIssueCode.AuthorSignedAttributesNotCanonical:
+        <text>
+            The author signature's signed attributes are not in canonical DER order. The package must be signed again with a compliant signing tool.
+        </text>
+        break;
     case ValidationIssueCode.SymbolErrorCode_ChecksumDoesNotMatch:
         <text>
             The checksum does not match for the dll(s) and corresponding pdb(s).

--- a/src/Validation.Common.Job/FeatureFlags/FeatureFlagService.cs
+++ b/src/Validation.Common.Job/FeatureFlags/FeatureFlagService.cs
@@ -31,5 +31,12 @@ namespace NuGet.Jobs.Validation
         {
             return _featureFlagClient.IsEnabled(ValidationPrefix + "ExtraValidation", defaultValue: false);
         }
+
+        public bool IsDerOrderingEnforcementEnabled()
+        {
+            return _featureFlagClient.IsEnabled(
+                ValidationPrefix + "DerOrderingEnforcement",
+                defaultValue: false);
+        }
     }
 }

--- a/src/Validation.Common.Job/FeatureFlags/IFeatureFlagService.cs
+++ b/src/Validation.Common.Job/FeatureFlags/IFeatureFlagService.cs
@@ -24,5 +24,10 @@ namespace NuGet.Jobs.Validation
         /// https://github.com/NuGet/Engineering/issues/5250
         /// </summary>
         bool IsExtraValidationLoggingEnabled();
+
+        /// <summary>
+        /// Determines whether non-canonical DER ordering in author signed attributes should be rejected.
+        /// </summary>
+        bool IsDerOrderingEnforcementEnabled();
     }
 }

--- a/src/Validation.PackageSigning.ProcessSignature/AuthorSignedAttributesValidator.cs
+++ b/src/Validation.PackageSigning.ProcessSignature/AuthorSignedAttributesValidator.cs
@@ -1,0 +1,104 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Formats.Asn1;
+
+namespace NuGet.Jobs.Validation.PackageSigning.ProcessSignature
+{
+    // Traverses the CMS structures defined by RFC 5652, sections 3 and 5, and validates the
+    // signedAttrs ordering requirement described in sections 5.3 and 5.4.
+    internal static class AuthorSignedAttributesValidator
+    {
+        private const string SignedDataOid = "1.2.840.113549.1.7.2";
+        private static readonly Asn1Tag ContextSpecific0 = new(tagClass: TagClass.ContextSpecific, tagValue: 0);
+        private static readonly Asn1Tag ContextSpecific1 = new(tagClass: TagClass.ContextSpecific, tagValue: 1);
+
+        public static bool IsCanonical(ReadOnlyMemory<byte> signatureBytes)
+        {
+            // ContentInfo
+            AsnReader contentInfoReader = new(signatureBytes, AsnEncodingRules.BER);
+            AsnReader contentInfo = contentInfoReader.ReadSequence();
+
+            // ContentInfo.contentType
+            if (contentInfo.ReadObjectIdentifier() != SignedDataOid)
+            {
+                throw new UnexpectedCmsContentTypeException();
+            }
+
+            // ContentInfo.content and SignedData
+            AsnReader signedDataContent = contentInfo.ReadSequence(ContextSpecific0);
+            AsnReader signedData = signedDataContent.ReadSequence();
+
+            // SignedData.version, digestAlgorithms, and encapContentInfo
+            signedData.ReadInteger();
+            signedData.ReadEncodedValue();
+            signedData.ReadEncodedValue();
+
+            // SignedData.certificates and crls
+            while (signedData.HasData
+                && (signedData.PeekTag().HasSameClassAndValue(ContextSpecific0)
+                    || signedData.PeekTag().HasSameClassAndValue(ContextSpecific1)))
+            {
+                signedData.ReadEncodedValue();
+            }
+
+            // SignedData.signerInfos and the primary SignerInfo
+            AsnReader signerInfos = signedData.ReadSetOf(skipSortOrderValidation: true);
+            AsnReader signerInfo = signerInfos.ReadSequence();
+
+            // SignerInfo.version, sid, and digestAlgorithm
+            signerInfo.ReadInteger();
+            signerInfo.ReadEncodedValue();
+            signerInfo.ReadEncodedValue();
+
+            // SignerInfo.signedAttrs is optional.
+            if (!signerInfo.HasData
+                || !signerInfo.PeekTag().HasSameClassAndValue(ContextSpecific0))
+            {
+                return true;
+            }
+
+            AsnReader signedAttributes = signerInfo.ReadSetOf(
+                skipSortOrderValidation: true,
+                expectedTag: ContextSpecific0);
+            ReadOnlyMemory<byte> previousAttribute = default;
+
+            while (signedAttributes.HasData)
+            {
+                // Preserve the complete encoded Attribute TLV for the DER SET OF ordering comparison.
+                ReadOnlyMemory<byte> attribute = signedAttributes.ReadEncodedValue();
+
+                if (!previousAttribute.IsEmpty
+                    && Compare(previousAttribute.Span, attribute.Span) > 0)
+                {
+                    return false;
+                }
+
+                previousAttribute = attribute;
+            }
+
+            return true;
+        }
+
+        private static int Compare(ReadOnlySpan<byte> left, ReadOnlySpan<byte> right)
+        {
+            int commonLength = Math.Min(left.Length, right.Length);
+
+            for (int index = 0; index < commonLength; index++)
+            {
+                int comparison = left[index].CompareTo(right[index]);
+                if (comparison != 0)
+                {
+                    return comparison;
+                }
+            }
+
+            return left.Length.CompareTo(right.Length);
+        }
+
+        internal sealed class UnexpectedCmsContentTypeException : Exception
+        {
+        }
+    }
+}

--- a/src/Validation.PackageSigning.ProcessSignature/Properties/AssemblyInfo.cs
+++ b/src/Validation.PackageSigning.ProcessSignature/Properties/AssemblyInfo.cs
@@ -1,0 +1,10 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Runtime.CompilerServices;
+
+#if SIGNED_BUILD
+[assembly: InternalsVisibleTo("Validation.PackageSigning.ProcessSignature.Tests,PublicKey=0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9")]
+#else
+[assembly: InternalsVisibleTo("Validation.PackageSigning.ProcessSignature.Tests")]
+#endif

--- a/src/Validation.PackageSigning.ProcessSignature/README.md
+++ b/src/Validation.PackageSigning.ProcessSignature/README.md
@@ -15,8 +15,9 @@ stripped. Any author signature is validated. The enqueuer in the orchestrator is
 This mode is executed before repository signing to prepare the package for signing and to quickly reject any bad author
 signatures.
 
-**Second**, it is treated as an `INuGetValidator`, meaning the package is not allowed to be modified. All of the same validations
-as the first mode are run. Additionally, a repository signature is now required. The enqueuer in the orchestrator is
+**Second**, it is treated as an `INuGetValidator`, meaning the package is not allowed to be modified. The applicable signature
+validations are run again, except for policies that apply only before repository signing. Additionally, a repository signature
+is now required. The enqueuer in the orchestrator is
 [`PackageSignatureValidator`](https://github.com/NuGet/NuGet.Jobs/blob/master/src/NuGet.Services.Validation.Orchestrator/PackageSigning/ProcessSignature/PackageSignatureValidator.cs).
 This mode is executed after the package has been repository signed so that the whole signature, as it will be seen by
 package consumers, can be validated.
@@ -63,6 +64,7 @@ words, this job does not have to be a singleton.
 ### Algorithm for signed packages
 
 1. ❌ If the signature is unreadable, reject the package.
+1. ❌ Before repository signing (`RequireRepositorySignature` is `false`), when `Validation.DerOrderingEnforcement` is enabled, reject a primary author signature whose signed attributes in the original raw `.signature.p7s` are not canonically DER ordered, unless the package is already `Available`.
 1. ❌ If the package has author counter signatures, reject the package.
 1. Strip unacceptable repository signatures (e.g. signatures from another repository).
     1. A repository signature is unacceptable is:

--- a/src/Validation.PackageSigning.ProcessSignature/SignatureValidator.cs
+++ b/src/Validation.PackageSigning.ProcessSignature/SignatureValidator.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Formats.Asn1;
 using System.IO;
 using System.Linq;
 using System.Security.Cryptography.Pkcs;
@@ -38,6 +39,7 @@ namespace NuGet.Jobs.Validation.PackageSigning.ProcessSignature
         private readonly ICorePackageService _corePackageService;
         private readonly IOptionsSnapshot<ProcessSignatureConfiguration> _configuration;
         private readonly SasDefinitionConfiguration _sasDefinitionConfiguration;
+        private readonly IFeatureFlagService _featureFlagService;
         private readonly ITelemetryService _telemetryService;
         private readonly ILogger<SignatureValidator> _logger;
 
@@ -49,6 +51,7 @@ namespace NuGet.Jobs.Validation.PackageSigning.ProcessSignature
             ICorePackageService corePackageService,
             IOptionsSnapshot<ProcessSignatureConfiguration> configuration,
             IOptionsSnapshot<SasDefinitionConfiguration> sasDefinitionConfigurationAccessor,
+            IFeatureFlagService featureFlagService,
             ITelemetryService telemetryService,
             ILogger<SignatureValidator> logger)
         {
@@ -59,6 +62,7 @@ namespace NuGet.Jobs.Validation.PackageSigning.ProcessSignature
             _corePackageService = corePackageService ?? throw new ArgumentNullException(nameof(corePackageService));
             _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
             _sasDefinitionConfiguration = (sasDefinitionConfigurationAccessor == null || sasDefinitionConfigurationAccessor.Value == null) ? new SasDefinitionConfiguration() : sasDefinitionConfigurationAccessor.Value;
+            _featureFlagService = featureFlagService ?? throw new ArgumentNullException(nameof(featureFlagService));
             _telemetryService = telemetryService ?? throw new ArgumentNullException(nameof(telemetryService));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
@@ -213,6 +217,40 @@ namespace NuGet.Jobs.Validation.PackageSigning.ProcessSignature
             // We now know we can safely read the signature.
             context.Signature = await context.PackageReader.GetPrimarySignatureAsync(context.CancellationToken);
 
+            if (_featureFlagService.IsDerOrderingEnforcementEnabled()
+                && !context.Message.RequireRepositorySignature
+                && context.Signature.Type == SignatureType.Author)
+            {
+                Package package = _corePackageService.FindPackageByIdAndVersionStrict(
+                    context.Message.PackageId,
+                    context.Message.PackageVersion);
+
+                if (package == null)
+                {
+                    throw new InvalidOperationException(
+                        $"Package '{context.Message.PackageId} {context.Message.PackageVersion}' could not be found " +
+                        $"for validation '{context.Message.ValidationId}'.");
+                }
+
+                if (package.PackageStatusKey == PackageStatus.Available)
+                {
+                    _logger.LogInformation(
+                        "Package {PackageId} {PackageVersion} for validation {ValidationId} is already available, " +
+                        "skipping author signed attribute ordering validation.",
+                        context.Message.PackageId,
+                        context.Message.PackageVersion,
+                        context.Message.ValidationId);
+                }
+                else
+                {
+                    SignatureValidatorResult signedAttributesResult = await ValidateAuthorSignedAttributesAsync(context);
+                    if (signedAttributesResult != null)
+                    {
+                        return signedAttributesResult;
+                    }
+                }
+            }
+
             // Only reject counter signatures that have the author commitment type. Repository counter signatures
             // are removed and replaced if they are invalid and valid ones are left as-is. Counter signatures
             // without author or repository signature commitment type are not produced by the client but
@@ -239,6 +277,71 @@ namespace NuGet.Jobs.Validation.PackageSigning.ProcessSignature
             }
 
             return null;
+        }
+
+        private async Task<SignatureValidatorResult> ValidateAuthorSignedAttributesAsync(Context context)
+        {
+            byte[] signatureBytes;
+
+            using (Stream signatureStream = await context.PackageReader.GetStreamAsync(
+                SigningSpecifications.V1.SignaturePath,
+                context.CancellationToken))
+            using (MemoryStream memoryStream = new())
+            {
+                await signatureStream.CopyToAsync(
+                    memoryStream,
+                    bufferSize: 81920,
+                    cancellationToken: context.CancellationToken);
+                signatureBytes = memoryStream.ToArray();
+            }
+
+            try
+            {
+                if (AuthorSignedAttributesValidator.IsCanonical(signatureBytes))
+                {
+                    return null;
+                }
+            }
+            catch (AsnContentException ex)
+            {
+                return await RejectUnparseableCmsAsync(context, ex, "RawCmsAsn1ParseFailure");
+            }
+            catch (AuthorSignedAttributesValidator.UnexpectedCmsContentTypeException ex)
+            {
+                return await RejectUnparseableCmsAsync(context, ex, "UnexpectedCmsContentType");
+            }
+
+            _logger.LogInformation(
+                "Signed package {PackageId} {PackageVersion} is blocked for validation {ValidationId} because its " +
+                "author signed attributes are not in canonical DER order. Reason = {Reason}",
+                context.Message.PackageId,
+                context.Message.PackageVersion,
+                context.Message.ValidationId,
+                "NonCanonicalSignedAttributes");
+
+            return await RejectAsync(context, ValidationIssue.AuthorSignedAttributesNotCanonical);
+        }
+
+        private async Task<SignatureValidatorResult> RejectUnparseableCmsAsync(
+            Context context,
+            Exception exception,
+            string reason)
+        {
+            _logger.LogInformation(
+                eventId: 0,
+                exception: exception,
+                message: "Signed package {PackageId} {PackageVersion} is blocked for validation {ValidationId} because its " +
+                "signature CMS could not be traversed for signed attribute ordering validation. Reason = {Reason}",
+                context.Message.PackageId,
+                context.Message.PackageVersion,
+                context.Message.ValidationId,
+                reason);
+
+            return await RejectAsync(
+                context,
+                new ClientSigningVerificationFailure(
+                    clientCode: "NU3003",
+                    clientMessage: "The package signature is invalid or cannot be verified on this platform."));
         }
 
         private async Task<SignatureValidatorResult> StripUnacceptableRepositorySignaturesAsync(Context context)
@@ -772,7 +875,7 @@ namespace NuGet.Jobs.Validation.PackageSigning.ProcessSignature
             public Context(
                 int packageKey,
                 Stream packageStream,
-                ISignedPackage packageReader,
+                SignedPackageArchive packageReader,
                 SignatureValidationMessage message,
                 CancellationToken cancellationToken)
             {
@@ -786,7 +889,7 @@ namespace NuGet.Jobs.Validation.PackageSigning.ProcessSignature
             public int PackageKey { get; }
             public bool Changed { get; set; }
             public Stream PackageStream { get; set; }
-            public ISignedPackage PackageReader { get; set; }
+            public SignedPackageArchive PackageReader { get; set; }
             public PrimarySignature Signature { get; set; }
             public SignatureValidationMessage Message { get; }
             public CancellationToken CancellationToken { get; }

--- a/src/Validation.PackageSigning.ProcessSignature/Validation.PackageSigning.ProcessSignature.csproj
+++ b/src/Validation.PackageSigning.ProcessSignature/Validation.PackageSigning.ProcessSignature.csproj
@@ -13,6 +13,9 @@
     <None Include="Settings\*" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="System.Formats.Asn1" />
+  </ItemGroup>
+  <ItemGroup>
     <ProjectReference Include="..\NuGet.Services.Validation.Orchestrator\NuGet.Services.Validation.Orchestrator.csproj" />
   </ItemGroup>
 </Project>

--- a/tests/NuGet.Services.Contracts.Tests/Validation/ValidationErrorCodeFacts.cs
+++ b/tests/NuGet.Services.Contracts.Tests/Validation/ValidationErrorCodeFacts.cs
@@ -22,6 +22,7 @@ namespace NuGet.Services.Validation
             { 7, ValidationIssueCode.AuthorCounterSignaturesNotSupported },
             { 8, ValidationIssueCode.PackageIsNotSigned },
             { 9, ValidationIssueCode.PackageIsSignedWithUnauthorizedCertificate },
+            { 10, ValidationIssueCode.AuthorSignedAttributesNotCanonical },
             { 250, ValidationIssueCode.SymbolErrorCode_ChecksumDoesNotMatch },
             { 251, ValidationIssueCode.SymbolErrorCode_MatchingAssemblyNotFound},
             { 252, ValidationIssueCode.SymbolErrorCode_PdbIsNotPortable},

--- a/tests/NuGet.Services.Validation.Issues.Tests/ValidationIssuesFacts.cs
+++ b/tests/NuGet.Services.Validation.Issues.Tests/ValidationIssuesFacts.cs
@@ -240,6 +240,7 @@ namespace NuGet.Services.Validation.Issues.Tests
             { ValidationIssueCode.OnlySignatureFormatVersion1Supported, () => ValidationIssue.OnlySignatureFormatVersion1Supported },
             { ValidationIssueCode.AuthorCounterSignaturesNotSupported, () => ValidationIssue.AuthorCounterSignaturesNotSupported },
             { ValidationIssueCode.PackageIsNotSigned, () => ValidationIssue.PackageIsNotSigned },
+            { ValidationIssueCode.AuthorSignedAttributesNotCanonical, () => ValidationIssue.AuthorSignedAttributesNotCanonical },
             { ValidationIssueCode.SymbolErrorCode_ChecksumDoesNotMatch, () => ValidationIssue.SymbolErrorCode_ChecksumDoesNotMatch },
             { ValidationIssueCode.SymbolErrorCode_MatchingAssemblyNotFound, () => ValidationIssue.SymbolErrorCode_MatchingAssemblyNotFound },
             { ValidationIssueCode.SymbolErrorCode_PdbIsNotPortable, () => ValidationIssue.SymbolErrorCode_PdbIsNotPortable },

--- a/tests/NuGet.Services.Validation.Orchestrator.Tests/PackageSigning/ProcessSignature/PackageSignatureProcessorFacts.cs
+++ b/tests/NuGet.Services.Validation.Orchestrator.Tests/PackageSigning/ProcessSignature/PackageSignatureProcessorFacts.cs
@@ -85,6 +85,11 @@ namespace NuGet.Services.Validation.PackageSigning
                                 IssueCode = ValidationIssueCode.ClientSigningVerificationFailure,
                                 Data = "unknown contract",
                             },
+                            new ValidatorIssue
+                            {
+                                IssueCode = ValidationIssueCode.AuthorSignedAttributesNotCanonical,
+                                Data = "{}",
+                            },
                         },
                     });
 
@@ -93,13 +98,16 @@ namespace NuGet.Services.Validation.PackageSigning
 
                 // Assert
                 Assert.Equal(ValidationStatus.Failed, actual.Status);
-                Assert.Equal(2, actual.Issues.Count);
+                Assert.Equal(3, actual.Issues.Count);
 
                 Assert.Equal((ValidationIssueCode)987, actual.Issues[0].IssueCode);
                 Assert.Equal("{}", actual.Issues[0].Serialize());
 
                 Assert.Equal(ValidationIssueCode.ClientSigningVerificationFailure, actual.Issues[1].IssueCode);
                 Assert.Equal("unknown contract", actual.Issues[1].Serialize());
+
+                Assert.Equal(ValidationIssueCode.AuthorSignedAttributesNotCanonical, actual.Issues[2].IssueCode);
+                Assert.Equal("{}", actual.Issues[2].Serialize());
             }
 
             public static IEnumerable<object[]> PossibleValidationStatuses => possibleValidationStatuses.Select(s => new object[] { s });

--- a/tests/NuGet.Services.Validation.Orchestrator.Tests/ValidationSetProcessorFacts.cs
+++ b/tests/NuGet.Services.Validation.Orchestrator.Tests/ValidationSetProcessorFacts.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Moq;
+using NuGet.Jobs.Validation;
 using NuGet.Services.Entities;
 using NuGet.Services.Validation.Issues;
 using NuGet.Services.Validation.Orchestrator.Telemetry;
@@ -182,6 +183,30 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
             validator2.Verify(v => v.StartAsync(It.IsAny<INuGetValidationRequest>()), Times.Never);
             validator2.Verify(v => v.GetResponseAsync(It.IsAny<INuGetValidationRequest>()), Times.Never);
             validator2.Verify(v => v.CleanUpAsync(It.IsAny<INuGetValidationRequest>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task DoesNotStartScanAndSignAfterPackageSignatureProcessorFails()
+        {
+            UseDefaultValidatorProvider();
+            AddValidation(
+                ValidatorName.PackageSignatureProcessor,
+                TimeSpan.FromDays(1),
+                validationStatus: ValidationStatus.Failed);
+            Mock<INuGetValidator> scanAndSign = AddValidation(
+                ValidatorName.ScanAndSign,
+                TimeSpan.FromDays(1),
+                requiredValidations: new[] { ValidatorName.PackageSignatureProcessor });
+
+            ValidationSetProcessor processor = CreateProcessor();
+            await processor.ProcessValidationsAsync(ValidationSet);
+
+            scanAndSign.Verify(
+                validator => validator.GetResponseAsync(It.IsAny<INuGetValidationRequest>()),
+                Times.Never);
+            scanAndSign.Verify(
+                validator => validator.StartAsync(It.IsAny<INuGetValidationRequest>()),
+                Times.Never);
         }
 
         [Fact]

--- a/tests/NuGetGallery.Facts/Views/Packages/ValidationIssueFacts.cs
+++ b/tests/NuGetGallery.Facts/Views/Packages/ValidationIssueFacts.cs
@@ -77,6 +77,7 @@ namespace NuGetGallery.Views.Packages
                 yield return ValidationIssue.OnlySignatureFormatVersion1Supported;
                 yield return ValidationIssue.AuthorCounterSignaturesNotSupported;
                 yield return ValidationIssue.PackageIsNotSigned;
+                yield return ValidationIssue.AuthorSignedAttributesNotCanonical;
                 yield return ValidationIssue.SymbolErrorCode_ChecksumDoesNotMatch;
                 yield return ValidationIssue.SymbolErrorCode_MatchingAssemblyNotFound;
                 yield return ValidationIssue.SymbolErrorCode_PdbIsNotPortable;

--- a/tests/Validation.Common.Job.Tests/FeatureFlagServiceFacts.cs
+++ b/tests/Validation.Common.Job.Tests/FeatureFlagServiceFacts.cs
@@ -1,0 +1,31 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Moq;
+using NuGet.Jobs.Validation;
+using NuGet.Services.FeatureFlags;
+using Xunit;
+
+namespace Validation.Common.Job.Tests
+{
+    public class FeatureFlagServiceFacts
+    {
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void ReturnsDerOrderingEnforcementStatus(bool isEnabled)
+        {
+            Mock<IFeatureFlagClient> client = new();
+            client
+                .Setup(featureFlags => featureFlags.IsEnabled(
+                    "Validation.DerOrderingEnforcement",
+                    defaultValue: false))
+                .Returns(isEnabled);
+            FeatureFlagService service = new(client.Object);
+
+            bool actual = service.IsDerOrderingEnforcementEnabled();
+
+            Assert.Equal(isEnabled, actual);
+        }
+    }
+}

--- a/tests/Validation.PackageSigning.ProcessSignature.Tests/AuthorSignedAttributesValidatorFacts.cs
+++ b/tests/Validation.PackageSigning.ProcessSignature.Tests/AuthorSignedAttributesValidatorFacts.cs
@@ -1,0 +1,61 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Formats.Asn1;
+using System.Security.Cryptography.Pkcs;
+using System.Security.Cryptography.X509Certificates;
+using Microsoft.Internal.NuGet.Testing.SignedPackages;
+using NuGet.Jobs.Validation.PackageSigning.ProcessSignature;
+using Xunit;
+
+namespace Validation.PackageSigning.ProcessSignature.Tests
+{
+    public class AuthorSignedAttributesValidatorFacts
+    {
+        [Fact]
+        public void AllowsMissingSignedAttributes()
+        {
+            using (X509Certificate2 certificate = SigningTestUtility.GenerateCertificate(subjectName: null, modifyGenerator: null))
+            {
+                ContentInfo contentInfo = new(content: new byte[] { 0 });
+                SignedCms signedCms = new(contentInfo);
+                signedCms.ComputeSignature(new CmsSigner(certificate: certificate));
+                byte[] signatureBytes = signedCms.Encode();
+                SignedCms decodedSignedCms = new();
+                decodedSignedCms.Decode(signatureBytes);
+
+                Assert.Empty(decodedSignedCms.SignerInfos[0].SignedAttributes);
+                Assert.True(AuthorSignedAttributesValidator.IsCanonical(signatureBytes));
+            }
+        }
+
+        [Fact]
+        public void ThrowsForTruncatedAsn1()
+        {
+            using (X509Certificate2 certificate = SigningTestUtility.GenerateCertificate(subjectName: null, modifyGenerator: null))
+            {
+                ContentInfo contentInfo = new(content: new byte[] { 0 });
+                SignedCms signedCms = new(contentInfo);
+                signedCms.ComputeSignature(new CmsSigner(certificate: certificate));
+                byte[] signatureBytes = signedCms.Encode();
+                Array.Resize(ref signatureBytes, signatureBytes.Length - 1);
+
+                Assert.Throws<AsnContentException>(
+                    () => AuthorSignedAttributesValidator.IsCanonical(signatureBytes));
+            }
+        }
+
+        [Fact]
+        public void ThrowsDistinctExceptionForUnexpectedContentType()
+        {
+            AsnWriter writer = new(AsnEncodingRules.BER);
+            writer.PushSequence();
+            writer.WriteObjectIdentifier(oidValue: "1.2.3");
+            writer.PopSequence();
+
+            Assert.Throws<AuthorSignedAttributesValidator.UnexpectedCmsContentTypeException>(
+                () => AuthorSignedAttributesValidator.IsCanonical(writer.Encode()));
+        }
+    }
+}

--- a/tests/Validation.PackageSigning.ProcessSignature.Tests/SignatureValidatorFacts.cs
+++ b/tests/Validation.PackageSigning.ProcessSignature.Tests/SignatureValidatorFacts.cs
@@ -4,12 +4,16 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Internal.NuGet.Testing.SignedPackages;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Moq;
 using NuGet.Common;
+using NuGet.Jobs.Validation;
 using NuGet.Jobs.Validation.PackageSigning.Configuration;
 using NuGet.Jobs.Validation.PackageSigning.Messages;
 using NuGet.Jobs.Validation.PackageSigning.ProcessSignature;
@@ -30,6 +34,8 @@ namespace Validation.PackageSigning.ProcessSignature.Tests
     {
         public class ValidateAsync
         {
+            private const string RuntimePackageId = "RuntimeSignaturePackage";
+            private const string RuntimePackageVersion = "1.0.0";
             private MemoryStream _packageStream;
             private readonly int _packageKey;
             private SignatureValidationMessage _message;
@@ -51,10 +57,13 @@ namespace Validation.PackageSigning.ProcessSignature.Tests
             private readonly Mock<IOptionsSnapshot<SasDefinitionConfiguration>> _sasDefinitionConfigurationMock;
             private readonly ProcessSignatureConfiguration _configuration;
             private readonly SasDefinitionConfiguration _sasDefinitionConfiguration;
+            private readonly Mock<IFeatureFlagService> _featureFlagService;
             private readonly Mock<ITelemetryService> _telemetryService;
+            private readonly ITestOutputHelper _output;
 
             public ValidateAsync(ITestOutputHelper output)
             {
+                _output = output;
                 _packageStream = TestResources.GetResourceStream(TestResources.UnsignedPackage);
                 _packageKey = 42;
                 _message = new SignatureValidationMessage(
@@ -112,6 +121,10 @@ namespace Validation.PackageSigning.ProcessSignature.Tests
                 _sasDefinitionConfigurationMock.Setup(x => x.Value).Returns(() => _sasDefinitionConfiguration);
 
 
+                _featureFlagService = new Mock<IFeatureFlagService>();
+                _featureFlagService
+                    .Setup(service => service.IsDerOrderingEnforcementEnabled())
+                    .Returns(true);
                 _telemetryService = new Mock<ITelemetryService>();
 
                 _target = new SignatureValidator(
@@ -122,6 +135,7 @@ namespace Validation.PackageSigning.ProcessSignature.Tests
                     _corePackageService.Object,
                     _optionsSnapshot.Object,
                     _sasDefinitionConfigurationMock.Object,
+                    _featureFlagService.Object,
                     _telemetryService.Object,
                     _logger);
             }
@@ -215,6 +229,311 @@ namespace Validation.PackageSigning.ProcessSignature.Tests
             }
 
             [Fact]
+            public async Task AcceptsDynamicallyCreatedUnsignedPackage()
+            {
+                // Arrange
+                _packageStream = NonCanonicalSignedAttributesTestUtility.CreatePackage(
+                    RuntimePackageId,
+                    RuntimePackageVersion);
+                TestUtility.RequireUnsignedPackage(
+                    _corePackageService,
+                    RuntimePackageId,
+                    RuntimePackageVersion);
+                _message = CreateRuntimePackageMessage();
+
+                // Act
+                SignatureValidatorResult result = await _target.ValidateAsync(
+                    _packageKey,
+                    _packageStream,
+                    _message,
+                    _cancellationToken);
+
+                // Assert
+                Validate(result, ValidationStatus.Succeeded, PackageSigningStatus.Unsigned);
+                Assert.Empty(result.Issues);
+            }
+
+            [Fact]
+            public async Task AcceptsDynamicallyCreatedAuthorSignatureWithCanonicalSignedAttributes()
+            {
+                // Arrange
+                using (X509Certificate2 certificate = SigningTestUtility.GenerateCertificate(subjectName: null, modifyGenerator: null))
+                using (MemoryStream unsignedPackage = NonCanonicalSignedAttributesTestUtility.CreatePackage(
+                    RuntimePackageId,
+                    RuntimePackageVersion))
+                {
+                    byte[] packageBytes = await NonCanonicalSignedAttributesTestUtility.CreateAuthorSignedPackageAsync(
+                        unsignedPackage,
+                        certificate,
+                        _output);
+                    _packageStream = new MemoryStream(buffer: packageBytes);
+                    TestUtility.RequireSignedPackage(
+                        _corePackageService,
+                        RuntimePackageId,
+                        RuntimePackageVersion,
+                        certificate.ComputeSHA256Thumbprint());
+                    _message = CreateRuntimePackageMessage();
+
+                    // Act
+                    SignatureValidatorResult result = await _target.ValidateAsync(
+                        _packageKey,
+                        _packageStream,
+                        _message,
+                        _cancellationToken);
+
+                    // Assert
+                    Validate(result, ValidationStatus.Succeeded, PackageSigningStatus.Valid);
+                    Assert.Empty(result.Issues);
+                }
+            }
+
+            [Fact]
+            public async Task ThrowsWhenPackageCannotBeFoundForSignedAttributesPolicy()
+            {
+                // Arrange
+                using (X509Certificate2 certificate = SigningTestUtility.GenerateCertificate(subjectName: null, modifyGenerator: null))
+                using (MemoryStream unsignedPackage = NonCanonicalSignedAttributesTestUtility.CreatePackage(
+                    RuntimePackageId,
+                    RuntimePackageVersion))
+                {
+                    byte[] packageBytes = await NonCanonicalSignedAttributesTestUtility.CreateAuthorSignedPackageAsync(
+                        unsignedPackage,
+                        certificate,
+                        _output);
+                    _packageStream = new MemoryStream(buffer: packageBytes);
+                    _message = CreateRuntimePackageMessage();
+
+                    // Act
+                    InvalidOperationException exception = await Assert.ThrowsAsync<InvalidOperationException>(
+                        () => _target.ValidateAsync(
+                            _packageKey,
+                            _packageStream,
+                            _message,
+                            _cancellationToken));
+
+                    // Assert
+                    Assert.Equal(
+                        $"Package '{RuntimePackageId} {RuntimePackageVersion}' could not be found " +
+                        $"for validation '{_message.ValidationId}'.",
+                        exception.Message);
+                }
+            }
+
+            [Fact]
+            public async Task RejectsDynamicallyCreatedAuthorSignatureWithNonCanonicalSignedAttributesBeforeSigning()
+            {
+                // Arrange
+                using (X509Certificate2 certificate = SigningTestUtility.GenerateCertificate(subjectName: null, modifyGenerator: null))
+                using (MemoryStream unsignedPackage = NonCanonicalSignedAttributesTestUtility.CreatePackage(
+                    RuntimePackageId,
+                    RuntimePackageVersion))
+                {
+                    byte[] packageBytes = await NonCanonicalSignedAttributesTestUtility.CreateAuthorSignedPackageAsync(
+                        unsignedPackage,
+                        certificate,
+                        _output);
+                    NonCanonicalSignedAttributesTestUtility.NonCanonicalSignatureResult nonCanonicalSignature =
+                        NonCanonicalSignedAttributesTestUtility.MakeSignedAttributesNonCanonical(
+                        packageBytes,
+                        certificate);
+                    _packageStream = nonCanonicalSignature.PackageStream;
+                    _corePackageService
+                        .Setup(service => service.FindPackageByIdAndVersionStrict(
+                            RuntimePackageId,
+                            RuntimePackageVersion))
+                        .Returns(new Package { PackageStatusKey = PackageStatus.Validating });
+                    _message = CreateRuntimePackageMessage();
+
+                    using (RSA publicKey = certificate.GetRSAPublicKey())
+                    using (SHA256 sha256 = SHA256.Create())
+                    {
+                        Assert.True(publicKey.VerifyData(
+                            nonCanonicalSignature.NonCanonicalSignatureInput,
+                            nonCanonicalSignature.SignatureValue,
+                            System.Security.Cryptography.HashAlgorithmName.SHA256,
+                            RSASignaturePadding.Pkcs1));
+                        Assert.False(
+                            sha256.ComputeHash(nonCanonicalSignature.CanonicalSignatureInput)
+                                .SequenceEqual(sha256.ComputeHash(nonCanonicalSignature.NonCanonicalSignatureInput)));
+                    }
+
+                    // Act
+                    SignatureValidatorResult result = await _target.ValidateAsync(
+                        _packageKey,
+                        _packageStream,
+                        _message,
+                        _cancellationToken);
+
+                    // Assert
+                    Validate(result, ValidationStatus.Failed, PackageSigningStatus.Invalid);
+                    IValidationIssue issue = Assert.Single(result.Issues);
+                    Assert.Equal(ValidationIssueCode.AuthorSignedAttributesNotCanonical, issue.IssueCode);
+                    Assert.Null(result.NupkgUri);
+                    _packageFileService.Verify(
+                        x => x.SaveAsync(
+                            It.IsAny<string>(),
+                            It.IsAny<string>(),
+                            It.IsAny<Guid>(),
+                            It.IsAny<Stream>()),
+                        Times.Never);
+                    _formatValidator.Verify(
+                        x => x.ValidateAllSignaturesAsync(
+                            It.IsAny<ISignedPackageReader>(),
+                            It.IsAny<bool>(),
+                            It.IsAny<CancellationToken>()),
+                        Times.Never);
+                }
+            }
+
+            [Fact]
+            public async Task DoesNotApplySignedAttributesPolicyToAvailablePackages()
+            {
+                // Arrange
+                using (X509Certificate2 certificate = SigningTestUtility.GenerateCertificate(subjectName: null, modifyGenerator: null))
+                using (MemoryStream unsignedPackage = NonCanonicalSignedAttributesTestUtility.CreatePackage(
+                    RuntimePackageId,
+                    RuntimePackageVersion))
+                {
+                    byte[] packageBytes = await NonCanonicalSignedAttributesTestUtility.CreateAuthorSignedPackageAsync(
+                        unsignedPackage,
+                        certificate,
+                        _output);
+                    NonCanonicalSignedAttributesTestUtility.NonCanonicalSignatureResult nonCanonicalSignature =
+                        NonCanonicalSignedAttributesTestUtility.MakeSignedAttributesNonCanonical(
+                            packageBytes,
+                            certificate);
+                    _packageStream = nonCanonicalSignature.PackageStream;
+                    TestUtility.RequireSignedPackage(
+                        _corePackageService,
+                        RuntimePackageId,
+                        RuntimePackageVersion,
+                        certificate.ComputeSHA256Thumbprint(),
+                        status: PackageStatus.Available);
+                    _message = CreateRuntimePackageMessage();
+
+                    Assert.False(
+                        AuthorSignedAttributesValidator.IsCanonical(
+                            NonCanonicalSignedAttributesTestUtility.GetSignatureBytes(
+                                _packageStream.ToArray())));
+
+                    // Act
+                    SignatureValidatorResult result = await _target.ValidateAsync(
+                        _packageKey,
+                        _packageStream,
+                        _message,
+                        _cancellationToken);
+
+                    // Assert
+                    Validate(result, ValidationStatus.Succeeded, PackageSigningStatus.Valid);
+                    Assert.Empty(result.Issues);
+                }
+            }
+
+            [Fact]
+            public async Task DoesNotApplySignedAttributesPolicyWhenFeatureIsDisabled()
+            {
+                // Arrange
+                using (X509Certificate2 certificate = SigningTestUtility.GenerateCertificate(subjectName: null, modifyGenerator: null))
+                using (MemoryStream unsignedPackage = NonCanonicalSignedAttributesTestUtility.CreatePackage(
+                    RuntimePackageId,
+                    RuntimePackageVersion))
+                {
+                    byte[] packageBytes = await NonCanonicalSignedAttributesTestUtility.CreateAuthorSignedPackageAsync(
+                        unsignedPackage,
+                        certificate,
+                        _output);
+                    NonCanonicalSignedAttributesTestUtility.NonCanonicalSignatureResult nonCanonicalSignature =
+                        NonCanonicalSignedAttributesTestUtility.MakeSignedAttributesNonCanonical(
+                            packageBytes,
+                            certificate);
+                    _packageStream = nonCanonicalSignature.PackageStream;
+                    TestUtility.RequireSignedPackage(
+                        _corePackageService,
+                        RuntimePackageId,
+                        RuntimePackageVersion,
+                        certificate.ComputeSHA256Thumbprint());
+                    _message = CreateRuntimePackageMessage();
+                    _featureFlagService
+                        .Setup(service => service.IsDerOrderingEnforcementEnabled())
+                        .Returns(false);
+
+                    Assert.False(
+                        AuthorSignedAttributesValidator.IsCanonical(
+                            NonCanonicalSignedAttributesTestUtility.GetSignatureBytes(
+                                _packageStream.ToArray())));
+
+                    // Act
+                    SignatureValidatorResult result = await _target.ValidateAsync(
+                        _packageKey,
+                        _packageStream,
+                        _message,
+                        _cancellationToken);
+
+                    // Assert
+                    Validate(result, ValidationStatus.Succeeded, PackageSigningStatus.Valid);
+                    Assert.Empty(result.Issues);
+                }
+            }
+
+            [Fact]
+            public async Task DoesNotApplySignedAttributesPolicyWhenRepositorySignatureIsRequired()
+            {
+                // Arrange
+                using (X509Certificate2 certificate = SigningTestUtility.GenerateCertificate(subjectName: null, modifyGenerator: null))
+                using (MemoryStream unsignedPackage = NonCanonicalSignedAttributesTestUtility.CreatePackage(
+                    RuntimePackageId,
+                    RuntimePackageVersion))
+                {
+                    byte[] packageBytes = await NonCanonicalSignedAttributesTestUtility.CreateAuthorSignedPackageAsync(
+                        unsignedPackage,
+                        certificate,
+                        _output);
+                    NonCanonicalSignedAttributesTestUtility.NonCanonicalSignatureResult nonCanonicalSignature =
+                        NonCanonicalSignedAttributesTestUtility.MakeSignedAttributesNonCanonical(
+                        packageBytes,
+                        certificate);
+                    _packageStream = nonCanonicalSignature.PackageStream;
+                    TestUtility.RequireSignedPackage(
+                        _corePackageService,
+                        RuntimePackageId,
+                        RuntimePackageVersion,
+                        certificate.ComputeSHA256Thumbprint());
+                    _message = new SignatureValidationMessage(
+                        RuntimePackageId,
+                        RuntimePackageVersion,
+                        new Uri($"https://unit.test/validation/{RuntimePackageId.ToLowerInvariant()}"),
+                        Guid.NewGuid(),
+                        requireRepositorySignature: true);
+
+                    Assert.False(
+                        AuthorSignedAttributesValidator.IsCanonical(
+                            NonCanonicalSignedAttributesTestUtility.GetSignatureBytes(
+                                _packageStream.ToArray())));
+
+                    // Act
+                    SignatureValidatorResult result = await _target.ValidateAsync(
+                        _packageKey,
+                        _packageStream,
+                        _message,
+                        _cancellationToken);
+
+                    // Assert
+                    Validate(
+                        result,
+                        ValidationStatus.Failed,
+                        PackageSigningStatus.Valid,
+                        shouldExtract: true);
+                    Assert.Empty(result.Issues);
+                    _formatValidator.Verify(
+                        x => x.ValidateAllSignaturesAsync(
+                            It.IsAny<ISignedPackageReader>(),
+                            hasRepositorySignature: false,
+                            It.IsAny<CancellationToken>()),
+                        Times.Once);
+                }
+            }
+
+            [Fact]
             public async Task RejectsRepositorySignedPackagesWhenAuthorSigningIsRequired()
             {
                 // Arrange
@@ -237,6 +556,15 @@ namespace Validation.PackageSigning.ProcessSignature.Tests
                 Validate(result, ValidationStatus.Failed, PackageSigningStatus.Invalid);
                 var issue = Assert.Single(result.Issues);
                 Assert.Equal(ValidationIssueCode.PackageIsNotSigned, issue.IssueCode);
+            }
+
+            private SignatureValidationMessage CreateRuntimePackageMessage()
+            {
+                return new SignatureValidationMessage(
+                    RuntimePackageId,
+                    RuntimePackageVersion,
+                    new Uri($"https://unit.test/validation/{RuntimePackageId.ToLowerInvariant()}"),
+                    Guid.NewGuid());
             }
 
             [Fact]

--- a/tests/Validation.PackageSigning.ProcessSignature.Tests/SignatureValidatorIntegrationTests.cs
+++ b/tests/Validation.PackageSigning.ProcessSignature.Tests/SignatureValidatorIntegrationTests.cs
@@ -17,6 +17,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.Internal.NuGet.Testing.SignedPackages;
 using Moq;
+using NuGet.Jobs.Validation;
 using NuGet.Jobs.Validation.PackageSigning.Configuration;
 using NuGet.Jobs.Validation.PackageSigning.Messages;
 using NuGet.Jobs.Validation.PackageSigning.ProcessSignature;
@@ -184,6 +185,7 @@ namespace Validation.PackageSigning.ProcessSignature.Tests
                 _corePackageService.Object,
                 _optionsSnapshot.Object,
                 _sasDefinitionConfigurationMock.Object,
+                Mock.Of<IFeatureFlagService>(service => service.IsDerOrderingEnforcementEnabled()),
                 _telemetryService,
                 _logger);
         }
@@ -2011,6 +2013,7 @@ namespace Validation.PackageSigning.ProcessSignature.Tests
                 _corePackageService.Object,
                 _optionsSnapshot.Object,
                 _sasDefinitionConfigurationMock.Object,
+                Mock.Of<IFeatureFlagService>(service => service.IsDerOrderingEnforcementEnabled()),
                 _telemetryService,
                 _logger);
         }

--- a/tests/Validation.PackageSigning.ProcessSignature.Tests/Support/NonCanonicalSignedAttributesTestUtility.cs
+++ b/tests/Validation.PackageSigning.ProcessSignature.Tests/Support/NonCanonicalSignedAttributesTestUtility.cs
@@ -1,0 +1,350 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Formats.Asn1;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading;
+using System.Threading.Tasks;
+using ICSharpCode.SharpZipLib.Zip;
+using Microsoft.Internal.NuGet.Testing.SignedPackages;
+using NuGet.Frameworks;
+using NuGet.Packaging;
+using NuGet.Packaging.Core;
+using NuGet.Packaging.Signing;
+using NuGet.Versioning;
+using TestUtil;
+using Xunit.Abstractions;
+
+namespace Validation.PackageSigning.ProcessSignature.Tests
+{
+    internal static class NonCanonicalSignedAttributesTestUtility
+    {
+        private static readonly Asn1Tag ContextSpecific0 = new(tagClass: TagClass.ContextSpecific, tagValue: 0);
+        private static readonly Asn1Tag ContextSpecific1 = new(tagClass: TagClass.ContextSpecific, tagValue: 1);
+
+        public static MemoryStream CreatePackage(string packageId, string packageVersion)
+        {
+            PackageBuilder packageBuilder = new()
+            {
+                Id = packageId,
+                Version = NuGetVersion.Parse(packageVersion),
+                Description = "A package generated at runtime for signature validation tests.",
+            };
+            packageBuilder.Authors.Add("Test");
+            packageBuilder.DependencyGroups.Add(
+                new PackageDependencyGroup(
+                    NuGetFramework.AnyFramework,
+                    new[] { new PackageDependency(id: "RuntimeDependency", versionRange: VersionRange.All) }));
+
+            MemoryStream packageStream = new();
+            packageBuilder.Save(packageStream);
+            packageStream.Position = 0;
+
+            return packageStream;
+        }
+
+        public static async Task<byte[]> CreateAuthorSignedPackageAsync(
+            Stream packageStream,
+            X509Certificate2 certificate,
+            ITestOutputHelper output)
+        {
+            X509SignatureProvider signatureProvider = new(timestampProvider: null);
+
+            using (MemoryStream outputPackageStream = new())
+            {
+                await SigningUtility.SignAsync(
+                    new SigningOptions(
+                        inputPackageStream: new Lazy<Stream>(() => packageStream),
+                        outputPackageStream: new Lazy<Stream>(() => outputPackageStream),
+                        overwrite: true,
+                        signatureProvider: signatureProvider,
+                        logger: new TestLogger(output)),
+                    new AuthorSignPackageRequest(certificate, NuGet.Common.HashAlgorithmName.SHA256),
+                    CancellationToken.None);
+
+                return outputPackageStream.ToArray();
+            }
+        }
+
+        public static NonCanonicalSignatureResult MakeSignedAttributesNonCanonical(
+            byte[] packageBytes,
+            X509Certificate2 certificate)
+        {
+            byte[] signatureBytes = GetSignatureBytes(packageBytes);
+
+            SignerInfoParts signerInfoParts = ReadSignerInfoParts(signatureBytes);
+            List<byte[]> attributes = signerInfoParts.SignedAttributes.ToList();
+            int swapIndex = Enumerable.Range(start: 0, count: attributes.Count - 1)
+                .First(index => Compare(attributes[index], attributes[index + 1]) < 0);
+            byte[][] reorderedAttributes = attributes.ToArray();
+            byte[] temporary = reorderedAttributes[swapIndex];
+            reorderedAttributes[swapIndex] = reorderedAttributes[swapIndex + 1];
+            reorderedAttributes[swapIndex + 1] = temporary;
+
+            byte[] nonCanonicalSignedAttributes = (byte[])signerInfoParts.EncodedSignedAttributes.Clone();
+            int contentOffset = nonCanonicalSignedAttributes.Length - attributes.Sum(attribute => attribute.Length);
+            int writeOffset = contentOffset;
+
+            foreach (byte[] attribute in reorderedAttributes)
+            {
+                Buffer.BlockCopy(
+                    src: attribute,
+                    srcOffset: 0,
+                    dst: nonCanonicalSignedAttributes,
+                    dstOffset: writeOffset,
+                    count: attribute.Length);
+                writeOffset += attribute.Length;
+            }
+
+            // SignerInfo.signedAttrs is encoded on the wire with its [0] IMPLICIT tag. RFC 5652
+            // requires the signature input to use the same contents with the universal SET OF tag.
+            byte[] canonicalSignatureInput = (byte[])signerInfoParts.EncodedSignedAttributes.Clone();
+            canonicalSignatureInput[0] = 0x31;
+            byte[] nonCanonicalSignatureInput = (byte[])nonCanonicalSignedAttributes.Clone();
+            nonCanonicalSignatureInput[0] = 0x31;
+
+            byte[] signatureValue;
+            using (RSA privateKey = certificate.GetRSAPrivateKey())
+            {
+                signatureValue = privateKey.SignData(
+                    nonCanonicalSignatureInput,
+                    System.Security.Cryptography.HashAlgorithmName.SHA256,
+                    RSASignaturePadding.Pkcs1);
+            }
+
+            byte[] encodedSignatureValue = (byte[])signerInfoParts.EncodedSignatureValue.Clone();
+            int signatureValueOffset = encodedSignatureValue.Length - signerInfoParts.SignatureValue.Length;
+            Buffer.BlockCopy(
+                src: signatureValue,
+                srcOffset: 0,
+                dst: encodedSignatureValue,
+                dstOffset: signatureValueOffset,
+                count: signatureValue.Length);
+
+            int signedAttributesOffset = FindUniqueOffset(signatureBytes, signerInfoParts.EncodedSignedAttributes);
+            int signatureValueFieldOffset = FindUniqueOffset(signatureBytes, signerInfoParts.EncodedSignatureValue);
+            Buffer.BlockCopy(
+                src: nonCanonicalSignedAttributes,
+                srcOffset: 0,
+                dst: signatureBytes,
+                dstOffset: signedAttributesOffset,
+                count: nonCanonicalSignedAttributes.Length);
+            Buffer.BlockCopy(
+                src: encodedSignatureValue,
+                srcOffset: 0,
+                dst: signatureBytes,
+                dstOffset: signatureValueFieldOffset,
+                count: encodedSignatureValue.Length);
+
+            MemoryStream outputPackageStream = new(packageBytes);
+            ReplaceSignature(outputPackageStream, signatureBytes);
+
+            return new NonCanonicalSignatureResult(
+                outputPackageStream,
+                canonicalSignatureInput,
+                nonCanonicalSignatureInput,
+                signatureValue);
+        }
+
+        public static byte[] GetSignatureBytes(byte[] packageBytes)
+        {
+            using (MemoryStream packageStream = new(packageBytes))
+            using (ZipArchive archive = new(packageStream, ZipArchiveMode.Read))
+            using (Stream signatureStream = archive.GetEntry(SigningSpecifications.V1.SignaturePath).Open())
+            using (MemoryStream memoryStream = new())
+            {
+                signatureStream.CopyTo(memoryStream);
+                return memoryStream.ToArray();
+            }
+        }
+
+        private static SignerInfoParts ReadSignerInfoParts(byte[] signatureBytes)
+        {
+            // ContentInfo ::= SEQUENCE { contentType, [0] EXPLICIT content }
+            AsnReader contentInfo = new AsnReader(signatureBytes, AsnEncodingRules.BER).ReadSequence();
+            contentInfo.ReadObjectIdentifier();
+
+            // ContentInfo.content contains the SignedData SEQUENCE.
+            AsnReader signedDataContent = contentInfo.ReadSequence(ContextSpecific0);
+            AsnReader signedData = signedDataContent.ReadSequence();
+
+            // SignedData.version, digestAlgorithms, and encapContentInfo.
+            signedData.ReadInteger();
+            signedData.ReadEncodedValue();
+            signedData.ReadEncodedValue();
+
+            // SignedData optionally contains certificates [0] and CRLs [1] before signerInfos.
+            while (signedData.HasData
+                && (signedData.PeekTag().HasSameClassAndValue(ContextSpecific0)
+                    || signedData.PeekTag().HasSameClassAndValue(ContextSpecific1)))
+            {
+                signedData.ReadEncodedValue();
+            }
+
+            // SignedData.signerInfos is a SET OF; NuGet package signatures have one primary SignerInfo.
+            AsnReader signerInfo = signedData.ReadSetOf(skipSortOrderValidation: true).ReadSequence();
+
+            // SignerInfo.version, sid, and digestAlgorithm precede signedAttrs.
+            signerInfo.ReadInteger();
+            signerInfo.ReadEncodedValue();
+            signerInfo.ReadEncodedValue();
+
+            // Preserve the complete [0] IMPLICIT signedAttrs field and each enclosed Attribute TLV.
+            byte[] encodedSignedAttributes = signerInfo.ReadEncodedValue().ToArray();
+            AsnReader signedAttributes = new AsnReader(
+                encodedSignedAttributes,
+                AsnEncodingRules.BER).ReadSetOf(
+                    skipSortOrderValidation: true,
+                    expectedTag: ContextSpecific0);
+            List<byte[]> attributes = new();
+            while (signedAttributes.HasData)
+            {
+                attributes.Add(signedAttributes.ReadEncodedValue().ToArray());
+            }
+
+            // SignerInfo.signatureAlgorithm is followed by the signature OCTET STRING.
+            signerInfo.ReadEncodedValue();
+            byte[] encodedSignatureValue = signerInfo.ReadEncodedValue().ToArray();
+            byte[] signatureValue = new AsnReader(
+                encodedSignatureValue,
+                AsnEncodingRules.BER).ReadOctetString();
+
+            return new SignerInfoParts(
+                encodedSignedAttributes,
+                attributes,
+                encodedSignatureValue,
+                signatureValue);
+        }
+
+        private static void ReplaceSignature(MemoryStream packageStream, byte[] signatureBytes)
+        {
+            using (ICSharpCode.SharpZipLib.Zip.ZipFile zipFile = new(packageStream))
+            {
+                zipFile.IsStreamOwner = false;
+                zipFile.BeginUpdate();
+                zipFile.Delete(SigningSpecifications.V1.SignaturePath);
+                zipFile.CommitUpdate();
+                zipFile.BeginUpdate();
+                zipFile.Add(
+                    new StreamDataSource(new MemoryStream(buffer: signatureBytes)),
+                    SigningSpecifications.V1.SignaturePath,
+                    CompressionMethod.Stored);
+                zipFile.CommitUpdate();
+            }
+
+            packageStream.Position = 0;
+        }
+
+        private static int FindUniqueOffset(byte[] source, byte[] value)
+        {
+            int foundOffset = -1;
+
+            for (int offset = 0; offset <= source.Length - value.Length; offset++)
+            {
+                bool matches = true;
+                for (int index = 0; index < value.Length; index++)
+                {
+                    if (source[offset + index] != value[index])
+                    {
+                        matches = false;
+                        break;
+                    }
+                }
+
+                if (matches)
+                {
+                    if (foundOffset >= 0)
+                    {
+                        throw new InvalidOperationException("The encoded value was not unique in the CMS.");
+                    }
+
+                    foundOffset = offset;
+                }
+            }
+
+            if (foundOffset < 0)
+            {
+                throw new InvalidOperationException("The encoded value was not found in the CMS.");
+            }
+
+            return foundOffset;
+        }
+
+        private static int Compare(byte[] left, byte[] right)
+        {
+            int commonLength = Math.Min(left.Length, right.Length);
+
+            for (int index = 0; index < commonLength; index++)
+            {
+                int comparison = left[index].CompareTo(right[index]);
+                if (comparison != 0)
+                {
+                    return comparison;
+                }
+            }
+
+            return left.Length.CompareTo(right.Length);
+        }
+
+        internal sealed class NonCanonicalSignatureResult
+        {
+            public NonCanonicalSignatureResult(
+                MemoryStream packageStream,
+                byte[] canonicalSignatureInput,
+                byte[] nonCanonicalSignatureInput,
+                byte[] signatureValue)
+            {
+                PackageStream = packageStream;
+                CanonicalSignatureInput = canonicalSignatureInput;
+                NonCanonicalSignatureInput = nonCanonicalSignatureInput;
+                SignatureValue = signatureValue;
+            }
+
+            public MemoryStream PackageStream { get; }
+            public byte[] CanonicalSignatureInput { get; }
+            public byte[] NonCanonicalSignatureInput { get; }
+            public byte[] SignatureValue { get; }
+        }
+
+        private sealed class SignerInfoParts
+        {
+            public SignerInfoParts(
+                byte[] encodedSignedAttributes,
+                IReadOnlyList<byte[]> signedAttributes,
+                byte[] encodedSignatureValue,
+                byte[] signatureValue)
+            {
+                EncodedSignedAttributes = encodedSignedAttributes;
+                SignedAttributes = signedAttributes;
+                EncodedSignatureValue = encodedSignatureValue;
+                SignatureValue = signatureValue;
+            }
+
+            public byte[] EncodedSignedAttributes { get; }
+            public IReadOnlyList<byte[]> SignedAttributes { get; }
+            public byte[] EncodedSignatureValue { get; }
+            public byte[] SignatureValue { get; }
+        }
+
+        private sealed class StreamDataSource : IStaticDataSource
+        {
+            private readonly Stream _stream;
+
+            public StreamDataSource(Stream stream)
+            {
+                _stream = stream;
+            }
+
+            public Stream GetSource()
+            {
+                return _stream;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #10972.

## Summary

Adds feature-gated, fail-fast validation for non-canonical DER ordering in an author signature's original CMS `SignerInfo.signedAttrs`.

A non-canonical signature may appear valid when initially processed because some CMS implementations accept BER-encoded or incorrectly ordered signed attributes and verify the signature against the original encoded bytes. The signature is nevertheless non-compliant with DER requirements.

During repository countersigning, normal standards-compliant CMS decoding and re-encoding can canonicalize `signedAttrs`. Because the author's signature value remains unchanged, it no longer matches the corrected encoding. Repository signing therefore exposes a pre-existing malformed author signature; it does not cause the underlying defect.

This change rejects that malformed author signature before malware scanning and repository signing.

## Implementation

- Adds `AuthorSignedAttributesValidator`, which:
  - Reads the original `.signature.p7s` bytes from the package.
  - Parses CMS using BER rules so the original wire ordering remains observable.
  - Traverses `ContentInfo`, `SignedData`, and the primary `SignerInfo`.
  - Reads `[0] IMPLICIT signedAttrs` while preserving each complete Attribute TLV.
  - Compares adjacent Attribute encodings lexicographically as unsigned octet strings, as required for DER SET OF ordering.
  - Accepts equal adjacent encodings, leaving duplicate-attribute policy to existing semantic validation.

- Enforces the policy in the pre-repository-signing Process Signature stage when:
  - `Validation.DerOrderingEnforcement` is enabled.
  - The current validation mode does not require a repository-primary signature.
  - The primary signature is an author signature.
  - The package is not already `Available`.

- Returns a terminal `AuthorSignedAttributesNotCanonical` validation issue with an actionable message instructing the author to sign the package again with a compliant tool.

- Maps malformed or unexpected CMS input to the existing NU3003 signature-validation failure behavior.

- Uses generic, stable policy reason values while preserving existing package correlation fields.

## Feature flag

`Validation.DerOrderingEnforcement`

The flag uses positive capability naming and defaults to `false`.

## Tests

All new package, certificate, and CMS test data is generated at runtime. Coverage includes:

- Unsigned package acceptance
- Canonical author signature acceptance
- Cryptographically valid non-canonical author signature rejection
- Rejection before full signature validation or package submission
- Disabled feature-flag behavior
- Already-available package revalidation
- Repository-signing-mode exclusion
- Missing-package retry behavior
- Missing `signedAttrs`
- Truncated ASN.1
- Unexpected CMS content type
- Validation issue propagation
- ScanAndSign prerequisite blocking
- Feature flag name and default value

## Standards

- [RFC 5652 §5.3 — SignerInfo Type](https://www.rfc-editor.org/rfc/rfc5652.html#section-5.3)
- [RFC 5652 §5.4 — Message Digest Calculation Process](https://www.rfc-editor.org/rfc/rfc5652.html#section-5.4)
- [ITU-T X.690 §11.6 — Set-of components](https://www.itu.int/rec/T-REC-X.690/en)

## Rollout

Enable `Validation.DerOrderingEnforcement` after completing compatibility validation against the existing NuGet.org package corpus.